### PR TITLE
Prevent SDK being loaded more than once

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -1,17 +1,26 @@
-import { DEV_HOST, PROD_HOST, API_URL } from './vars.js';
 import Environment from './environment.js';
+import { getSdkLoadCount, incrementSdkLoadCount } from './utils';
+import log from 'loglevel';
 
 
 if (Environment.isBrowser()) {
-  // We're running in the host page, iFrame of the host page, or popup window
-  // Load OneSignal's web SDK
-  if (typeof OneSignal !== "undefined")
-    var predefinedOneSignalPushes = OneSignal;
+  incrementSdkLoadCount();
+  if (getSdkLoadCount() > 1) {
+    log.warn(`OneSignal: The web push SDK is included more than once. For optimal performance, please include our ` +
+             `SDK only once on your page.`);
+    log.debug(`OneSignal: Exiting from SDK initialization to prevent double-initialization errors. ` +
+              `Occurred ${getSdkLoadCount()} times.`);
+  } else {
+    // We're running in the host page, iFrame of the host page, or popup window
+    // Load OneSignal's web SDK
+    if (typeof OneSignal !== "undefined")
+      var predefinedOneSignalPushes = OneSignal;
 
-  require("expose?OneSignal!./OneSignal.js");
+    require("expose?OneSignal!./OneSignal.js");
 
-  if (predefinedOneSignalPushes)
-    OneSignal._processPushes(predefinedOneSignalPushes);
+    if (predefinedOneSignalPushes)
+      OneSignal._processPushes(predefinedOneSignalPushes);
+  }
 }
 else if (Environment.isServiceWorker()) {
   // We're running as the service worker

--- a/src/utils.js
+++ b/src/utils.js
@@ -478,3 +478,19 @@ export function wait(milliseconds) {
 export function substringAfter(string, search) {
   return string.substr(string.indexOf(search) + search.length);
 }
+
+/**
+ * Returns the number of times the SDK has been loaded into the browser.
+ * Expects a browser environment, otherwise this call will fail.
+ */
+export function getSdkLoadCount() {
+  return window.__oneSignalSdkLoadCount || 0;
+}
+
+/**
+ * Increments the counter describing the number of times the SDK has been loaded into the browser.
+ * Expects a browser environment, otherwise this call will fail.
+ */
+export function incrementSdkLoadCount() {
+  window.__oneSignalSdkLoadCount = getSdkLoadCount() + 1;
+}


### PR DESCRIPTION
If the web SDK is loaded more than once, a console warning is thrown and
the SDK exits. This is to prevent the errors that occur when the SDK is
initialized twice and global variables become shared.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/142)
<!-- Reviewable:end -->
