### PR TITLE
support sw custom name

### DIFF
--- a/src/helpers/MainHelper.ts
+++ b/src/helpers/MainHelper.ts
@@ -291,11 +291,11 @@ export default class MainHelper {
 
   static getPrefixedServiceWorkerNameForEnv() {
     if (Environment.isDev()) {
-      OneSignal.SERVICE_WORKER_PATH = DEV_PREFIX + 'OneSignalSDKWorker.js';
-      OneSignal.SERVICE_WORKER_UPDATER_PATH = DEV_PREFIX + 'OneSignalSDKUpdaterWorker.js';
+      OneSignal.SERVICE_WORKER_PATH = DEV_PREFIX + OneSignal.SERVICE_WORKER_PATH;
+      OneSignal.SERVICE_WORKER_UPDATER_PATH = DEV_PREFIX + OneSignal.SERVICE_WORKER_UPDATER_PATH;
     } else if (Environment.isStaging()) {
-      OneSignal.SERVICE_WORKER_PATH = STAGING_PREFIX + 'OneSignalSDKWorker.js';
-      OneSignal.SERVICE_WORKER_UPDATER_PATH = STAGING_PREFIX + 'OneSignalSDKUpdaterWorker.js';
+      OneSignal.SERVICE_WORKER_PATH = STAGING_PREFIX + OneSignal.SERVICE_WORKER_PATH;
+      OneSignal.SERVICE_WORKER_UPDATER_PATH = STAGING_PREFIX + OneSignal.SERVICE_WORKER_UPDATER_PATH;
     }
   }
 

--- a/src/helpers/ServiceWorkerHelper.ts
+++ b/src/helpers/ServiceWorkerHelper.ts
@@ -9,11 +9,11 @@ import SubscriptionHelper from "./SubscriptionHelper";
 export default class ServiceWorkerHelper {
   static applyServiceWorkerEnvPrefixes() {
     if (Environment.isDev()) {
-      OneSignal.SERVICE_WORKER_PATH = DEV_PREFIX + 'OneSignalSDKWorker.js';
-      OneSignal.SERVICE_WORKER_UPDATER_PATH = DEV_PREFIX + 'OneSignalSDKUpdaterWorker.js';
+      OneSignal.SERVICE_WORKER_PATH = DEV_PREFIX + OneSignal.SERVICE_WORKER_PATH;
+      OneSignal.SERVICE_WORKER_UPDATER_PATH = DEV_PREFIX + OneSignal.SERVICE_WORKER_UPDATER_PATH;
     } else if (Environment.isStaging()) {
-      OneSignal.SERVICE_WORKER_PATH = STAGING_PREFIX + 'OneSignalSDKWorker.js';
-      OneSignal.SERVICE_WORKER_UPDATER_PATH = STAGING_PREFIX + 'OneSignalSDKUpdaterWorker.js';
+      OneSignal.SERVICE_WORKER_PATH = STAGING_PREFIX + OneSignal.SERVICE_WORKER_PATH;
+      OneSignal.SERVICE_WORKER_UPDATER_PATH = STAGING_PREFIX + OneSignal.SERVICE_WORKER_UPDATER_PATH;
     }
   }
 
@@ -144,8 +144,8 @@ export default class ServiceWorkerHelper {
       return serviceWorkerRegistration &&
         serviceWorkerRegistration.active &&
         serviceWorkerRegistration.active.state === 'activated' &&
-        (contains(serviceWorkerRegistration.active.scriptURL, 'OneSignalSDKWorker') ||
-        contains(serviceWorkerRegistration.active.scriptURL, 'OneSignalSDKUpdaterWorker'));
+        (contains(serviceWorkerRegistration.active.scriptURL, OneSignal.SERVICE_WORKER_PATH) ||
+        contains(serviceWorkerRegistration.active.scriptURL, OneSignal.SERVICE_WORKER_UPDATER_PATH));
     }
 
     return new Promise((resolve, reject) => {

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -714,7 +714,7 @@ class ServiceWorker {
     log.debug(`Called %conServiceWorkerInstalled(${JSON.stringify(event, null, 4)}):`, getConsoleStyle('code'), event);
     log.info(`Installing service worker: %c${(self as any).location.pathname}`, getConsoleStyle('code'), `(version ${__VERSION__})`);
 
-    if (contains((self as any).location.pathname, "OneSignalSDKWorker"))
+    if (contains((self as any).location.pathname, OneSignal.SERVICE_WORKER_PATH))
       var serviceWorkerVersionType = 'WORKER1_ONE_SIGNAL_SW_VERSION';
     else
       var serviceWorkerVersionType = 'WORKER2_ONE_SIGNAL_SW_VERSION';


### PR DESCRIPTION
As discussed here [https://github.com/OneSignal/OneSignal-Website-SDK/issues/219](https://github.com/OneSignal/OneSignal-Website-SDK/issues/219
), there is an option on the sdk for defining a custom file name.

It's also documented in the code, as you can see in the next snippet:

```js
/**
   * The additional path to the worker file.
   *
   * Usually just the filename (in case the file is named differently), but also supports cases where the folder
   * is different.
   *
   * However, the init options 'path' should be used to specify the folder path instead since service workers will not
   * auto-update correctly on HTTPS site load if the config init options 'path' is not set.
   */
  static SERVICE_WORKER_UPDATER_PATH = 'OneSignalSDKUpdaterWorker.js';
  static SERVICE_WORKER_PATH = 'OneSignalSDKWorker.js';
```
Most of the code is using this variables but in some places, the code is still using the literal filename, breaking some methods of the SDK..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/236)
<!-- Reviewable:end -->
