### PR TITLE
New consent flag and function

### DIFF
--- a/src/Event.ts
+++ b/src/Event.ts
@@ -60,7 +60,7 @@ export default class Event {
    * @param data Any JavaScript variable to be passed with the event.
    * @param remoteTriggerEnv If this method is being called in a different environment (e.g. was triggered in iFrame but now retriggered on main host), this is the string of the original environment for logging purposes.
    */
-  static trigger(eventName, data?, remoteTriggerEnv=null) {
+  static async trigger(eventName, data?, remoteTriggerEnv=null) {
     if (!contains(SILENT_EVENTS, eventName)) {
       let displayData = data;
       if (remoteTriggerEnv) {
@@ -84,7 +84,7 @@ export default class Event {
         else
           OneSignal.initialized = true;
       }
-      OneSignal.emitter.emit(eventName, data);
+      await OneSignal.emitter.emit(eventName, data);
     }
     if (LEGACY_EVENT_MAP.hasOwnProperty(eventName)) {
       let legacyEventName = LEGACY_EVENT_MAP[eventName];
@@ -118,7 +118,7 @@ export default class Event {
    * @private
    */
   static _triggerLegacy(eventName, data) {
-    var event = new CustomEvent(eventName, {
+    const event = new CustomEvent(eventName, {
       bubbles: true, cancelable: true, detail: data
     });
     // Fire the event that listeners can listen to via 'window.addEventListener()'

--- a/src/bell/Bell.ts
+++ b/src/bell/Bell.ts
@@ -561,8 +561,8 @@ export default class Bell {
    */
   updateState() {
     Promise.all([
-      OneSignal.isPushNotificationsEnabled(),
-      OneSignal.getNotificationPermission()
+      OneSignal.privateIsPushNotificationsEnabled(),
+      OneSignal.privateGetNotificationPermission()
     ])
     .then(([isEnabled, permission]) => {
       this.setState(isEnabled ? Bell.STATES.SUBSCRIBED : Bell.STATES.UNSUBSCRIBED);

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -482,7 +482,7 @@ export default class InitHelper {
     OneSignal._initCalled = true;
   }
 
-  static async initializeConfig(options: object) {
+  static async initializeConfig(options: AppUserConfig) {
     const appConfig = await new ConfigManager().getAppConfig(options);
     Log.debug(`OneSignal: Final web app config: %c${JSON.stringify(appConfig, null, 4)}`, getConsoleStyle('code'));
 

--- a/src/libraries/Emitter.ts
+++ b/src/libraries/Emitter.ts
@@ -126,11 +126,11 @@ export default class Emitter {
   }
 
   /**
-   * Execute each item in the listener collection in order with the specified
-   * data.
+   * Execute each item in the listener collection in order with the specified data.
+   * @param event - String of the event name
+   * @param args - Variable number of args to pass to the functions subscribe to the event
    */
-  public emit(..._: any[]): Emitter {
-    const args = [].slice.call(arguments, 0); // converted to array
+  public async emit(...args: any[]): Promise<Emitter> {
     const event = args.shift();
     let listeners = this._events[event];
 
@@ -138,7 +138,7 @@ export default class Emitter {
       listeners = listeners.slice(0);
       const len = listeners.length;
       for (let i = 0; i < len; i += 1)
-        (listeners[i] as Function).apply(this, args);
+        await (listeners[i] as Function).apply(this, args);
     }
 
     return this;

--- a/src/libraries/WorkerMessenger.ts
+++ b/src/libraries/WorkerMessenger.ts
@@ -160,19 +160,18 @@ export class WorkerMessenger {
    * parameter is set to true on HTTPS iframes expecting service worker messages
    * that live under an HTTP page.
    */
-  public listen(listenIfPageUncontrolled?: boolean) {
-    if (!Environment.supportsServiceWorkers()) {
+  public async listen(listenIfPageUncontrolled?: boolean) {
+    if (!Environment.supportsServiceWorkers())
       return;
-    }
 
     const env = SdkEnvironment.getWindowEnv();
 
     if (env === WindowEnvironmentKind.ServiceWorker) {
       self.addEventListener('message', this.onWorkerMessageReceivedFromPage.bind(this));
       Log.debug('[Worker Messenger] Service worker is now listening for messages.');
-    } else {
-      this.listenForPage(listenIfPageUncontrolled);
     }
+    else
+      await this.listenForPage(listenIfPageUncontrolled);
   }
 
   /**
@@ -313,9 +312,9 @@ export class WorkerMessenger {
   async isWorkerControllingPage(): Promise<boolean> {
     const env = SdkEnvironment.getWindowEnv();
 
-    if (env === WindowEnvironmentKind.ServiceWorker) {
+    if (env === WindowEnvironmentKind.ServiceWorker)
       return !!self.registration.active;
-    } else {
+    else {
       const workerState = await this.context.serviceWorkerManager.getActiveState();
       return workerState === ServiceWorkerActiveState.WorkerA ||
         workerState === ServiceWorkerActiveState.WorkerB;
@@ -329,22 +328,21 @@ export class WorkerMessenger {
    */
   async waitUntilWorkerControlsPage() {
     return new Promise<void>(async resolve => {
-      if (await this.isWorkerControllingPage()) {
+      if (await this.isWorkerControllingPage())
         resolve();
-      } else {
+      else {
         const env = SdkEnvironment.getWindowEnv();
 
         if (env === WindowEnvironmentKind.ServiceWorker) {
           self.addEventListener('activate', async e => {
-            if (await this.isWorkerControllingPage()) {
+            if (await this.isWorkerControllingPage())
               resolve();
-            }
           });
-        } else {
+        }
+        else {
           navigator.serviceWorker.addEventListener('controllerchange', async e => {
-            if (await this.isWorkerControllingPage()) {
+            if (await this.isWorkerControllingPage())
               resolve();
-            }
           });
         }
       }

--- a/src/managers/PermissionManager.ts
+++ b/src/managers/PermissionManager.ts
@@ -120,7 +120,7 @@ export default class PermissionManager {
    *
    * @param safariWebId The Safari web ID necessary to access the permission state on Safari.
    */
-  private getOneSignalSubdomainNotificationPermission(safariWebId: string): Promise<NotificationPermission> {
+  private getOneSignalSubdomainNotificationPermission(safariWebId?: string): Promise<NotificationPermission> {
     return new Promise<NotificationPermission>(resolve => {
       OneSignal.proxyFrameHost.message(
         OneSignal.POSTMAM_COMMANDS.REMOTE_NOTIFICATION_PERMISSION,

--- a/src/managers/PermissionManager.ts
+++ b/src/managers/PermissionManager.ts
@@ -40,14 +40,12 @@ export default class PermissionManager {
    * @param safariWebId The Safari web ID necessary to access the permission
    * state on Safari.
    */
-  public async getNotificationPermission(safariWebId: string) {
+  public async getNotificationPermission(safariWebId?: string) {
     const reportedPermission = await this.getReportedNotificationPermission(safariWebId);
+    if (await this.isPermissionEnvironmentAmbiguous(reportedPermission))
+      return await this.getInterpretedAmbiguousPermission(reportedPermission);
 
-    if (await this.isPermissionEnvironmentAmbiguous(reportedPermission)) {
-      return this.getInterpretedAmbiguousPermission(reportedPermission);
-    } else {
-      return reportedPermission;
-    }
+    return reportedPermission;
   }
 
   /**
@@ -73,7 +71,7 @@ export default class PermissionManager {
    *
    * @param safariWebId The Safari web ID necessary to access the permission state on Safari.
    */
-  public async getReportedNotificationPermission(safariWebId: string) {
+  public async getReportedNotificationPermission(safariWebId?: string) {
     if (bowser.safari) {
       return this.getSafariNotificationPermission(safariWebId);
     } else {
@@ -99,7 +97,7 @@ export default class PermissionManager {
    *
    * @param safariWebId The Safari web ID necessary to access the permission state on Safari.
    */
-  private getSafariNotificationPermission(safariWebId: string): NotificationPermission {
+  private getSafariNotificationPermission(safariWebId?: string): NotificationPermission {
     if (safariWebId) {
       return window.safari.pushNotification.permission(safariWebId).permission as NotificationPermission;
     } else {

--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -161,13 +161,15 @@ export class ServiceWorkerManager {
         only say we're active if the service worker directly controls this page.
        */
       return ServiceWorkerActiveState.None;
-    } else if (workerRegistration.installing) {
+    }
+    else if (workerRegistration.installing) {
       /*
         Workers that are installing block for a while, since we can't use them until they're done
         installing.
        */
       return ServiceWorkerActiveState.Installing;
-    } else if (!workerRegistration.active) {
+    }
+    else if (!workerRegistration.active) {
       /*
         Workers that are waiting won't be our service workers, since we use clients.claim() and
         skipWaiting() to bypass the install and waiting stages.
@@ -183,13 +185,13 @@ export class ServiceWorkerManager {
 
       Check the filename to see if it belongs to our A / B worker.
     */
-    if (new Path(workerScriptPath).getFileName() == this.config.workerAPath.getFileName()) {
+
+    if (new Path(workerScriptPath).getFileName() == this.config.workerAPath.getFileName())
       workerState = ServiceWorkerActiveState.WorkerA;
-    } else if (new Path(workerScriptPath).getFileName() == this.config.workerBPath.getFileName()) {
+    else if (new Path(workerScriptPath).getFileName() == this.config.workerBPath.getFileName())
       workerState = ServiceWorkerActiveState.WorkerB;
-    } else {
+    else
       workerState = ServiceWorkerActiveState.ThirdParty;
-    }
 
     /*
       Our service worker registration can be both active and in the controlling scope of the current
@@ -204,11 +206,9 @@ export class ServiceWorkerManager {
     if (!navigator.serviceWorker.controller && (
       workerState === ServiceWorkerActiveState.WorkerA ||
       workerState === ServiceWorkerActiveState.WorkerB
-    )) {
+    ))
       return ServiceWorkerActiveState.Bypassed;
-    } else {
-      return workerState;
-    }
+    return workerState;
   }
 
   public async getWorkerVersion(): Promise<number> {
@@ -285,7 +285,7 @@ export class ServiceWorkerManager {
 
     if (workerVersion !== Environment.version()) {
       Log.info(`[Service Worker Update] Updating service worker from v${workerVersion} --> v${Environment.version()}.`);
-      this.installWorker();
+      await this.installWorker();
     } else {
       Log.info(`[Service Worker Update] Service worker version is current at v${workerVersion} (no update required).`);
     }
@@ -362,10 +362,10 @@ export class ServiceWorkerManager {
       await this.installAlternatingWorker();
     }
 
-    this.establishServiceWorkerChannel();
+    await this.establishServiceWorkerChannel();
   }
 
-  public establishServiceWorkerChannel() {
+  public async establishServiceWorkerChannel() {
     const workerMessenger = this.context.workerMessenger;
     workerMessenger.off();
 

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -24,10 +24,10 @@ export interface AppConfig {
    */
   httpUseOneSignalCom?: boolean;
   cookieSyncEnabled?: boolean;
-  restrictedOriginEnabled?: boolean;
+  restrictedOriginEnabled?: boolean | null;
   metrics: {
     enable: boolean;
-    mixpanelReportingToken: string;
+    mixpanelReportingToken: string | null;
   };
 
   safariWebId?: string;
@@ -48,7 +48,7 @@ export interface AppConfig {
    * Describes whether this app's email records require authentication.
    */
   emailAuthRequired?: boolean;
-  userConfig?: AppUserConfig;
+  userConfig: AppUserConfig;
   // TODO: Cleanup: pageUrl is also on AppUserConfig
   pageUrl?: string;
 }

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -1,4 +1,3 @@
-import { Serializable } from './Serializable';
 import { SlidedownPermissionMessageOptions } from '../popover/Popover';
 
 
@@ -50,6 +49,8 @@ export interface AppConfig {
    */
   emailAuthRequired?: boolean;
   userConfig?: AppUserConfig;
+  // TODO: Cleanup: pageUrl is also on AppUserConfig
+  pageUrl?: string;
 }
 
 export enum ConfigIntegrationKind {
@@ -138,6 +139,8 @@ export interface AppUserConfig {
   notificationClickHandlerMatch?: NotificationClickMatchBehavior;
   notificationClickHandlerAction?: NotificationClickActionBehavior;
   allowLocalhostAsSecureOrigin?: boolean;
+  requiresUserPrivacyConsent?: boolean;
+  pageUrl?: string;
 }
 
 export interface FullscreenPermissionMessageOptions {

--- a/src/modules/CookieSyncer.ts
+++ b/src/modules/CookieSyncer.ts
@@ -34,11 +34,10 @@ export default class CookieSyncer {
     }
   }
 
-  install() {
-    if (window.top !== window) {
-      /* Only process for top frames */
+  async install() {
+    // Only process for top frames */
+    if (window.top !== window)
       return;
-    }
 
     const frameUrl = this.getFrameOrigin();
 

--- a/src/modules/frames/RemoteFrame.ts
+++ b/src/modules/frames/RemoteFrame.ts
@@ -45,7 +45,8 @@ export default class RemoteFrame implements Disposable {
       metrics: {
         enable: false,
         mixpanelReportingToken: null
-      }
+      },
+      userConfig: {}
     };
   }
 

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -100,7 +100,7 @@ export default class Database {
    * @param table
    * @param keypath
    */
-  async put(table: OneSignalDbTable, keypath: any) {
+  async put(table: OneSignalDbTable, keypath: any): Promise<void> {
     await new Promise(async (resolve, reject) => {
       if (SdkEnvironment.getWindowEnv() !== WindowEnvironmentKind.ServiceWorker &&
         isUsingSubscriptionWorkaround() &&
@@ -286,7 +286,7 @@ export default class Database {
     }
   }
 
-  async setProvideUserConsent(consent: boolean) {
+  async setProvideUserConsent(consent: boolean): Promise<void> {
     await this.put('Options', { key: 'userConsent', value: consent });
   }
 
@@ -342,7 +342,7 @@ export default class Database {
     return Database.databaseInstance.getSubscription.call(Database.databaseInstance);
   }
 
-  static async setProvideUserConsent(consent: boolean) {
+  static async setProvideUserConsent(consent: boolean): Promise<void> {
     Database.ensureSingletonInstance();
     return Database.databaseInstance.setProvideUserConsent.call(Database.databaseInstance, consent);
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -144,13 +144,12 @@ export function isLocalhostAllowedAsSecureOrigin() {
  * Helper method for public APIs that waits until OneSignal is initialized, rejects if push notifications are
  * not supported, and wraps these tasks in a Promise.
  */
-export function awaitOneSignalInitAndSupported() {
+export async function awaitOneSignalInitAndSupported(): Promise<object> {
   return new Promise(resolve => {
-    if (!OneSignal.initialized) {
+    if (!OneSignal.initialized)
       OneSignal.emitter.once(OneSignal.EVENTS.SDK_INITIALIZED, resolve);
-    } else {
+    else
       resolve();
-    }
   });
 }
 
@@ -200,7 +199,7 @@ export function awaitOneSignalInitAndSupported() {
 
 export async function triggerNotificationPermissionChanged(updateIfIdentical = false) {
   let newPermission, isUpdating;
-  const currentPermission = await OneSignal.getNotificationPermission();
+  const currentPermission = await OneSignal.privateGetNotificationPermission();
   const previousPermission = await Database.get('Options', 'notificationPermission');
 
   newPermission = currentPermission;

--- a/test/support/mocks/service-workers/ServiceWorkerContainer.ts
+++ b/test/support/mocks/service-workers/ServiceWorkerContainer.ts
@@ -1,8 +1,6 @@
-import NotImplementedError from '../../../../src/errors/NotImplementedError';
 import ServiceWorker from './ServiceWorker';
 import ServiceWorkerRegistration from './models/ServiceWorkerRegistration';
 import { EventHandler } from "../../../../src/libraries/Emitter";
-import ExtendableEvent from "./models/ExtendableEvent";
 
 export class ServiceWorkerContainer implements EventTarget {
   private resolveReadyPromise: Function;
@@ -39,16 +37,14 @@ export class ServiceWorkerContainer implements EventTarget {
     return await this.serviceWorkerRegistration;
   }
 
-  public async getRegistration(clientURL: string = ''): Promise<ServiceWorkerRegistration> {
+  public async getRegistration(_clientURL: string = ''): Promise<ServiceWorkerRegistration> {
     return this.serviceWorkerRegistration;
   }
 
   public async getRegistrations(): Promise<ServiceWorkerRegistration[]> {
-    if (this.serviceWorkerRegistration) {
+    if (this.serviceWorkerRegistration)
       return [this.serviceWorkerRegistration];
-    } else {
-      return [];
-    }
+    return [];
   }
 
   public addEventListener(eventName: string, callback: EventHandler) {
@@ -56,9 +52,9 @@ export class ServiceWorkerContainer implements EventTarget {
       const handlers = this.listeners.get(eventName);
       handlers.push(callback);
       this.listeners.set(eventName, handlers);
-    } else {
-      this.listeners.set(eventName, [callback]);
     }
+    else
+      this.listeners.set(eventName, [callback]);
   }
 
   public removeEventListener(eventName: string, callback: EventHandler) {
@@ -75,13 +71,11 @@ export class ServiceWorkerContainer implements EventTarget {
   public dispatchEvent(event: Event): boolean {
     const handlers = this.listeners.get(event.type);
     if (handlers) {
-      for (const handler of handlers) {
+      for (const handler of handlers)
         handler(event);
-      }
       return true;
-    } else {
-      return false;
     }
+    return false;
   }
   // EventHandler oncontrollerchange;
   // EventHandler onmessage; // event.source of message events is ServiceWorker object

--- a/test/support/mocks/service-workers/ServiceWorkerGlobalScope.ts
+++ b/test/support/mocks/service-workers/ServiceWorkerGlobalScope.ts
@@ -41,9 +41,9 @@ export default class ServiceWorkerGlobalScope implements EventTarget {
         const handlers = this.listeners.get(eventName);
         handlers.push(callback);
         this.listeners.set(eventName, handlers);
-      } else {
-        this.listeners.set(eventName, [callback]);
       }
+      else
+        this.listeners.set(eventName, [callback]);
     };
     this.removeEventListener = function(eventName: string, callback: EventHandler) {
       if (this.listeners.has(eventName)) {

--- a/test/unit/managers/ConfigManager.ts
+++ b/test/unit/managers/ConfigManager.ts
@@ -28,9 +28,8 @@ test('can customize initialization options', async t => {
     fakeServerConfig
   );
 
-  for (const userConfigKey in Object.keys(fakeUserConfig)) {
+  for (const userConfigKey in Object.keys(fakeUserConfig))
     t.deepEqual(fakeMergedConfig.userConfig[userConfigKey], fakeUserConfig[userConfigKey]);
-  }
 });
 
 test('should use server-provided subdomain if enabled', async t => {

--- a/test/unit/managers/ServiceWorkerManager.ts
+++ b/test/unit/managers/ServiceWorkerManager.ts
@@ -169,7 +169,7 @@ test('notification clicked - While page is opened in background', async t => {
   const workerMessageReplyBuffer = new WorkerMessengerReplyBuffer();
   OneSignal.context.workerMessenger = new WorkerMessenger(OneSignal.context, workerMessageReplyBuffer);
 
-  const triggerStub = sinon.stub(Event, 'trigger', function(event) {
+  const triggerStub = sinon.stub(Event, 'trigger', function(event: string) {
     if (event === OneSignal.EVENTS.NOTIFICATION_CLICKED)
       t.pass();
   });
@@ -179,7 +179,7 @@ test('notification clicked - While page is opened in background', async t => {
   manager.establishServiceWorkerChannel();
 
   const listeners = workerMessageReplyBuffer.findListenersForMessage(WorkerMessengerCommand.NotificationClicked);
-  for (let listenerRecord of listeners)
+  for (const listenerRecord of listeners)
     listenerRecord.callback.apply(null, ['test']);
 
   getRegistrationStub.restore();

--- a/test/unit/modules/subscriptionHelper.ts
+++ b/test/unit/modules/subscriptionHelper.ts
@@ -24,7 +24,7 @@ test.beforeEach(async t => {
 });
 
 test('should not resubscribe user on subsequent page views if the user is already subscribed', async t => {
-  const isPushEnabledStub = sinon.stub(OneSignal, 'isPushNotificationsEnabled').resolves(true);
+  const isPushEnabledStub = sinon.stub(OneSignal, 'privateIsPushNotificationsEnabled').resolves(true);
   const getSessionCountStub = sinon.stub(SessionManager.prototype, 'getPageViewCount').returns(2);
   const subscribeSpy = sinon.spy(SubscriptionManager.prototype, 'subscribe');
 

--- a/test/unit/public-sdk-apis/init.ts
+++ b/test/unit/public-sdk-apis/init.ts
@@ -139,11 +139,8 @@ async function expectPushRecordCreationRequest(t: TestContext) {
         "identifier"
       ];
       const parsedRequestBody = JSON.parse(requestBody);
-      // for (const sameValueKey of Object.keys(sameValues))
-      //   t.deepEqual(parsedRequestBody[sameValueKey], sameValues[sameValueKey]);
       for (const anyValueKey of anyValues)
         t.not(parsedRequestBody[anyValueKey], undefined);
-      // return { success: true, id: playerId };
       return {};
     });
 }

--- a/test/unit/public-sdk-apis/init.ts
+++ b/test/unit/public-sdk-apis/init.ts
@@ -1,17 +1,39 @@
 import "../../support/polyfills/polyfills";
 import test, { TestContext } from "ava";
+import sinon, {SinonSandbox} from 'sinon';
 import Database from "../../../src/services/Database";
-import Macros from "../../support/tester/Macros";
 import { TestEnvironment, HttpHttpsEnvironment } from '../../support/sdk/TestEnvironment';
 import OneSignal from "../../../src/OneSignal";
 import Context from '../../../src/models/Context';
 import InitHelper from '../../../src/helpers/InitHelper';
-import { AppConfig } from '../../../src/models/AppConfig';
-import ConfigManager from '../../../src/managers/ConfigManager';
+import {AppConfig, ConfigIntegrationKind, ServerAppConfig} from '../../../src/models/AppConfig';
 
 import nock from 'nock';
 import { SessionManager } from "../../../src/managers/SessionManager";
 import Random from "../../support/tester/Random";
+import OneSignalApi from "../../../src/OneSignalApi";
+
+let sinonSandbox: SinonSandbox;
+test.beforeEach(function () {
+  expectWebPushAnalytics();
+
+  sinonSandbox = sinon.sandbox.create();
+});
+
+test.afterEach(function () {
+  sinonSandbox.restore();
+
+  OneSignal._initCalled = false;
+  OneSignal.__initAlreadyCalled = false;
+});
+
+class InitTestHelpers {
+  static stubJSONP(serverAppConfig: ServerAppConfig) {
+    sinonSandbox.stub(OneSignalApi, "jsonpLib", function (_url: string, callback: Function) {
+      callback(null, serverAppConfig);
+    });
+  }
+}
 
 test("correct degree of persistNotification setting should be stored", async t => {
   await TestEnvironment.initialize({
@@ -57,16 +79,21 @@ test("correct degree of persistNotification setting should be stored", async t =
   }
 });
 
-async function expectUserSessionCountUpdateRequest(
-  t: TestContext,
-  pushDevicePlayerId: string,
-) {
+async function expectUserSessionCountUpdateRequest(_t: TestContext, pushDevicePlayerId: string) {
   nock('https://onesignal.com')
     .post(`/api/v1/players/${pushDevicePlayerId}/on_session`)
     .reply(200, (uri, requestBody) => {
       // Not matching for anything yet, because no email-specific data is sent here
       // Just a whole bunch of params like timezone, os, sdk version..etc.
-      return { "success":true };
+      return { success: true };
+    });
+}
+
+async function expectWebPushAnalytics() {
+  nock('https://onesignal.com')
+    .get("/webPushAnalytics")
+    .reply(200, (_uri: string, _requestBody: string) => {
+      return { success: true };
     });
 }
 
@@ -80,13 +107,127 @@ test("email session should be updated on first page view", async t => {
   const appConfig = TestEnvironment.getFakeAppConfig();
   OneSignal.context = new Context(appConfig);
   OneSignal.config = appConfig;
-  const config: AppConfig = OneSignal.config;
   OneSignal.context.sessionManager = sessionManager;
+
   // Ensure this is true, that way email on_session gets run
   sessionManager.setPageViewCount(1);
   t.true(sessionManager.isFirstPageView());
 
-  expectUserSessionCountUpdateRequest(t, testData.emailPlayerId);
+  await expectUserSessionCountUpdateRequest(t, testData.emailPlayerId);
 
   await InitHelper.updateEmailSessionCount();
+});
+
+
+async function expectPushRecordCreationRequest(t: TestContext) {
+  nock('https://onesignal.com')
+    .post(`/api/v1/players`)
+    .reply(400, (_uri: string, requestBody: string) => {
+      const anyValues = [
+        "device_type",
+        "language",
+        "timezone",
+        "device_os",
+        "sdk",
+        "delivery_platform",
+        "browser_name",
+        "browser_version",
+        "operating_system",
+        "operating_system_version",
+        "device_platform",
+        "device_model",
+        "identifier"
+      ];
+      const parsedRequestBody = JSON.parse(requestBody);
+      // for (const sameValueKey of Object.keys(sameValues))
+      //   t.deepEqual(parsedRequestBody[sameValueKey], sameValues[sameValueKey]);
+      for (const anyValueKey of anyValues)
+        t.not(parsedRequestBody[anyValueKey], undefined);
+      // return { success: true, id: playerId };
+      return {};
+    });
+}
+
+test("Test OneSignal.init, Custom, with requiresUserPrivacyConsent", async t => {
+  const testConfig = {
+    initOptions: {},
+    httpOrHttps: HttpHttpsEnvironment.Https,
+    pushIdentifier: (await TestEnvironment.getFakePushSubscription()).endpoint
+  };
+  await TestEnvironment.initialize(testConfig);
+  OneSignal.initialized = false;
+
+  sinonSandbox.stub(document, "visibilityState").value("visible");
+
+  const serverAppConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom);
+  InitTestHelpers.stubJSONP(serverAppConfig);
+
+  sinonSandbox.stub(OneSignalApi, "get").resolves({});
+
+  let delayInit = true;
+  let firedSDKInitalizedPublic = false;
+  OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, function() {
+    if (delayInit)
+      t.fail();
+
+    firedSDKInitalizedPublic = true;
+  });
+
+  TestEnvironment.mockInternalOneSignal();
+
+  await OneSignal.init({
+    appId: Random.getRandomUuid(),
+    requiresUserPrivacyConsent: true
+  });
+
+  expectPushRecordCreationRequest(t);
+
+  delayInit = false;
+  await OneSignal.provideUserConsent(true);
+
+  if (!firedSDKInitalizedPublic)
+    t.fail();
+});
+
+
+test("Test OneSignal.init, TypicalSite, with requiresUserPrivacyConsent", async t => {
+  const testConfig = {
+    initOptions: { },
+    httpOrHttps: HttpHttpsEnvironment.Https,
+    pushIdentifier: (await TestEnvironment.getFakePushSubscription()).endpoint
+  };
+  await TestEnvironment.initialize(testConfig);
+  OneSignal.initialized = false;
+
+  sinonSandbox.stub(document, "visibilityState").value("visible");
+
+  const serverAppConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.TypicalSite);
+  InitTestHelpers.stubJSONP(serverAppConfig);
+
+  sinonSandbox.stub(OneSignalApi, "get").resolves({});
+
+  let delayInit = true;
+  let firedSDKInitializedPublic = false;
+  OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, function() {
+    if (delayInit)
+      t.fail();
+    else
+      t.pass();
+
+    firedSDKInitializedPublic = true;
+  });
+
+  TestEnvironment.mockInternalOneSignal();
+  // Don't need to mock create call, autoRegister not settable with TypicalSite
+
+  await OneSignal.init({
+    appId: Random.getRandomUuid(),
+    requiresUserPrivacyConsent: true
+  });
+
+  delayInit = false;
+  await OneSignal.provideUserConsent(true);
+
+  if (!firedSDKInitializedPublic)
+    t.fail();
 });

--- a/tslinit.json
+++ b/tslinit.json
@@ -12,6 +12,7 @@
     "max-line-length": [true, 120],
     "trailing-comma": [false],
     "no-void-expression": true,
+    "no-floating-promises": true,
 
     // Not enforcing curlt until "multi-or-nest" is supported
     //    - https://github.com/buzinas/tslint-eslint-rules/issues/205


### PR DESCRIPTION
* Lots of refactoring with awaits to allow unit testing of init method
* `requiresUserPrivacyConsent `flag can be set with init
* `provideUserConsent(boolean)` can then be called which will initialize the SDK


**History**
* Commit with extra debugging 231e39a0bebed3caf4ce3e59828cf4c3f1fcf3be
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/354)
<!-- Reviewable:end -->
