### PR TITLE
Report 403 and 404 if service worker failed to install.

### DIFF
--- a/src/errors/AlreadySubscribedError.ts
+++ b/src/errors/AlreadySubscribedError.ts
@@ -4,5 +4,12 @@ import OneSignalError from './OneSignalError';
 export default class AlreadySubscribedError extends OneSignalError {
   constructor() {
     super('This operation can only be performed when the user is not subscribed.');
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, AlreadySubscribedError.prototype);
   }
 }

--- a/src/errors/DeprecatedApiError.ts
+++ b/src/errors/DeprecatedApiError.ts
@@ -19,6 +19,13 @@ export class DeprecatedApiError extends OneSignalError {
         this.reportUsage(ApiUsageMetricKind.SyncHashedEmail);
         break;
     }
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, DeprecatedApiError.prototype);
   }
 
   reportUsage(apiKind: ApiUsageMetricKind) {

--- a/src/errors/InvalidArgumentError.ts
+++ b/src/errors/InvalidArgumentError.ts
@@ -24,5 +24,12 @@ export class InvalidArgumentError extends OneSignalError {
     }
     this.argument = argName;
     this.reason = InvalidArgumentReason[reason];
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, InvalidArgumentError.prototype);
   }
 }

--- a/src/errors/InvalidStateError.ts
+++ b/src/errors/InvalidStateError.ts
@@ -25,7 +25,7 @@ export class InvalidStateError extends OneSignalError {
         break;
       case InvalidStateReason.RedundantPermissionMessage:
         let extraInfo = '';
-        if (extra.permissionPromptType)
+        if (extra && extra.permissionPromptType)
           extraInfo = `(${PermissionPromptType[extra.permissionPromptType]})`;
         super(`Another permission message ${extraInfo} is being displayed.`);
         break;
@@ -44,5 +44,12 @@ export class InvalidStateError extends OneSignalError {
     }
     this.description = InvalidStateReason[reason];
     this.reason = reason;
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, InvalidStateError.prototype);
   }
 }

--- a/src/errors/InvalidUuidError.ts
+++ b/src/errors/InvalidUuidError.ts
@@ -4,5 +4,12 @@ import OneSignalError from "./OneSignalError";
 export default class InvalidUuidError extends OneSignalError {
   constructor(uuid) {
     super(`'${uuid}' is not a valid UUID`);
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, InvalidUuidError.prototype);
   }
 }

--- a/src/errors/NotImplementedError.ts
+++ b/src/errors/NotImplementedError.ts
@@ -4,5 +4,12 @@ import OneSignalError from "./OneSignalError";
 export default class NotImplementedError extends OneSignalError {
   constructor() {
     super('This code is not implemented yet.');
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, NotImplementedError.prototype);
   }
 }

--- a/src/errors/NotSubscribedError.ts
+++ b/src/errors/NotSubscribedError.ts
@@ -24,5 +24,12 @@ export class NotSubscribedError extends OneSignalError {
         break;
     }
     this.reason = NotSubscribedReason[reason];
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, NotSubscribedError.prototype);
   }
 }

--- a/src/errors/OneSignalApiError.ts
+++ b/src/errors/OneSignalApiError.ts
@@ -14,5 +14,12 @@ export class OneSignalApiError extends OneSignalError {
         super('The API call is missing an app ID.');
         break;
     }
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, OneSignalApiError.prototype);
   }
 }

--- a/src/errors/OneSignalError.js
+++ b/src/errors/OneSignalError.js
@@ -28,6 +28,13 @@ export default class OneSignalError extends Error {
       value : (new Error(message)).stack,
       writable : true,
     });
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, OneSignalError.prototype);
   }
 }
 

--- a/src/errors/PermissionMessageDismissedError.ts
+++ b/src/errors/PermissionMessageDismissedError.ts
@@ -4,5 +4,12 @@ import OneSignalError from "./OneSignalError";
 export default class PermissionMessageDismissedError extends OneSignalError {
   constructor() {
     super('The permission message was previously dismissed.');
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, PermissionMessageDismissedError.prototype);
   }
 }

--- a/src/errors/PushNotSupportedError.ts
+++ b/src/errors/PushNotSupportedError.ts
@@ -4,5 +4,12 @@ import OneSignalError from "./OneSignalError";
 export default class PushNotSupportedError extends OneSignalError {
   constructor() {
     super('Push notifications are not supported.');
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, PushNotSupportedError.prototype);
   }
 }

