### PR TITLE
Add opera desktop support

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,8 +56,8 @@ export function isPushNotificationsSupported () {
   if ((<any>Browser).yandexbrowser && Number(Browser.version) >= 15.12)
     return true;
 
-  // https://www.chromestatus.com/feature/5416033485586432
-  if (Browser.opera && (Browser.mobile || Browser.tablet) && Number(Browser.version) >= 37)
+  if (Browser.opera && (Browser.mobile || Browser.tablet) && Number(Browser.version) >= 37 ||
+      Browser.opera && Number(Browser.version) >= 42)
     return true;
 
   return false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,7 +57,7 @@ export function isPushNotificationsSupported () {
     return true;
 
   // https://www.chromestatus.com/feature/5416033485586432
-  if (Browser.opera && Browser.mobile && Number(Browser.version) >= 37)
+  if (Browser.opera && (Browser.mobile || Browser.tablet) && Number(Browser.version) >= 37)
     return true;
 
   return false;


### PR DESCRIPTION
- Support Opera Mobile on tablets as well as phones  …
  Opera Mobile support only worked on mobile phones and not tablets due to the kind of detection we were doing.

- Support Opera Desktop v42+ for push
  Opera Desktop v42.0.2372.0+ now supports notifications and is basically Chromium 55 under the hood.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/205)
<!-- Reviewable:end -->
