### PR TITLE
Fix for privateShowHttpPrompt error with force

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -336,14 +336,14 @@ export default class OneSignal {
    * @PublicApi
    */
   static async showHttpPrompt(options?) {
-    if (!options)
-      options = {};
-
     await awaitOneSignalInitAndSupported();
     await OneSignal.privateShowHttpPrompt(options);
   }
 
   static async privateShowHttpPrompt(options?) {
+    if (!options)
+      options = {};
+
     /*
     Only show the HTTP popover if:
     - Notifications aren't already enabled
@@ -355,22 +355,24 @@ export default class OneSignal {
       });
     }
 
-    const permission = await OneSignal.privateGetNotificationPermission();
-    const isEnabled = await OneSignal.privateIsPushNotificationsEnabled();
-    const notOptedOut = await OneSignal.privateGetSubscription();
     const doNotPrompt = await MainHelper.wasHttpsNativePromptDismissed();
 
     if (doNotPrompt && !options.force) {
       Log.info(new PermissionMessageDismissedError());
       return;
     }
+
+    const permission = await OneSignal.privateGetNotificationPermission();
     if (permission === NotificationPermission.Denied) {
       Log.info(new PushPermissionNotGrantedError(PushPermissionNotGrantedErrorReason.Blocked));
       return;
     }
 
+    const isEnabled = await OneSignal.privateIsPushNotificationsEnabled();
     if (isEnabled)
       throw new AlreadySubscribedError();
+
+    const notOptedOut = await OneSignal.privateGetSubscription();
     if (!notOptedOut)
       throw new NotSubscribedError(NotSubscribedReason.OptedOut);
 

--- a/test/unit/public-sdk-apis/showHttpPrompt.ts
+++ b/test/unit/public-sdk-apis/showHttpPrompt.ts
@@ -1,0 +1,31 @@
+import test, {TestContext} from "ava";
+import OneSignal from "../../../src/OneSignal";
+import {TestEnvironment} from "../../support/sdk/TestEnvironment";
+import Context from "../../../src/models/Context";
+import MainHelper from "../../../src/helpers/MainHelper";
+import sinon, {SinonSandbox} from 'sinon';
+
+let sinonSandbox: SinonSandbox;
+
+test.beforeEach(function () {
+  sinonSandbox = sinon.sandbox.create();
+});
+
+test.afterEach(function (_t: TestContext) {
+  sinonSandbox.restore();
+});
+
+test("Test showHttpPrompt with no params", async t => {
+  await TestEnvironment.initialize();
+  const appConfig = TestEnvironment.getFakeAppConfig();
+  OneSignal.context = new Context(appConfig);
+
+  sinonSandbox.stub(MainHelper, "wasHttpsNativePromptDismissed").resolves(true);
+  sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(false);
+
+  // Ensure both public and private calls work
+  await OneSignal.showHttpPrompt();
+  await OneSignal.privateShowHttpPrompt();
+  // Pass if we did not throw
+  t.pass();
+});


### PR DESCRIPTION
* Fixes "Cannot read property 'force' of undefined" introduced in 150201
* resolves #363

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/369)
<!-- Reviewable:end -->