--- a/src/errors/PushPermissionNotGrantedError.ts
+++ b/src/errors/PushPermissionNotGrantedError.ts
@@ -24,5 +24,12 @@ export default class PushPermissionNotGrantedError extends OneSignalError {
     }
 
     this.reason = reason;
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, PushPermissionNotGrantedError.prototype);
   }
 }

--- a/src/errors/SdkInitError.ts
+++ b/src/errors/SdkInitError.ts
@@ -45,5 +45,12 @@ export class SdkInitError extends OneSignalError {
         break;
     }
     this.reason = SdkInitErrorKind[reason];
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, SdkInitError.prototype);
   }
 }

--- a/src/errors/ServiceUnavailableError.ts
+++ b/src/errors/ServiceUnavailableError.ts
@@ -3,5 +3,12 @@ import OneSignalError from './OneSignalError';
 export default class ServiceUnavailableError extends OneSignalError {
   constructor(public description: string) {
     super(`The OneSignal service is temporarily unavailable. ${description}`);
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, ServiceUnavailableError.prototype);
   }
 }

--- a/src/errors/ServiceWorkerRegistrationError.ts
+++ b/src/errors/ServiceWorkerRegistrationError.ts
@@ -1,0 +1,21 @@
+import OneSignalError from './OneSignalError';
+
+export class ServiceWorkerRegistrationError extends OneSignalError {
+  public readonly status: number;
+  public readonly statusText: string;
+  
+  constructor(status: number, statusText: string) {
+    super(`Registration of a Service Worker failed.`);
+    this.status = status;
+    this.statusText = statusText;
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, ServiceWorkerRegistrationError.prototype);
+  }
+}
+
+export default ServiceWorkerRegistrationError;

--- a/src/errors/SubscriptionError.ts
+++ b/src/errors/SubscriptionError.ts
@@ -8,8 +8,6 @@ export enum SubscriptionErrorReason {
 }
 
 export default class SubscriptionError extends OneSignalError {
-  reason: string;
-
   constructor(reason: SubscriptionErrorReason) {
     switch (reason) {
       case SubscriptionErrorReason.InvalidSafariSetup:
@@ -22,5 +20,12 @@ export default class SubscriptionError extends OneSignalError {
         super('The notification permission prompt was dismissed.');
         break;
     }
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, SubscriptionError.prototype);
   }
 }

--- a/src/errors/TimeoutError.ts
+++ b/src/errors/TimeoutError.ts
@@ -4,5 +4,12 @@ import OneSignalError from "./OneSignalError";
 export default class TimeoutError extends OneSignalError {
   constructor(public message: string = "The asynchronous operation has timed out.") {
     super(message);
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, TimeoutError.prototype);
   }
 }

--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -1,5 +1,3 @@
-
-
 import Environment from '../Environment';
 import { InvalidStateError, InvalidStateReason } from '../errors/InvalidStateError';
 import { WorkerMessengerCommand } from '../libraries/WorkerMessenger';
@@ -18,6 +16,8 @@ import ProxyFrameHost from '../modules/frames/ProxyFrameHost';
 import Log from '../libraries/Log';
 import Event from '../Event';
 import ProxyFrame from '../modules/frames/ProxyFrame';
+import ServiceWorkerRegistrationError from "../errors/ServiceWorkerRegistrationError"
+import Utils from "../utils/Utils";
 
 export enum ServiceWorkerActiveState {
   /**
@@ -492,7 +492,34 @@ export class ServiceWorkerManager {
     };
     fullWorkerPath = `${workerDirectory}/${workerFileName}?${encodeHashAsUriComponent(installUrlQueryParams)}`;
     Log.info(`[Service Worker Installation] Installing service worker ${fullWorkerPath}.`);
-    await navigator.serviceWorker.register(fullWorkerPath, this.config.registrationOptions);
+    try {
+      await navigator.serviceWorker.register(fullWorkerPath, this.config.registrationOptions);
+    } catch (error) {
+      Log.error(`[Service Worker Installation] Installing service worker failed ${error}`)
+      /*
+        Try accessing the service worker path directly to find out what the problem is and report it to OneSignal api.
+      */
+
+      /*
+        If we are inside the popup and service worker fails to register, it's not developer's fault.
+        No need to report it to the api then.
+       */
+      const env = SdkEnvironment.getWindowEnv();
+      if (env === WindowEnvironmentKind.OneSignalSubscriptionPopup) {
+        throw error;
+      }
+      /*
+        Node-fetch Request works only with absolute urls.
+        Building the absolute url for service worker file to make a request.
+      */
+      const baseUrl = Utils.getBaseUrl();
+      fullWorkerPath = `${baseUrl}${workerDirectory}/${workerFileName}?${encodeHashAsUriComponent(installUrlQueryParams)}`;
+      const response = await fetch(fullWorkerPath);
+      if (response.status === 403 || response.status === 404) {
+        throw new ServiceWorkerRegistrationError(response.status, response.statusText);
+      } 
+      throw error;
+    }
     Log.debug(`[Service Worker Installation] Service worker installed.`);
   }
 }

