### PR TITLE
Add fix to detect and remove dup. sub. on iframes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "onesignal-web-sdk",
   "version": "1.2.0",
-  "sdkVersion": "130035",
+  "sdkVersion": "130040",
   "description": "Web push notifications from OneSignal.",
   "main": "src/entry.ts",
   "dependencies": {

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -907,7 +907,8 @@ export default class OneSignal {
     SERVICEWORKER_COMMAND_REDIRECT: 'postmam.command.redirect',
     HTTP_PERMISSION_REQUEST_RESUBSCRIBE: 'postmam.httpPermissionRequestResubscribe',
     MARK_PROMPT_DISMISSED: 'postmam.markPromptDismissed',
-    IS_SUBSCRIBED: 'postmam.isSubscribed'
+    IS_SUBSCRIBED: 'postmam.isSubscribed',
+    UNSUBSCRIBE_PROXY_FRAME: 'postman.unsubscribeProxyFrame'
   };
 
   static EVENTS = {

--- a/src/modules/frames/ProxyFrameHost.ts
+++ b/src/modules/frames/ProxyFrameHost.ts
@@ -3,7 +3,7 @@ import { MessengerMessageEvent } from '../../models/MessengerMessageEvent';
 import Database from "../../services/Database";
 import Event from "../../Event";
 import EventHelper from "../../helpers/EventHelper";
-import { timeoutPromise } from "../../utils";
+import { timeoutPromise, unsubscribeFromPush } from '../../utils';
 import TimeoutError from '../../errors/TimeoutError';
 import * as log from 'loglevel';
 import { NotificationPermission } from '../../models/NotificationPermission';
@@ -181,6 +181,14 @@ export default class ProxyFrameHost implements Disposable {
     return new Promise((resolve, reject) => {
       this.messenger.message(OneSignal.POSTMAM_COMMANDS.IS_SUBSCRIBED, null, reply => {
         resolve(reply.data);
+      });
+    });
+  }
+
+  unsubscribeFromPush(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      this.messenger.message(OneSignal.POSTMAM_COMMANDS.UNSUBSCRIBE_PROXY_FRAME, null, reply => {
+        resolve();
       });
     });
   }

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -285,32 +285,13 @@ export default class Database {
    * Asynchronously removes the Ids, NotificationOpened, and Options tables from the database and recreates them with blank values.
    * @returns {Promise} Returns a promise that is fulfilled when rebuilding is completed, or rejects with an error.
    */
-  async rebuild() {
+  static async rebuild() {
+    Database.ensureSingletonInstance();
     return Promise.all([
-      this.remove('Ids'),
-      this.remove('NotificationOpened'),
-      this.remove('Options'),
+      Database.databaseInstance.remove('Ids'),
+      Database.databaseInstance.remove('NotificationOpened'),
+      Database.databaseInstance.remove('Options'),
     ]);
-  }
-
-  async printIds() {
-    return Promise.all([
-      this.get('Ids', 'appId'),
-      this.get('Ids', 'registrationId'),
-      this.get('Ids', 'userId')
-    ]).then(function([appId, registrationId, userId]) {
-      if (console.table) {
-       console.table({'OneSignal Database IDs': {
-         'App ID': appId,
-         'Registration ID': registrationId,
-         'User ID': userId
-       }});
-      } else {
-        log.info('App ID:', appId);
-        log.info('Registration ID:', registrationId);
-        log.info('User ID:', userId);
-      }
-    });
   }
 
   /* Temp Database Proxy */


### PR DESCRIPTION
Due to an accidental SDK rollback, a small number of users within a 3
hour period last week were prompted to subscribe on both subdomain.os.tc
and subdomain.onesignal.com.

This commit introduces some code to detect those cases and unsubscribe
users from one of those iframes, to prevent duplicate
messages/subscriptions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/240)
<!-- Reviewable:end -->
