### PR TITLE
Add web push multiple notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onesignal-web-sdk",
   "version": "1.2.0",
-  "sdkVersion": "120070",
+  "sdkVersion": "120075",
   "description": "Web push notifications from OneSignal.",
   "main": "src/entry.js",
   "dependencies": {

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -313,6 +313,7 @@ class ServiceWorker {
       url: rawNotification.custom.u,
       icon: rawNotification.icon,
       image: rawNotification.image
+      tag: rawNotification.tag
     };
 
     // Add action buttons
@@ -402,7 +403,7 @@ class ServiceWorker {
           notification.heading = notification.heading ? notification.heading : defaultTitle;
           notification.icon = notification.icon ? notification.icon : (defaultIcon ? defaultIcon : undefined);
           var extra: any = {};
-          extra.tag = `${appId}`;
+          extra.tag = notification.tag || appId;
           extra.persistNotification = persistNotification;
 
           // Allow overriding some values

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -312,7 +312,7 @@ class ServiceWorker {
       data: rawNotification.custom.a,
       url: rawNotification.custom.u,
       icon: rawNotification.icon,
-      image: rawNotification.image
+      image: rawNotification.image,
       tag: rawNotification.tag
     };
 


### PR DESCRIPTION
Allow multiple notifications to be displayed by setting the notification
tag property if supplied. Notifications with identical tags will replace
each other.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/211)
<!-- Reviewable:end -->