--- a/src/models/PushDeviceRecord.ts
+++ b/src/models/PushDeviceRecord.ts
@@ -31,7 +31,7 @@ export class PushDeviceRecord extends DeviceRecord {
     if (this.subscription) {
       serializedBundle.identifier = bowser.safari ?
         this.subscription.safariDeviceToken :
-        this.subscription.w3cEndpoint.toString();
+        this.subscription.w3cEndpoint ? this.subscription.w3cEndpoint.toString() : null;
       serializedBundle.web_auth = this.subscription.w3cAuth;
       serializedBundle.web_p256 = this.subscription.w3cP256dh;
     }

--- a/src/models/RawPushSubscription.ts
+++ b/src/models/RawPushSubscription.ts
@@ -32,14 +32,23 @@ export class RawPushSubscription implements Serializable {
    */
   public isNewSubscription(): boolean {
     if (this.existingW3cPushSubscription) {
-      return this.existingW3cPushSubscription.w3cEndpoint.toString() !== this.w3cEndpoint.toString() ||
-        this.existingW3cPushSubscription.w3cP256dh !== this.w3cP256dh ||
-        this.existingW3cPushSubscription.w3cAuth !== this.w3cAuth;
+      if (!!this.existingW3cPushSubscription.w3cEndpoint !== !!this.w3cEndpoint) {
+        return false;
+      }
+      if (!!this.existingW3cPushSubscription.w3cEndpoint && !!this.w3cEndpoint && 
+        this.existingW3cPushSubscription.w3cEndpoint.toString() !== this.w3cEndpoint.toString()) {
+          return false;
+      }
+      if (this.existingW3cPushSubscription.w3cP256dh !== this.w3cP256dh) {
+        return false;
+      }
+      if (this.existingW3cPushSubscription.w3cAuth !== this.w3cAuth) {
+        return false;
+      }
     } else if (this.existingSafariDeviceToken) {
       return this.existingSafariDeviceToken !== this.safariDeviceToken;
-    } else {
-      return true;
     }
+    return true;
   }
 
   /**
@@ -99,7 +108,7 @@ export class RawPushSubscription implements Serializable {
   public serialize() {
     const serializedBundle: any = {
       /* Old Parameters */
-      w3cEndpoint: this.w3cEndpoint.toString(),
+      w3cEndpoint: this.w3cEndpoint ? this.w3cEndpoint.toString() : null,
       w3cP256dh: this.w3cP256dh,
       w3cAuth: this.w3cAuth,
       safariDeviceToken: this.safariDeviceToken,

--- a/src/models/SubscriptionStateKind.ts
+++ b/src/models/SubscriptionStateKind.ts
@@ -5,4 +5,6 @@ export enum SubscriptionStateKind {
   TemporaryWebRecord = -20,
   PermissionRevoked = -21,
   PushSubscriptionRevoked = -22,
+  ServiceWorkerStatus403 = -23,
+  ServiceWorkerStatus404 = -24
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,0 +1,7 @@
+export class Utils {
+    public static getBaseUrl() {
+        return location.origin;
+    }
+}
+
+export default Utils;


### PR DESCRIPTION
- Added error handling for service worker registration call;
- Performing an additional request to determine if there is an issue with service worker file configuration;
- Reporting an error to the api in case of 403 and 404 errors
   - on first page view only;
   - not from inside a popup;
- Added tests for corresponding pieces in ServiceWorkerManager and SubscriptionManager;
- Added the workaround to correct the type checking for custom errors derived from Error class (TypeScript specific).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/368)
<!-- Reviewable:end -->
