### PR TITLE
Fixed issue with prompts not showing on HTTP

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -368,12 +368,11 @@ export default class OneSignal {
       Log.info(new PushPermissionNotGrantedError(PushPermissionNotGrantedErrorReason.Blocked));
       return;
     }
-    if (isEnabled) {
+
+    if (isEnabled)
       throw new AlreadySubscribedError();
-    }
-    if (!notOptedOut) {
+    if (!notOptedOut)
       throw new NotSubscribedError(NotSubscribedReason.OptedOut);
-    }
 
     MainHelper.markHttpPopoverShown();
 
@@ -451,7 +450,8 @@ export default class OneSignal {
            */
         OneSignal.subscriptionPopupHost = new SubscriptionPopupHost(OneSignal.proxyFrameHost.url, options);
         OneSignal.subscriptionPopupHost.load();
-      } else {
+      }
+      else {
         if (!options)
           options = {};
         options.fromRegisterFor = true;
@@ -459,11 +459,10 @@ export default class OneSignal {
       }
     }
 
-    if (!OneSignal.initialized) {
+    if (!OneSignal.initialized)
       OneSignal.emitter.once(OneSignal.EVENTS.SDK_INITIALIZED, () => __registerForPushNotifications());
-    } else {
+    else
       return __registerForPushNotifications();
-    }
   }
 
   /**

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -427,7 +427,7 @@ export default class InitHelper {
               Number(bowser.version) >= 63 &&
               (bowser.tablet || bowser.mobile)
               )
-              await OneSignal.showHttpPrompt();
+              await OneSignal.privateShowHttpPrompt();
             else
               await SubscriptionHelper.registerForPush();
           }
@@ -437,14 +437,13 @@ export default class InitHelper {
       }
     }
     else {
-      if (OneSignal.config.userConfig.autoRegister !== true) {
+      if (OneSignal.config.userConfig.autoRegister !== true)
         Log.debug('OneSignal: Not automatically showing popover because autoRegister is not specifically true.');
-      }
-      if (MainHelper.isHttpPromptAlreadyShown()) {
+      if (MainHelper.isHttpPromptAlreadyShown())
         Log.debug('OneSignal: Not automatically showing popover because it was previously shown in the same session.');
-      }
+
       if (OneSignal.config.userConfig.autoRegister === true && !MainHelper.isHttpPromptAlreadyShown()) {
-        await OneSignal.showHttpPrompt().catch(e => {
+        await OneSignal.privateShowHttpPrompt().catch(e => {
           if (
             (e instanceof InvalidStateError &&
               (e as any).reason === InvalidStateReason[InvalidStateReason.RedundantPermissionMessage]) ||
@@ -454,7 +453,9 @@ export default class InitHelper {
           ) {
             Log.debug('[Prompt Not Showing]', e);
             // Another prompt is being shown, that's okay
-          } else Log.info(e);
+          }
+          else
+            Log.info(e);
         });
       }
       OneSignal._sessionInitAlreadyRunning = false;

--- a/src/helpers/MainHelper.ts
+++ b/src/helpers/MainHelper.ts
@@ -11,7 +11,6 @@ import OneSignalApi from '../OneSignalApi';
 import Database from '../services/Database';
 import { ResourceLoadState } from '../services/DynamicResourceLoader';
 import {
-  awaitOneSignalInitAndSupported,
   capitalize,
   contains,
   getConsoleStyle,

--- a/src/modules/frames/ProxyFrameHost.ts
+++ b/src/modules/frames/ProxyFrameHost.ts
@@ -84,13 +84,12 @@ export default class ProxyFrameHost implements Disposable {
   }
 
   removeFrame() {
-    // Unit tests may not have access to document
-    if (Environment.isBrowser()) {
-      const existingInstance = document.querySelector(`iFrame[src='${this.url.toString()}'`);
-      if (existingInstance) {
-        existingInstance.remove();
-      }
-    }
+    if (!Environment.isBrowser())
+      return;
+
+    const existingInstance = document.querySelector(`iframe[src='${this.url.toString()}']`);
+    if (existingInstance)
+      existingInstance.remove();
   }
 
   onFrameLoad(_: UIEvent): void {

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -256,6 +256,10 @@ export class TestEnvironment {
     process.on('unhandledRejection', (error: object) => {
       console.log("error", error);
     });
+
+    process.on('uncaughtException', (error: object) => {
+      console.log("error", error);
+    });
   }
 
   static async getFakePushSubscription(): Promise<PushSubscription> {


### PR DESCRIPTION
* Fixed issue by removing some awaitOneSignalInitAndSupported that were blocking
  - Used the privateShowHttpPrompt() internally instead of showHttpPrompt
* Added tests reproducing the issue and ensuring the issue is fixed
* Misc clean up to init tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/356)
<!-- Reviewable:end -->
