### PR TITLE
Fix Opera mobile push notifications support

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -158,7 +158,7 @@ var DEVICE_TYPES = {
 };
 
 export function getDeviceTypeForBrowser() {
-  if (Browser.chrome || Browser.yandexbrowser) {
+  if (Browser.chrome || Browser.yandexbrowser || Browser.opera) {
     return DEVICE_TYPES.CHROME;
   } else if (Browser.firefox) {
     return DEVICE_TYPES.FIREFOX;


### PR DESCRIPTION
Opera has been supported but a device type wasn't returned for
getDeviceTypeForBrowser() because Opera wasn't one of the expected
browsers. This commit fixes that and Opera mobile push notifications now
work!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/138)
<!-- Reviewable:end -->
