### PR TITLE
Chrome 63 permission changes for Chrome on Android

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -310,11 +310,13 @@ export default class OneSignal {
       OneSignal.popover.close();
       log.debug("Setting flag to not show the popover to the user again.");
       TestHelper.markHttpsNativePromptDismissed();
+      OneSignal._sessionInitAlreadyRunning = false;
       OneSignal.registerForPushNotifications({ autoAccept: true });
     });
     OneSignal.once(Popover.EVENTS.CANCEL_CLICK, () => {
       log.debug("Setting flag to not show the popover to the user again.");
       TestHelper.markHttpsNativePromptDismissed();
+      OneSignal._sessionInitAlreadyRunning = false;
     });
   }
 

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -304,7 +304,24 @@ export default class InitHelper {
         log.debug('OneSignal: Not automatically showing native HTTPS prompt because the user previously dismissed it.');
         OneSignal._sessionInitAlreadyRunning = false;
       } else {
-        SubscriptionHelper.registerForPush();
+        /*
+         * Chrome 63 on Android permission prompts are permanent without a dismiss option. To avoid
+         * permanent blocks, we want to replace sites automatically showing the native browser request
+         * with a slide prompt first.
+         */
+        if (
+          (
+            !options ||
+            options && !options.fromRegisterFor
+          ) &&
+          Browser.chrome &&
+          Number(Browser.version) >= 63 &&
+          (Browser.tablet || Browser.mobile)
+          ) {
+          OneSignal.showHttpPrompt();
+        } else {
+          SubscriptionHelper.registerForPush();
+        }
       }
     } else {
       if (OneSignal.config.userConfig.autoRegister !== true) {


### PR DESCRIPTION
Chrome 63 on Android permission prompts are permanent without a dismiss
option. To avoid permanent blocks, we want to replace sites
automatically showing the native browser request with a slide prompt
first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/292)
<!-- Reviewable:end -->
