### PR TITLE
Fullscreen pre-permission prompt centered via Flexbox

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -426,16 +426,18 @@ export default class Helpers {
   static createSubscriptionDomModal(url) {
     let iframeContainer = document.createElement('div');
     iframeContainer.setAttribute('id', 'OneSignal-iframe-modal');
-    iframeContainer.innerHTML = '<div id="notif-permission" style="background: rgba(0, 0, 0, 0.7); position: fixed; top: 0; left: 0; right: 0; bottom: 0; z-index: 3000000000; display: block"></div>';
+    iframeContainer.innerHTML = '<div id="notif-permission" style="background: rgba(0, 0, 0, 0.7); position: fixed;' +
+                                ' top: 0; left: 0; right: 0; bottom: 0; z-index: 3000000000; display: flex;' +
+                                ' align-items: center; justify-content: center;"></div>';
     document.body.appendChild(iframeContainer);
 
     let iframeContainerStyle = document.createElement('style');
-    iframeContainerStyle.innerHTML = `@media (max-width: 560px) { .OneSignal-permission-iframe { width: 100%; height: 100%;} } @media (min-width: 561px) { .OneSignal-permission-iframe { top: 50%; left: 50%; margin-left: -275px; margin-top: -248px;} }`;
+    iframeContainerStyle.innerHTML = `@media (max-width: 560px) { .OneSignal-permission-iframe { width: 100%; height: 100%;} }`;
     document.getElementsByTagName('head')[0].appendChild(iframeContainerStyle);
 
     let iframe = document.createElement("iframe");
     iframe.className = "OneSignal-permission-iframe"
-    iframe.style.cssText = "background: rgba(255, 255, 255, 1); position: fixed;";
+    iframe.style.cssText = "position: fixed;";
     iframe.setAttribute('frameborder', '0');
     iframe.width = OneSignal._windowWidth.toString();
     iframe.height = OneSignal._windowHeight.toString();


### PR DESCRIPTION
The fullscreen pre-permission prompt was not perfectly centered, and
relied on negative margins to be in the center of the screen. The prompt
is now centered via Flexbox, and it should be supported by all modern
browsers who are able to register for push notifications.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/137)
<!-- Reviewable:end -->
