### PR TITLE
New prompt type - Custom link

### DIFF
--- a/src/CustomLink.ts
+++ b/src/CustomLink.ts
@@ -1,0 +1,129 @@
+import { hasCssClass, addCssClass, removeCssClass, isUsingSubscriptionWorkaround } from "./utils";
+import { AppUserConfigCustomLinkOptions } from "./models/AppConfig";
+import { ResourceLoadState } from "./services/DynamicResourceLoader";
+import OneSignal from "./OneSignal";
+import Log from "./libraries/Log";
+
+export class CustomLink {
+  public static async initialize(config: AppUserConfigCustomLinkOptions, isUserSubscribed?: boolean) {
+    Log.info("Inititalize CustomLink");
+    const sdkStylesLoadResult = await OneSignal.context.dynamicResourceLoader.loadSdkStylesheet();
+    if (sdkStylesLoadResult !== ResourceLoadState.Loaded) {
+        Log.debug('Not initializing custom link button because styles failed to load.');
+        return;
+    }
+    
+    const isPushEnabled = (isUserSubscribed !== undefined) ? isUserSubscribed : await OneSignal.isPushNotificationsEnabled();
+
+    const onClickAttribute = "data-click"; 
+
+    const subscribeElements = document.querySelectorAll<HTMLElement>(".onesignal-customlink-subscribe");
+    subscribeElements.forEach((subscribe: HTMLElement) => {
+      subscribe.textContent = config.text.subscribe;
+      CustomLink.setResetClass(subscribe);
+      CustomLink.setStateClass(subscribe, isPushEnabled);
+      CustomLink.setStyleClass(subscribe, config.style);
+      CustomLink.setSizeClass(subscribe, config.size);
+      CustomLink.setCustomColors(subscribe, config);
+
+      const hasEvent = !!subscribe.getAttribute(onClickAttribute);
+      if (!hasEvent) {
+        subscribe.addEventListener("click", async () => {
+          Log.info("subscribe clicked");
+          if (isUsingSubscriptionWorkaround()) {
+            // Show the HTTP popup so users can re-allow notifications
+            OneSignal.registerForPushNotifications();
+          } else {
+            const subscriptionState: PushSubscriptionState = await OneSignal.context.subscriptionManager.getSubscriptionState();
+            if (!subscriptionState.subscribed) {
+              OneSignal.registerForPushNotifications();
+              return;
+            }
+            if (subscriptionState.optedOut) {
+              OneSignal.setSubscription(true);
+            }
+          }
+        });
+        subscribe.setAttribute("data-click", "1");
+      }
+    });
+
+    const unsubscribeElements = document.querySelectorAll<HTMLElement>(".onesignal-customlink-unsubscribe");
+    unsubscribeElements.forEach((unsubscribe: HTMLElement) => {
+      unsubscribe.textContent = config.text.unsubscribe;
+      CustomLink.setResetClass(unsubscribe);
+      CustomLink.setStateClass(unsubscribe, isPushEnabled);
+      CustomLink.setStyleClass(unsubscribe, config.style);
+      CustomLink.setSizeClass(unsubscribe, config.size);
+      CustomLink.setCustomColors(unsubscribe, config);
+
+      const hasEvent = !!unsubscribe.getAttribute(onClickAttribute);
+      if (!hasEvent) {
+        unsubscribe.addEventListener("click", async () => {
+          Log.info("unsubscribe clicked");
+          const isPushEnabled = await OneSignal.isPushNotificationsEnabled();
+          if (isPushEnabled) {
+            await OneSignal.setSubscription(false);
+          }
+        });
+        unsubscribe.setAttribute("data-click", "1");
+      }
+    });
+
+    const explanationElements = document.querySelectorAll<HTMLElement>(".onesignal-customlink-explanation");
+    explanationElements.forEach((explanation: HTMLElement) => {
+      explanation.textContent = config.text.explanation;
+      CustomLink.setResetClass(explanation);
+      CustomLink.setStateClass(explanation, isPushEnabled);
+      CustomLink.setSizeClass(explanation, config.size);
+    });
+  }
+
+  private static setCustomColors(element: HTMLElement, config: AppUserConfigCustomLinkOptions) {
+    if (config.style === "button") {
+      element.style.backgroundColor = config.color.button;
+      element.style.color = config.color.text;
+    } else if (config.style === "link") {
+      element.style.color = config.color.button;
+    }
+  }
+
+  private static setStateClass(element: HTMLElement, subscribed: boolean) {
+    const oldClassName = subscribed ? "state-unsubscribed" : "state-subscribed";
+    const newClassName = subscribed ? "state-subscribed" : "state-unsubscribed";
+
+    if (hasCssClass(element, oldClassName)) {
+      removeCssClass(element, oldClassName);
+    }
+
+    if (!hasCssClass(element, newClassName)) {
+      addCssClass(element, newClassName);
+    }
+  }
+
+  private static setStyleClass(element: HTMLElement, style: "button" | "link") {
+    const newClassName = style;
+
+    if (!hasCssClass(element, newClassName)) {
+      addCssClass(element, newClassName);
+    }
+  }
+
+  private static setSizeClass(element: HTMLElement, size: "small" | "medium" | "large") {
+    const newClassName = size;
+
+    if (!hasCssClass(element, newClassName)) {
+      addCssClass(element, newClassName);
+    }
+  }
+
+  private static setResetClass(element: HTMLElement) {
+    const newClassName = "onesignal-reset";
+
+    if (!hasCssClass(element, newClassName)) {
+      addCssClass(element, newClassName);
+    }
+  }
+}
+
+export default CustomLink;

--- a/src/CustomLink.ts
+++ b/src/CustomLink.ts
@@ -5,7 +5,7 @@ import OneSignal from "./OneSignal";
 import Log from "./libraries/Log";
 
 export class CustomLink {
-  public static async initialize(config: AppUserConfigCustomLinkOptions | undefined, isUserSubscribed?: boolean): Promise<void> {
+  public static async initialize(config: AppUserConfigCustomLinkOptions | undefined): Promise<void> {
     if (!config || !config.enabled) {
       return;
     }
@@ -17,16 +17,13 @@ export class CustomLink {
         return;
     }
     
-    const isPushEnabled = (isUserSubscribed === true || isUserSubscribed === false) ? 
-      isUserSubscribed : await OneSignal.isPushNotificationsEnabled();
+    const isPushEnabled = await OneSignal.isPushNotificationsEnabled();
 
     const onClickAttribute = "data-cl-click"; 
 
     const subscribeElements = document.querySelectorAll<HTMLElement>(".onesignal-customlink-subscribe");
     subscribeElements.forEach((subscribe: HTMLElement) => {
-      if (config.text.subscribe) {
-        subscribe.textContent = config.text.subscribe;
-      }
+      subscribe.textContent = config.text.subscribe;
       CustomLink.setResetClass(subscribe);
       CustomLink.setStateClass(subscribe, isPushEnabled);
       CustomLink.setStyleClass(subscribe, config.style);
@@ -93,16 +90,10 @@ export class CustomLink {
 
   private static setCustomColors(element: HTMLElement, config: AppUserConfigCustomLinkOptions) {
     if (config.style === "button") {
-      if (config.color.button) {
-        element.style.backgroundColor = config.color.button;
-      }
-      if (config.color.text) {
-        element.style.color = config.color.text;
-      }
+      element.style.backgroundColor = config.color.button;
+      element.style.color = config.color.text;
     } else if (config.style === "link") {
-      if (config.color.button) {
-        element.style.color = config.color.button;
-      }
+      element.style.color = config.color.text;
     }
   }
 

--- a/src/entries/stylesheet.scss
+++ b/src/entries/stylesheet.scss
@@ -1,4 +1,5 @@
 @import '../stylesheets/bell';
+@import '../stylesheets/customlink';
 @import '../stylesheets/helpers';
 @import '../stylesheets/popover';
 @import '../stylesheets/reset';

--- a/src/helpers/EventHelper.ts
+++ b/src/helpers/EventHelper.ts
@@ -42,7 +42,7 @@ export default class EventHelper {
   static async _onSubscriptionChanged(newSubscriptionState: boolean | undefined) {
     EventHelper.onSubscriptionChanged_showWelcomeNotification(newSubscriptionState);
     EventHelper.onSubscriptionChanged_evaluateNotifyButtonDisplayPredicate();
-    EventHelper.onSubscriptionChanged_updateCustomLink(newSubscriptionState);
+    EventHelper.onSubscriptionChanged_updateCustomLink();
   }
 
   private static async onSubscriptionChanged_showWelcomeNotification(isSubscribed: boolean | undefined) {
@@ -113,9 +113,9 @@ export default class EventHelper {
     }
   }
 
-  private static async onSubscriptionChanged_updateCustomLink(isSubscribed: boolean | undefined) {
+  private static async onSubscriptionChanged_updateCustomLink() {
     if (OneSignal.config.userConfig.promptOptions) {
-      await CustomLink.initialize(OneSignal.config.userConfig.promptOptions.customLink, isSubscribed);
+      await CustomLink.initialize(OneSignal.config.userConfig.promptOptions.customlink);
     }
   }
 

--- a/src/helpers/EventHelper.ts
+++ b/src/helpers/EventHelper.ts
@@ -114,7 +114,7 @@ export default class EventHelper {
   }
 
   private static async onSubscriptionChanged_updateCustomLink(isSubscribed: boolean | undefined) {
-    if (OneSignal.config.userConfig.promptOptions && OneSignal.config.userConfig.promptOptions.customLink) {
+    if (OneSignal.config.userConfig.promptOptions) {
       await CustomLink.initialize(OneSignal.config.userConfig.promptOptions.customLink, isSubscribed);
     }
   }

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -232,7 +232,7 @@ export default class InitHelper {
       await OneSignal.privateShowHttpPrompt();
     }
 
-    if (config.userConfig.promptOptions && config.userConfig.promptOptions.customLink) {
+    if (config.userConfig.promptOptions) {
       await CustomLink.initialize(config.userConfig.promptOptions.customLink);
     }
   }

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -14,21 +14,14 @@ import { WindowEnvironmentKind } from '../models/WindowEnvironmentKind';
 import SubscriptionModalHost from '../modules/frames/SubscriptionModalHost';
 import Database from '../services/Database';
 import { getConsoleStyle, once, isUsingSubscriptionWorkaround, triggerNotificationPermissionChanged } from '../utils';
-import EventHelper from './EventHelper';
 import MainHelper from './MainHelper';
 import SubscriptionHelper from './SubscriptionHelper';
 import { SdkInitError, SdkInitErrorKind } from '../errors/SdkInitError';
 import OneSignalApi from '../OneSignalApi';
-import CookieSyncer from '../modules/CookieSyncer';
-import { SubscriptionManager } from '../managers/SubscriptionManager';
-import { ServiceWorkerManager } from '../managers/ServiceWorkerManager';
-import Path from '../models/Path';
 import Context from '../models/Context';
 import { WorkerMessenger, WorkerMessengerCommand } from '../libraries/WorkerMessenger';
 import { DynamicResourceLoader } from '../services/DynamicResourceLoader';
-import { DeviceRecord } from '../models/DeviceRecord';
 import PushPermissionNotGrantedError from '../errors/PushPermissionNotGrantedError';
-import { PageViewMetricEngagement } from '../managers/MetricsManager';
 import { PushDeviceRecord } from '../models/PushDeviceRecord';
 import { EmailDeviceRecord } from '../models/EmailDeviceRecord';
 import { SubscriptionStrategyKind } from "../models/SubscriptionStrategyKind";
@@ -39,6 +32,7 @@ import Log from '../libraries/Log';
 import Environment from '../Environment';
 import Bell from '../bell/Bell';
 import ConfigManager from "../managers/ConfigManager";
+import { CustomLink } from '../CustomLink';
 
 declare var OneSignal: any;
 
@@ -198,7 +192,7 @@ export default class InitHelper {
         };
       }
 
-      const displayPredicate: () => boolean = OneSignal.config.userConfig.notifyButton.displayPredicate;
+     const displayPredicate: () => boolean = OneSignal.config.userConfig.notifyButton.displayPredicate;
       if (displayPredicate && typeof displayPredicate === 'function') {
         const predicateValue = await Promise.resolve(OneSignal.config.userConfig.notifyButton.displayPredicate());
         if (predicateValue !== false) {
@@ -236,6 +230,10 @@ export default class InitHelper {
       config.userConfig.promptOptions.slidedown.autoPrompt &&
       !(await OneSignal.internalIsOptedOut())) {
       await OneSignal.privateShowHttpPrompt();
+    }
+
+    if (config.userConfig.promptOptions && config.userConfig.promptOptions.customLink) {
+      await CustomLink.initialize(config.userConfig.promptOptions.customLink);
     }
   }
 

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -233,7 +233,7 @@ export default class InitHelper {
     }
 
     if (config.userConfig.promptOptions) {
-      await CustomLink.initialize(config.userConfig.promptOptions.customLink);
+      await CustomLink.initialize(config.userConfig.promptOptions.customlink);
     }
   }
 

--- a/src/managers/ConfigManager.ts
+++ b/src/managers/ConfigManager.ts
@@ -115,40 +115,44 @@ export default class ConfigManager {
   }
 
   private getCustomLinkConfig(serverConfig: ServerAppConfig): AppUserConfigCustomLinkOptions {
-    if (!serverConfig.config.staticPrompts.customlink) {
-      return {
-        enabled: false,
-        style: "button",
-        size: "medium",
-        unsubscribeEnabled: false,
-        text: {
-          explanation: "",
-          subscribe: "",
-          unsubscribe: "",
-        },
-        color: {
-          button: "",
-          text: "",
-        }
-      };
+    const initialState: AppUserConfigCustomLinkOptions = {
+      enabled: false,
+      style: "button",
+      size: "medium",
+      unsubscribeEnabled: false,
+      text: {
+        explanation: "",
+        subscribe: "",
+        unsubscribe: "",
+      },
+      color: {
+        button: "",
+        text: "",
+      }
+    }; 
+
+    if (!serverConfig || !serverConfig.config ||
+      !serverConfig.config.staticPrompts || !serverConfig.config.staticPrompts.customLink ||
+      !serverConfig.config.staticPrompts.customLink.enabled) {
+      return initialState;
     }
 
-    const customLink = serverConfig.config.staticPrompts.customlink;
+    const customLink = serverConfig.config.staticPrompts.customLink;
 
     return {
       enabled: customLink.enabled,
       style: customLink.style,
       size: customLink.size,
       unsubscribeEnabled: customLink.unsubscribeEnabled,
-      text: {
+      text: customLink.text ? {
         subscribe: customLink.text.subscribe,
         unsubscribe: customLink.text.unsubscribe,
         explanation: customLink.text.explanation,
-      },
-      color: {
+      } : initialState.text,
+      color: customLink.color ? {
         button: customLink.color.button,
         text: customLink.color.text,
-      }
+      } : initialState.color,
     }
   }
 

--- a/src/managers/SdkEnvironment.ts
+++ b/src/managers/SdkEnvironment.ts
@@ -246,4 +246,19 @@ export default class SdkEnvironment {
 
     return new URL(origin + path)
   }
+
+  static getOneSignalCssFileName(buildEnv: BuildEnvironmentKind = SdkEnvironment.getBuildEnv()): string {
+    const baseFileName = "OneSignalSDKStyles.css";
+
+    switch (buildEnv) {
+      case BuildEnvironmentKind.Development:
+        return `Dev-${baseFileName}`;
+      case BuildEnvironmentKind.Staging:
+        return `Staging-${baseFileName}`;
+      case BuildEnvironmentKind.Production:
+        return baseFileName;
+      default:
+        throw new InvalidArgumentError('buildEnv', InvalidArgumentReason.EnumOutOfRange);
+    }
+  }
 }

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -77,53 +77,8 @@ export enum NotificationClickActionBehavior {
   Focus = 'focus'
 }
 
-export interface WebConfig {
-  siteInfo: {
-    name: string;
-    origin: string;
-    proxyOrigin: string | null;
-    defaultIconUrl: string | null;
-    proxyOriginEnabled: boolean;
-  };
-  webhooks: {
-    enable: boolean;
-    corsEnable: false;
-    notificationClickedHook: string;
-    notificationDismissedHook: string;
-    notificationDisplayedHook: string;
-  };
-  integration: {
-    kind: ConfigIntegrationKind;
-  };
-  serviceWorker: {
-    path: string;
-    workerName: string;
-    updaterWorkerName: string;
-    registrationScope: string;
-    customizationEnabled: boolean;
-  };
-  setupBehavior: {
-    allowLocalhostAsSecureOrigin: boolean;
-  };
-  welcomeNotification: {
-    url: string;
-    title: string;
-    enable: boolean;
-    message: string;
-    urlEnabled: boolean;
-  };
-  notificationBehavior: {
-    click: {
-      match: NotificationClickMatchBehavior;
-      action: NotificationClickActionBehavior;
-    };
-    display: {
-      persist: boolean;
-    };
-  };
-}
-
 export interface AppUserConfig {
+  [key: string]: any;
   appId?: string;
   autoRegister?: boolean;
   path?: string;
@@ -153,19 +108,22 @@ export interface FullscreenPermissionMessageOptions {
   caption: string;
 }
 
+type CustomLinkStyle = "button" | "link";
+type CustomLinkSize = "large" | "medium" | "small";
+
 export interface AppUserConfigCustomLinkOptions {
   enabled: boolean;
-  style: "button" | "link";
-  size: "large" | "medium" | "small";
-  unsubscribeEnabled: boolean;
-  text: {
-    explanation: string;
-    subscribe: string;
-    unsubscribe: string;
+  style?: CustomLinkStyle;
+  size?: CustomLinkSize;
+  unsubscribeEnabled?: boolean;
+  text?: {
+    explanation?: string;
+    subscribe?: string;
+    unsubscribe?: string;
   }
-  color: {
-    button: string;
-    text: string;
+  color?: {
+    button?: string;
+    text?: string;
   }
 }
 
@@ -185,19 +143,19 @@ export interface AppUserConfigPromptOptions {
   showCredit?: string;
   slidedown?: SlidedownPermissionMessageOptions;
   fullscreen?: FullscreenPermissionMessageOptions;
-  customLink?: AppUserConfigCustomLinkOptions;
+  customlink?: AppUserConfigCustomLinkOptions;
 }
 
 export interface AppUserConfigWelcomeNotification {
   disable: boolean;
-  title: string;
-  message: string;
-  url: string;
+  title: string | undefined;
+  message: string | undefined;
+  url: string | undefined;
 }
 
 export interface AppUserConfigNotifyButton {
   enable: boolean;
-  displayPredicate: Function | null;
+  displayPredicate: Function | null | undefined;
   size: 'small' | 'medium' | 'large';
   position: 'bottom-left' | 'bottom-right';
   offset: { bottom: string; left: string; right: string };
@@ -232,10 +190,10 @@ export interface AppUserConfigNotifyButton {
 }
 
 export interface AppUserConfigWebhooks {
-  cors: boolean;
-  'notification.displayed': string;
-  'notification.clicked': string;
-  'notification.dismissed': string;
+  cors: boolean | undefined;
+  'notification.displayed': string | undefined;
+  'notification.clicked': string | undefined;
+  'notification.dismissed': string | undefined;
 }
 
 export interface ServerAppConfigPrompt {
@@ -293,10 +251,10 @@ export interface ServerAppConfigPrompt {
     autoAcceptTitle: string;
     customizeTextEnabled: boolean;
   };
-  customLink?: {
+  customlink: {
     enabled: boolean;
-    style: "button" | "link";
-    size: "large" | "medium" | "small";
+    style: CustomLinkStyle;
+    size: CustomLinkSize;
     unsubscribeEnabled: boolean;
     text: {
       explanation: string;
@@ -324,7 +282,7 @@ export interface ServerAppConfig {
     restrict_origin: {
       enable: boolean;
     };
-    email: {
+    email?: {
       require_auth: boolean;
     };
   };
@@ -337,38 +295,38 @@ export interface ServerAppConfig {
     siteInfo: {
       name: string;
       origin: string;
-      proxyOrigin: string;
-      defaultIconUrl: string;
+      proxyOrigin: string | undefined;
+      defaultIconUrl: string | null;
       proxyOriginEnabled: boolean;
     };
     webhooks: {
       enable: boolean;
-      corsEnable: boolean;
-      notificationClickedHook: string;
-      notificationDismissedHook: string;
-      notificationDisplayedHook: string;
+      corsEnable?: boolean;
+      notificationClickedHook?: string;
+      notificationDismissedHook?: string;
+      notificationDisplayedHook?: string;
     };
     integration: {
       kind: ConfigIntegrationKind;
     };
     serviceWorker: {
-      path: string;
-      workerName: string;
-      registrationScope: string;
-      updaterWorkerName: string;
+      path?: string;
+      workerName?: string;
+      registrationScope?: string;
+      updaterWorkerName?: string;
       customizationEnabled: boolean;
     };
-    setupBehavior: {
+    setupBehavior?: {
       allowLocalhostAsSecureOrigin: false;
     };
     welcomeNotification: {
-      url: string;
-      title: string;
+      url: string | undefined;
+      title: string | undefined;
       enable: boolean;
-      message: string;
-      urlEnabled: boolean;
+      message: string | undefined;
+      urlEnabled: boolean| undefined;
     };
-    notificationBehavior: {
+    notificationBehavior?: {
       click: {
         match: NotificationClickMatchBehavior;
         action: NotificationClickActionBehavior;
@@ -379,9 +337,9 @@ export interface ServerAppConfig {
     };
     vapid_public_key: string;
     onesignal_vapid_public_key: string;
-    http_use_onesignal_com: boolean;
-    safari_web_id: string;
-    subdomain: string;
+    http_use_onesignal_com?: boolean;
+    safari_web_id?: string;
+    subdomain: string| undefined;
   };
 
   generated_at: number;

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -11,7 +11,7 @@ export interface AppConfig {
   /**
    * The subdomain chosen on the dashboard for non-HTTPS apps.
    */
-  subdomain: string;
+  subdomain?: string;
 
   /**
    * The allowed origin this web push config is allowed to run on.
@@ -153,6 +153,22 @@ export interface FullscreenPermissionMessageOptions {
   caption: string;
 }
 
+export interface AppUserConfigCustomLinkOptions {
+  enabled: boolean;
+  style: "button" | "link";
+  size: "large" | "medium" | "small";
+  unsubscribeEnabled: boolean;
+  text: {
+    explanation: string;
+    subscribe: string;
+    unsubscribe: string;
+  }
+  color: {
+    button: string;
+    text: string;
+  }
+}
+
 export interface AppUserConfigPromptOptions {
   subscribeText?: string;
   showGraphic?: boolean;
@@ -169,6 +185,7 @@ export interface AppUserConfigPromptOptions {
   showCredit?: string;
   slidedown?: SlidedownPermissionMessageOptions;
   fullscreen?: FullscreenPermissionMessageOptions;
+  customLink?: AppUserConfigCustomLinkOptions;
 }
 
 export interface AppUserConfigWelcomeNotification {
@@ -180,7 +197,7 @@ export interface AppUserConfigWelcomeNotification {
 
 export interface AppUserConfigNotifyButton {
   enable: boolean;
-  displayPredicate: Function;
+  displayPredicate: Function | null;
   size: 'small' | 'medium' | 'large';
   position: 'bottom-left' | 'bottom-right';
   offset: { bottom: string; left: string; right: string };
@@ -276,6 +293,21 @@ export interface ServerAppConfigPrompt {
     autoAcceptTitle: string;
     customizeTextEnabled: boolean;
   };
+  customlink?: {
+    enabled: boolean;
+    style: "button" | "link";
+    size: "large" | "medium" | "small";
+    unsubscribeEnabled: boolean;
+    text: {
+      explanation: string;
+      subscribe: string;
+      unsubscribe: string;
+    }
+    color: {
+      button: string;
+      text: string;
+    }
+  }
 }
 
 export interface ServerAppConfig {

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -293,7 +293,7 @@ export interface ServerAppConfigPrompt {
     autoAcceptTitle: string;
     customizeTextEnabled: boolean;
   };
-  customlink?: {
+  customLink?: {
     enabled: boolean;
     style: "button" | "link";
     size: "large" | "medium" | "small";

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -27,7 +27,7 @@ export default class Database {
 
   /* Temp Database Proxy */
   public static databaseInstanceName: string;
-  public static databaseInstance: Database;
+  public static databaseInstance: Database | null;
   /* End Temp Database Proxy */
 
   public static EVENTS = DatabaseEventName;

--- a/src/services/DynamicResourceLoader.ts
+++ b/src/services/DynamicResourceLoader.ts
@@ -37,9 +37,10 @@ export class DynamicResourceLoader {
 
   async loadSdkStylesheet(): Promise<ResourceLoadState> {
     const pathForEnv = SdkEnvironment.getOneSignalResourceUrlPath();
+    const cssFileForEnv = SdkEnvironment.getOneSignalCssFileName();
     return await this.loadIfNew(
       ResourceType.Stylesheet,
-      new URL(`${pathForEnv}/OneSignalSDKStyles.css?v=${Environment.getSdkStylesVersionHash()}`)
+      new URL(`${pathForEnv}/${cssFileForEnv}?v=${Environment.getSdkStylesVersionHash()}`)
     );
   }
 

--- a/src/stylesheets/customlink.scss
+++ b/src/stylesheets/customlink.scss
@@ -20,7 +20,7 @@ $customlink-base-padding-vertical: 8px;
     transition: all 0.1s;
     font-family: "Open Sans", Arial, Helvetica, sans-serif;
   }
-  &.state-subscribed {
+  &.state-subscribed.hide {
     display: none;
   }
   &.button {
@@ -34,65 +34,17 @@ $customlink-base-padding-vertical: 8px;
       text-decoration: none;
       box-shadow: 2px 3px 4px grey;
     }
-  }
-  &.link {
-    cursor: pointer;
-  }
-
-  @each $size-name, $size-amount in $customlink-sizes {
-    $button-font-size: $customlink-base-font-size;
-    $button-padding-horizontal: $customlink-base-padding-horizontal;
-    $button-padding-vertical: $customlink-base-padding-vertical;
-    @if $size-name == 'small' {
-      $button-font-size: $customlink-base-font-size - 2;
-      $button-padding-horizontal: $customlink-base-padding-horizontal - 4;
-      $button-padding-vertical: $customlink-base-padding-vertical - 4;
-    } @else if $size-name == 'medium' {
-      $button-font-size: $customlink-base-font-size;
-      $button-padding-horizontal: $customlink-base-padding-horizontal;
-      $button-padding-vertical: $customlink-base-padding-vertical;
-    } @else if $size-name == 'large' {
-      $button-font-size: $customlink-base-font-size + 3;
-      $button-padding-horizontal: $customlink-base-padding-horizontal + 4;
-      $button-padding-vertical: $customlink-base-padding-vertical + 4;
-    }
-
-    &.button.#{$size-name} {
-      font-size: #{$button-font-size};
-      padding: #{$button-padding-vertical} #{$button-padding-horizontal};
-    }
-    &.link.#{$size-name} {
-      font-size: #{$button-font-size};
-    }
-  }
-}
-
-.onesignal-customlink-unsubscribe {
-  display: inline-block;
-  transition: all 0.1s;
-  font-family: "Proxima-Nova", "Proxima Nova", "Open Sans", Arial, Helvetica, sans-serif;
-
-  &.onesignal-reset {
-    display: inline-block;
-    transition: all 0.1s;
-    font-family: "Proxima-Nova", "Proxima Nova", "Open Sans", Arial, Helvetica, sans-serif;
-  }
-  &.state-unsubscribed {
-    display: none;
-  }
-  &.button {
-    border-radius: 4px;
-    box-shadow: 1px 1px 1px grey;
-    text-decoration: none;
-    cursor: pointer;
-
-    &:hover, &:focus, &:active {
-      text-decoration: none;
-      box-shadow: 2px 3px 4px grey;
+    &.state-subscribed {
+      text-transform: none;
     }
   }
   &.link {
     cursor: pointer;
+    text-transform: uppercase;
+    font-weight: 600;
+    &.state-subscribed {
+      text-transform: none;
+    }
   }
 
   @each $size-name, $size-amount in $customlink-sizes {
@@ -134,6 +86,10 @@ $customlink-base-padding-vertical: 8px;
     transition: all 0.1s;
     font-family: "Proxima-Nova", "Proxima Nova", "Open Sans", Arial, Helvetica, sans-serif;
     margin-bottom: 12px;
+  }
+
+  &.state-subscribed.hide {
+    display: none;
   }
 
   @each $size-name, $size-amount in $customlink-sizes {

--- a/src/stylesheets/customlink.scss
+++ b/src/stylesheets/customlink.scss
@@ -13,17 +13,20 @@ $customlink-base-padding-vertical: 8px;
 .onesignal-customlink-subscribe {
   display: inline-block;
   transition: all 0.1s;
-  font-family: "Proxima-Nova", "Proxima Nova", "Open Sans", Arial, Helvetica, sans-serif;
+  font-family: "Open Sans", Arial, Helvetica, sans-serif;
 
   &.onesignal-reset {
     display: inline-block;
     transition: all 0.1s;
-    font-family: "Proxima-Nova", "Proxima Nova", "Open Sans", Arial, Helvetica, sans-serif;
+    font-family: "Open Sans", Arial, Helvetica, sans-serif;
   }
   &.state-subscribed {
     display: none;
   }
   &.button {
+    text-transform: uppercase;
+    touch-action: manipulation;
+    font-weight: 600;
     border-radius: 4px;
     box-shadow: 1px 1px 1px grey;
     cursor: pointer;
@@ -73,12 +76,6 @@ $customlink-base-padding-vertical: 8px;
     display: inline-block;
     transition: all 0.1s;
     font-family: "Proxima-Nova", "Proxima Nova", "Open Sans", Arial, Helvetica, sans-serif;
-  }
-  &.state-subscribed {
-    opacity: 0.2;
-      &:hover, &:focus, &:active {
-        opacity: 1;
-      }
   }
   &.state-unsubscribed {
     display: none;

--- a/src/stylesheets/customlink.scss
+++ b/src/stylesheets/customlink.scss
@@ -1,0 +1,157 @@
+@import 'reset';
+
+$customlink-sizes: (
+  'small': 32px,
+  'medium': 48px,
+  'large': 64px,
+);
+
+$customlink-base-font-size: 15px;
+$customlink-base-padding-horizontal: 16px;
+$customlink-base-padding-vertical: 8px;
+
+.onesignal-customlink-subscribe {
+  display: inline-block;
+  transition: all 0.1s;
+  font-family: "Proxima-Nova", "Proxima Nova", "Open Sans", Arial, Helvetica, sans-serif;
+
+  &.onesignal-reset {
+    display: inline-block;
+    transition: all 0.1s;
+    font-family: "Proxima-Nova", "Proxima Nova", "Open Sans", Arial, Helvetica, sans-serif;
+  }
+  &.state-subscribed {
+    display: none;
+  }
+  &.button {
+    border-radius: 4px;
+    box-shadow: 1px 1px 1px grey;
+    cursor: pointer;
+    &:hover, &:focus, &:active {
+      text-decoration: none;
+      box-shadow: 2px 3px 4px grey;
+    }
+  }
+  &.link {
+    cursor: pointer;
+  }
+
+  @each $size-name, $size-amount in $customlink-sizes {
+    $button-font-size: $customlink-base-font-size;
+    $button-padding-horizontal: $customlink-base-padding-horizontal;
+    $button-padding-vertical: $customlink-base-padding-vertical;
+    @if $size-name == 'small' {
+      $button-font-size: $customlink-base-font-size - 2;
+      $button-padding-horizontal: $customlink-base-padding-horizontal - 4;
+      $button-padding-vertical: $customlink-base-padding-vertical - 4;
+    } @else if $size-name == 'medium' {
+      $button-font-size: $customlink-base-font-size;
+      $button-padding-horizontal: $customlink-base-padding-horizontal;
+      $button-padding-vertical: $customlink-base-padding-vertical;
+    } @else if $size-name == 'large' {
+      $button-font-size: $customlink-base-font-size + 3;
+      $button-padding-horizontal: $customlink-base-padding-horizontal + 4;
+      $button-padding-vertical: $customlink-base-padding-vertical + 4;
+    }
+
+    &.button.#{$size-name} {
+      font-size: #{$button-font-size};
+      padding: #{$button-padding-vertical} #{$button-padding-horizontal};
+    }
+    &.link.#{$size-name} {
+      font-size: #{$button-font-size};
+    }
+  }
+}
+
+.onesignal-customlink-unsubscribe {
+  display: inline-block;
+  transition: all 0.1s;
+  font-family: "Proxima-Nova", "Proxima Nova", "Open Sans", Arial, Helvetica, sans-serif;
+
+  &.onesignal-reset {
+    display: inline-block;
+    transition: all 0.1s;
+    font-family: "Proxima-Nova", "Proxima Nova", "Open Sans", Arial, Helvetica, sans-serif;
+  }
+  &.state-subscribed {
+    opacity: 0.2;
+      &:hover, &:focus, &:active {
+        opacity: 1;
+      }
+  }
+  &.state-unsubscribed {
+    display: none;
+  }
+  &.button {
+    border-radius: 4px;
+    box-shadow: 1px 1px 1px grey;
+    text-decoration: none;
+    cursor: pointer;
+
+    &:hover, &:focus, &:active {
+      text-decoration: none;
+      box-shadow: 2px 3px 4px grey;
+    }
+  }
+  &.link {
+    cursor: pointer;
+  }
+
+  @each $size-name, $size-amount in $customlink-sizes {
+    $button-font-size: $customlink-base-font-size;
+    $button-padding-horizontal: $customlink-base-padding-horizontal;
+    $button-padding-vertical: $customlink-base-padding-vertical;
+    @if $size-name == 'small' {
+      $button-font-size: $customlink-base-font-size - 2;
+      $button-padding-horizontal: $customlink-base-padding-horizontal - 4;
+      $button-padding-vertical: $customlink-base-padding-vertical - 4;
+    } @else if $size-name == 'medium' {
+      $button-font-size: $customlink-base-font-size;
+      $button-padding-horizontal: $customlink-base-padding-horizontal;
+      $button-padding-vertical: $customlink-base-padding-vertical;
+    } @else if $size-name == 'large' {
+      $button-font-size: $customlink-base-font-size + 3;
+      $button-padding-horizontal: $customlink-base-padding-horizontal + 4;
+      $button-padding-vertical: $customlink-base-padding-vertical + 4;
+    }
+
+    &.button.#{$size-name} {
+      font-size: #{$button-font-size};
+      padding: #{$button-padding-vertical} #{$button-padding-horizontal};
+    }
+    &.link.#{$size-name} {
+      font-size: #{$button-font-size};
+    }
+  }
+}
+
+.onesignal-customlink-explanation {
+  color: rgba(0,0,0,0.64);
+  transition: all 0.1s;
+  font-family: "Proxima-Nova", "Proxima Nova", "Open Sans", Arial, Helvetica, sans-serif;
+  margin-bottom: 12px;
+
+  &.onesignal-reset {
+    color: rgba(0,0,0,0.64);
+    transition: all 0.1s;
+    font-family: "Proxima-Nova", "Proxima Nova", "Open Sans", Arial, Helvetica, sans-serif;
+    margin-bottom: 12px;
+  }
+
+  @each $size-name, $size-amount in $customlink-sizes {
+    $explanation-font-size: $customlink-base-font-size;
+
+    @if $size-name == 'small' {
+      $explanation-font-size: $customlink-base-font-size - 2;
+    } @else if $size-name == 'medium' {
+      $explanation-font-size: $customlink-base-font-size;
+    } @else if $size-name == 'large' {
+      $explanation-font-size: $customlink-base-font-size;
+    }
+
+    &.#{$size-name} {
+      font-size: #{$explanation-font-size};
+    }
+  }
+}

--- a/src/stylesheets/customlink.scss
+++ b/src/stylesheets/customlink.scss
@@ -36,6 +36,7 @@ $customlink-base-padding-vertical: 8px;
     }
     &.state-subscribed {
       text-transform: none;
+      font-weight: 400;
     }
   }
   &.link {
@@ -44,6 +45,10 @@ $customlink-base-padding-vertical: 8px;
     font-weight: 600;
     &.state-subscribed {
       text-transform: none;
+      font-weight: 400;
+    }
+    &:hover, &:focus, &:active {
+      text-decoration: underline;
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -255,9 +255,12 @@ export function addDomElement(targetSelectorOrElement, addOrder, elementHtml) {
     throw new Error(`${targetSelectorOrElement} must be a CSS selector string or DOM Element object.`);
 }
 
-export function clearDomElementChildren(targetSelectorOrElement) {
+export function clearDomElementChildren(targetSelectorOrElement: Element | string) {
   if (typeof targetSelectorOrElement === 'string') {
-    var element = document.querySelector(targetSelectorOrElement);
+    const element = document.querySelector(targetSelectorOrElement);
+    if (element === null) {
+      throw new Error(`Cannot find element with selector "${targetSelectorOrElement}"`);
+    }
     while (element.firstChild) {
       element.removeChild(element.firstChild);
     }
@@ -271,42 +274,65 @@ export function clearDomElementChildren(targetSelectorOrElement) {
     throw new Error(`${targetSelectorOrElement} must be a CSS selector string or DOM Element object.`);
 }
 
-export function addCssClass(targetSelectorOrElement, cssClass) {
-  if (typeof targetSelectorOrElement === 'string')
-    document.querySelector(targetSelectorOrElement).classList.add(cssClass);
-  else if (typeof targetSelectorOrElement === 'object')
+export function addCssClass(targetSelectorOrElement: Element | string, cssClass: string) {
+  if (typeof targetSelectorOrElement === 'string') {
+    const element = document.querySelector(targetSelectorOrElement);
+    if (element === null) {
+      throw new Error(`Cannot find element with selector "${targetSelectorOrElement}"`);
+    }
+    element.classList.add(cssClass);
+  }
+  else if (typeof targetSelectorOrElement === 'object') {
     targetSelectorOrElement.classList.add(cssClass);
-  else
+  }
+  else {
     throw new Error(`${targetSelectorOrElement} must be a CSS selector string or DOM Element object.`);
+  }
 }
 
-export function removeCssClass(targetSelectorOrElement, cssClass) {
-  if (typeof targetSelectorOrElement === 'string')
-    document.querySelector(targetSelectorOrElement).classList.remove(cssClass);
-  else if (typeof targetSelectorOrElement === 'object')
+export function removeCssClass(targetSelectorOrElement: Element | string, cssClass: string) {
+  if (typeof targetSelectorOrElement === 'string') {
+    const element = document.querySelector(targetSelectorOrElement);
+    if (element === null) {
+      throw new Error(`Cannot find element with selector "${targetSelectorOrElement}"`);
+    }
+    element.classList.remove(cssClass);
+  }
+  else if (typeof targetSelectorOrElement === 'object') {
     targetSelectorOrElement.classList.remove(cssClass);
-  else
+  }
+  else {
     throw new Error(`${targetSelectorOrElement} must be a CSS selector string or DOM Element object.`);
+  }
 }
 
-export function hasCssClass(targetSelectorOrElement, cssClass) {
-  if (typeof targetSelectorOrElement === 'string')
-    return document.querySelector(targetSelectorOrElement).classList.contains(cssClass);
-  else if (typeof targetSelectorOrElement === 'object')
+export function hasCssClass(targetSelectorOrElement: Element | string, cssClass: string) {
+  if (typeof targetSelectorOrElement === 'string') {
+    const element = document.querySelector(targetSelectorOrElement);
+    if (element === null) {
+      throw new Error(`Cannot find element with selector "${targetSelectorOrElement}"`);
+    }
+    return element.classList.contains(cssClass);
+  }
+  else if (typeof targetSelectorOrElement === 'object') {
     return targetSelectorOrElement.classList.contains(cssClass);
-  else
+  }
+  else {
     throw new Error(`${targetSelectorOrElement} must be a CSS selector string or DOM Element object.`);
+  }
 }
 
-var DEVICE_TYPES = {
-  CHROME: 5,
-  SAFARI: 7,
-  FIREFOX: 8,
-  EDGE: 12,
-  UNKNOWN: -99
-};
+/**
+ * var DEVICE_TYPES = {
+ *  CHROME: 5,
+ *  SAFARI: 7,
+ *  FIREFOX: 8,
+ *  EDGE: 12,
+ *  UNKNOWN: -99
+ * };
+ */
 
-export function getConsoleStyle(style) {
+export function getConsoleStyle(style: string) {
   if (style == 'code') {
     return `padding: 0 1px 1px 5px;border: 1px solid #ddd;border-radius: 3px;font-family: Monaco,"DejaVu Sans Mono","Courier New",monospace;color: #444;`;
   } else if (style == 'bold') {
@@ -329,7 +355,7 @@ export function getConsoleStyle(style) {
  * @param durationMs
  * @returns {Promise} Returns a promise that resolves when the timeout is complete.
  */
-export function delay(durationMs) {
+export function delay(durationMs: number) {
   return new Promise((resolve) => {
     setTimeout(resolve, durationMs)
   });
@@ -406,11 +432,11 @@ export function getRandomUuid(): string {
  * @param uuid
  * @returns {*|boolean}
  */
-export function isValidUuid(uuid) {
+export function isValidUuid(uuid: string) {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(uuid);
 }
 
-export function getUrlQueryParam(name) {
+export function getUrlQueryParam(name: string) {
   let url = window.location.href;
   url = url.toLowerCase(); // This is just to avoid case sensitiveness
   name = name.replace(/[\[\]]/g, "\\$&").toLowerCase();// This is just to avoid case sensitiveness for query parameter name
@@ -437,7 +463,7 @@ export function wipeIndexedDb() {
  * Capitalizes the first letter of the string.
  * @returns {string} The string with the first letter capitalized.
  */
-export function capitalize(text): string {
+export function capitalize(text: string): string {
   return text.charAt(0).toUpperCase() + text.slice(1);
 }
 
@@ -511,7 +537,7 @@ export function wipeServiceWorkerAndUnsubscribe() {
   ]);
 }
 
-export function wait(milliseconds) {
+export function wait(milliseconds: number) {
   return new Promise(resolve => setTimeout(resolve, milliseconds));
 }
 
@@ -521,7 +547,7 @@ export function wait(milliseconds) {
  * @param search The text returned will be everything *after* search.
  * e.g. substringAfter('A white fox', 'white') => ' fox'
  */
-export function substringAfter(string, search) {
+export function substringAfter(string: string, search: string) {
   return string.substr(string.indexOf(search) + search.length);
 }
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,3 +1,5 @@
+import { isUsingSubscriptionWorkaround } from "../utils";
+
 export class Utils {
   public static getBaseUrl() {
     return location.origin;
@@ -8,6 +10,13 @@ export class Utils {
       return value;
     }
     return defaultValue;
+  }
+
+  /**
+   * Wrapper function to allow stubing in tests
+   */
+  public static isUsingSubscriptionWorkaround(): boolean {
+    return isUsingSubscriptionWorkaround();
   }
 }
 

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,7 +1,14 @@
 export class Utils {
-    public static getBaseUrl() {
-        return location.origin;
+  public static getBaseUrl() {
+    return location.origin;
+  }
+
+  public static getValueOrDefault<T>(value: T | undefined | null, defaultValue: T): T {
+    if (value !== undefined && value !== null) {
+      return value;
     }
+    return defaultValue;
+  }
 }
 
 export default Utils;

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -12,13 +12,15 @@ import MockServiceWorker from '../mocks/service-workers/ServiceWorker';
 
 import SdkEnvironment from '../../../src/managers/SdkEnvironment';
 import { TestEnvironmentKind } from '../../../src/models/TestEnvironmentKind';
-import { AppConfig, ServerAppConfig, NotificationClickMatchBehavior, NotificationClickActionBehavior, AppUserConfig, ConfigIntegrationKind } from '../../../src/models/AppConfig';
-
+import { AppConfig, ServerAppConfig, NotificationClickMatchBehavior,
+  NotificationClickActionBehavior, AppUserConfig, ConfigIntegrationKind }
+  from '../../../src/models/AppConfig';
 import ServiceWorkerRegistration from '../mocks/service-workers/models/ServiceWorkerRegistration';
 import PushManager from "../mocks/service-workers/models/PushManager";
 import PushSubscription from "../mocks/service-workers/models/PushSubscription";
 import Context from "../../../src/models/Context";
-import {SessionManager} from "../../../src/managers/SessionManager";
+import { SessionManager } from "../../../src/managers/SessionManager";
+import CustomLink from "../../../src/CustomLink";
 
 var global = new Function('return this')();
 
@@ -84,6 +86,7 @@ export interface TestEnvironmentConfig {
   userAgent?: BrowserUserAgent;
   url?: URL;
   initializeAsIframe?: boolean;
+  addPrompts?: boolean;
 }
 
 /**
@@ -162,17 +165,28 @@ export class TestEnvironment {
   static async stubDomEnvironment(config?: TestEnvironmentConfig) {
     if (!config)
       config = {};
+    let url: string | undefined = undefined;
     if (config.httpOrHttps == HttpHttpsEnvironment.Http) {
-      var url = 'http://localhost:3000/webpush/sandbox?http=1';
+      url = 'http://localhost:3000/webpush/sandbox?http=1';
     } else {
-      var url = 'https://localhost:3001/webpush/sandbox?https=1';
+      url = 'https://localhost:3001/webpush/sandbox?https=1';
     }
     if (config.url) {
-      var url = config.url.toString();
+      url = config.url.toString();
     }
+
+    let html = '<!doctype html><html><head></head><body></body></html>';
+    if (config.addPrompts) {
+      html = `<!doctype html><html><head>\
+      <div class="${CustomLink.containerClass}"></div>\
+      <div class="${CustomLink.containerClass}"></div>\
+      <button class="${CustomLink.subscribeClass}"></button>\
+      </head><body></body></html>`;
+    }
+
     var windowDef = await new Promise<Window>((resolve, reject) => {
       (jsdom as any).env({
-        html: '<!doctype html><html><head></head><body></body></html>',
+        html: html,
         url: url,
         userAgent: config && config.userAgent ? config.userAgent : BrowserUserAgent.Default,
         features: {

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -3,8 +3,8 @@ import Random from "../tester/Random";
 import Database from "../../../src/services/Database";
 import { NotificationPermission } from "../../../src/models/NotificationPermission";
 import jsdom from 'jsdom';
-import DOMStorage from 'dom-storage';
-import fetch from 'node-fetch';
+import DOMStorage from "dom-storage";
+import fetch from "node-fetch";
 import ServiceWorkerGlobalScope from '../mocks/service-workers/ServiceWorkerGlobalScope';
 import { ServiceWorker } from '../../../src/service-worker/ServiceWorker';
 import { ServiceWorkerContainer } from '../mocks/service-workers/ServiceWorkerContainer';
@@ -94,7 +94,7 @@ export class TestEnvironment {
   /**
    * Intercepts requests to our virtual DOM to return fake responses.
    */
-  static onVirtualDomResourceRequested(resource, callback) {
+  static onVirtualDomResourceRequested(resource, callback: Function) {
     const pathname = resource.url.pathname;
     if (pathname.startsWith('https://test.node/scripts/')) {
       if (pathname.startsWith('https://test.node/scripts/delayed')) {
@@ -125,7 +125,7 @@ export class TestEnvironment {
     }
   }
 
-  static onVirtualDomDelayedResourceRequested(resource, callback) {
+  static onVirtualDomDelayedResourceRequested(resource, callback: Function) {
     const pathname = resource.url.pathname;
     var delay = pathname.match(/\d+/) || 1000;
     // Simulate a delayed request
@@ -174,7 +174,7 @@ export class TestEnvironment {
       (jsdom as any).env({
         html: '<!doctype html><html><head></head><body></body></html>',
         url: url,
-        userAgent: config.userAgent ? config.userAgent : BrowserUserAgent.Default,
+        userAgent: config && config.userAgent ? config.userAgent : BrowserUserAgent.Default,
         features: {
           FetchExternalResources: ["script", "frame", "iframe", "link", "img"],
           ProcessExternalResources: ['script']
@@ -296,10 +296,159 @@ export class TestEnvironment {
     };
   }
 
-  static getFakeServerAppConfig(configIntegrationKind: ConfigIntegrationKind, appId?: string): ServerAppConfig {
+  static getFakeServerAppConfig(configIntegrationKind: ConfigIntegrationKind, isHttps: boolean = true): ServerAppConfig {
+    if (configIntegrationKind === ConfigIntegrationKind.Custom) {
+      const customConfigHttps: ServerAppConfig = {
+        success: true,
+        app_id: "3d9dbff9-3956-49b3-9521-b0d755b350e5",
+        features: {
+          restrict_origin: {
+            enable: true
+          },
+          cookie_sync: {
+            enable: false
+          },
+          metrics: {
+            enable: true,
+            mixpanel_reporting_token: "7c2582e45a6ecf1501aa3ca7887f3673"
+          }
+        },
+        config: {
+          siteInfo: {
+            name: "localhost https",
+            origin: "https://localhost:3001",
+            proxyOrigin: undefined,
+            defaultIconUrl: null,
+            proxyOriginEnabled: true
+          },
+          integration: {
+            kind: ConfigIntegrationKind.Custom
+          },
+          staticPrompts: {
+            bell: {
+              enabled: false,
+              size: "large",
+              color: {
+                main: "red",
+                accent: "white"
+              },
+              dialog: {
+                main: {
+                  title: "Manage Notifications",
+                  subscribeButton: "Subscribe",
+                  unsubscribeButton: "Unsubscribe"
+                },
+                blocked: {
+                  title: "Unblock Notifications",
+                  message: "Click here to learn how to unblock notifications."
+                }
+              },
+                offset: {
+                  left: 0,
+                    right: 0,
+                    bottom: 0
+                },
+                message: {
+                    subscribing: "Thanks for subscribing!",
+                    unsubscribing: "You won't receive notifications again"
+                },
+                tooltip: {
+                    blocked: "You've blocked notifications",
+                    subscribed: "You're subscribed to notifications",
+                    unsubscribed: "Subscribe to notifications"
+                },
+                location: "bottom-right",
+                hideWhenSubscribed: false,
+                customizeTextEnabled: true
+            },
+            slidedown: {
+                enabled: false,
+                acceptButton: "Allow",
+                cancelButton: "No Thanks",
+                actionMessage: "We'd like to send you notifications for the latest news and updates.",
+                customizeTextEnabled: true
+            },
+            fullscreen: {
+                enabled: false,
+                title: "example.com",
+                caption: "You can unsubscribe anytime",
+                message: "This is an example notification message.",
+                acceptButton: "Continue",
+                cancelButton: "No Thanks",
+                actionMessage: "We'd like to send you notifications for the latest news and updates.",
+                autoAcceptTitle: "Click Allow",
+                customizeTextEnabled: true
+            },
+            customlink: {
+              enabled: false,
+              style: "button",
+              size: "medium",
+              color: {
+                button: "#e54b4d",
+                text: "#ffffff"
+              },
+              text: {
+                subscribe: "Subscribe to push notifications",
+                unsubscribe: "Unsubscribe from push notifications",
+                explanation: ""
+              },
+              unsubscribeEnabled: true
+            },
+          },
+          webhooks: {
+            enable: false
+          },
+          serviceWorker: {
+            customizationEnabled: false,
+            path: "/",
+            workerName: "OneSignalSDKWorker.js",
+            registrationScope: "/",
+            updaterWorkerName: "OneSignalSDKUpdaterWorker.js"
+          },
+          welcomeNotification: {
+            enable: true,
+            url: "https://localhost:3001/?_osp=do_not_open",
+            title: "localhost https",
+            message: "Thanks for subscribing!",
+            urlEnabled: false
+          },
+          vapid_public_key: "BDPplk0FjgsEPIG7Gi2-zbjpBGgM_RJ4c99tWbNvxv7VSKIUV1KA7UUaRsTuBpcTEuaPMjvz_kd8rZuQcgMepng",
+          onesignal_vapid_public_key: "BMzCIzYqtgz2Bx7S6aPVK6lDWets7kGm-pgo2H4RixFikUaNIoPqjPBBOEWMAfeFjuT9mAvbe-lckGi6vvNEiW0",
+          origin: "https://localhost:3001",
+          subdomain: undefined,
+        },
+        "generated_at": 1531177265
+      };
+      if (isHttps) {
+        return customConfigHttps;
+      }
+      return {
+        ...customConfigHttps,
+        config: {
+          ...customConfigHttps.config,
+          subdomain: "helloworld123",
+          origin: "http://localhost:3000",
+          siteInfo: {
+            name: "localhost http",
+            origin: "http://localhost:3000",
+            proxyOrigin: "helloworld123",
+            defaultIconUrl: null,
+            proxyOriginEnabled: true
+          },
+          welcomeNotification: {
+            enable: true,
+            url: "http://localhost:3000/?_osp=do_not_open",
+            title: "localhost http",
+            message: "Thanks for subscribing!",
+            urlEnabled: false
+          },
+        }
+      }
+    }
+
     return {
       success: true,
-      app_id: appId ? appId : '34fcbe85-278d-4fd2-a4ec-0f80e95072c5',
+      app_id: '34fcbe85-278d-4fd2-a4ec-0f80e95072c5',
       features: {
         restrict_origin: {
           enable: false,
@@ -374,6 +523,21 @@ export class TestEnvironment {
             autoAcceptTitle: "Click Allow",
             customizeTextEnabled: true,
           },
+          customlink: {
+            enabled: true,
+            style: "button",
+            size: "medium",
+            color: {
+              button: "#e54b4d",
+              text: "#ffffff",
+            },
+            text: {
+              subscribe: "Subscribe to push notifications",
+              unsubscribe: "Unsubscribe from push notifications",
+              explanation: "Get updates from all sorts of things that matter to you",
+            },
+            unsubscribeEnabled: true,
+          }
         },
         siteInfo: {
           name: 'My Website',
@@ -387,7 +551,7 @@ export class TestEnvironment {
           corsEnable: false,
           notificationClickedHook: undefined,
           notificationDismissedHook: undefined,
-          notificationDisplayedHook: undefined
+          notificationDisplayedHook: undefined,
         },
         integration: {
           kind: configIntegrationKind
@@ -450,7 +614,22 @@ export class TestEnvironment {
           title: 'fullscreen notification title',
           message: 'fullscreen notification message',
           caption: 'fullscreen notification caption'
-        }
+        }, 
+        customlink: {
+          enabled: false,
+          style: "link",
+          size: "small",
+          color: {
+            button: "#000000",
+            text: "#ffffff",
+          },
+          text: {
+            subscribe: "Let's do it",
+            unsubscribe: "I don't want it anymore",
+            explanation: "Wanna stay in touch?",
+          },
+          unsubscribeEnabled: true,
+        },
       },
       welcomeNotification: {
         disable: false,

--- a/test/unit/prompts/CustomLink.ts
+++ b/test/unit/prompts/CustomLink.ts
@@ -3,15 +3,33 @@ import sinon, { SinonSandbox } from 'sinon';
 import { TestEnvironment, HttpHttpsEnvironment } from '../../support/sdk/TestEnvironment';
 import { AppUserConfigCustomLinkOptions } from '../../../src/models/AppConfig';
 import CustomLink from '../../../src/CustomLink';
+import Utils from '../../../src/utils/Utils';
 import { ResourceLoadState } from '../../../src/services/DynamicResourceLoader';
+import { hasCssClass } from '../../../src/utils';
 
 let sandbox: SinonSandbox;
+let config: AppUserConfigCustomLinkOptions;
 
 const stateSubscribedClass = "state-subscribed";
 const stateUnsubscribedClass = "state-unsubscribed";
 
 test.beforeEach(async () => {
   sandbox = sinon.sandbox.create();
+  config = {
+    enabled: true,
+    style: "button",
+    size: "small",
+    color: {
+      button: "#000000",
+      text: "#ffffff",
+    },
+    text: {
+      subscribe: "Let's do it",
+      unsubscribe: "I don't want it anymore",
+      explanation: "Wanna stay in touch?",
+    },
+    unsubscribeEnabled: true,
+  };
 
   await TestEnvironment.initialize({
     addPrompts: true,
@@ -26,235 +44,279 @@ test.afterEach(function () {
   sandbox.restore();
 });
 
-test('customlink: not render if disabled', async t => {
-  const config: AppUserConfigCustomLinkOptions = {
+test('customlink: container: not render if disabled', async t => {
+  config = {
     enabled: false,
-    style: "link",
-    size: "small",
-    color: {
-      button: "#000000",
-      text: "#ffffff",
-    },
-    text: {
-      subscribe: "Let's do it",
-      unsubscribe: "I don't want it anymore",
-      explanation: "Wanna stay in touch?",
-    },
-    unsubscribeEnabled: true,
   };
   await CustomLink.initialize(config);
 
-  const containerElements = document.querySelectorAll(CustomLink.containerSelector);
+  const containerElements = document.querySelectorAll<HTMLElement>(CustomLink.containerSelector);
   t.is(containerElements.length, 2);
-  containerElements.forEach((el: HTMLElement) => t.is(el.childNodes.length, 0));
+  containerElements.forEach((el: HTMLElement) => t.is(el.children.length, 0));
 });
 
-test('customlink: render if enabled and all properties present, button style & push enabled', async t => {
+test('customlink: container: render if enabled, explanation present', async t => {
   sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(true);
-
-  const config: AppUserConfigCustomLinkOptions = {
-    enabled: true,
-    style: "button",
-    size: "small",
-    color: {
-      button: "#000000",
-      text: "#ffffff",
-    },
-    text: {
-      subscribe: "Let's do it",
-      unsubscribe: "I don't want it anymore",
-      explanation: "Wanna stay in touch?",
-    },
-    unsubscribeEnabled: true,
-  };
   await CustomLink.initialize(config);
-
-  // Make sure that we advance in the initialization after css loaded
-  const sdkStylesLoadResult = await OneSignal.context.dynamicResourceLoader.loadSdkStylesheet();
-  t.is(sdkStylesLoadResult, ResourceLoadState.Loaded)
 
   const containerElements = document.querySelectorAll<HTMLElement>(CustomLink.containerSelector);
   t.is(containerElements.length, 2);
   containerElements.forEach((el: HTMLElement) => {
-    t.is(el.childNodes.length, 3)
-    t.is(el.getAttribute(CustomLink.initializedAttribute), "1");
-  });
-
-  const subscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.subscribeSelector);
-  t.is(subscribeElements.length, 3);
-  subscribeElements.forEach((el: HTMLElement) => {
-    t.is(el.textContent, config.text.subscribe);
-    t.deepEqual(el.className.split(' '), 
-      [CustomLink.subscribeClass, CustomLink.resetClass,
-      stateSubscribedClass, config.style, config.size]);
-    t.is(el.style.backgroundColor, "rgb(0, 0, 0)");
-    t.is(el.style.color, "rgb(255, 255, 255)");
-  });
-
-  const unsubscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.unsubscribeSelector);
-  t.is(unsubscribeElements.length, 2);
-  unsubscribeElements.forEach((el: HTMLElement) => {
-    t.is(el.textContent, config.text.unsubscribe);
-    t.deepEqual(el.className.split(' '), 
-      [CustomLink.unsubscribeClass, CustomLink.resetClass,
-      stateSubscribedClass, config.style, config.size]);
-      t.is(el.style.backgroundColor, "rgb(0, 0, 0)");
-      t.is(el.style.color, "rgb(255, 255, 255)");
-  });
-
-  const explanationElements = document.querySelectorAll<HTMLElement>(CustomLink.explanationSelector);
-  t.is(explanationElements.length, 2);
-  explanationElements.forEach((el: HTMLElement) => {
-    t.is(el.textContent, config.text.explanation);
-    t.deepEqual(el.className.split(' '), 
-      [CustomLink.explanationClass, CustomLink.resetClass,
-      stateSubscribedClass, config.size]);
+    t.is(el.children.length, 2);
+    t.is(hasCssClass(el.children[0], CustomLink.explanationClass), true);
+    t.is(hasCssClass(el.children[1], CustomLink.subscribeClass), true);
   });
 });
 
-test('customlink: render if enabled and all properties present, link style & push disabled', async t => {
-  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(false);
-
-  const config: AppUserConfigCustomLinkOptions = {
-    enabled: true,
-    style: "link",
-    size: "small",
-    color: {
-      button: "#000000",
-      text: "#ffffff",
-    },
-    text: {
-      subscribe: "Let's do it",
-      unsubscribe: "I don't want it anymore",
-      explanation: "Wanna stay in touch?",
-    },
-    unsubscribeEnabled: true,
-  };
+test('customlink: container: render if enabled, no explanation', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(true);
+  config.text.explanation = "";
   await CustomLink.initialize(config);
-
-  // Make sure that we advance in the initialization after css loaded
-  const sdkStylesLoadResult = await OneSignal.context.dynamicResourceLoader.loadSdkStylesheet();
-  t.is(sdkStylesLoadResult, ResourceLoadState.Loaded)
 
   const containerElements = document.querySelectorAll<HTMLElement>(CustomLink.containerSelector);
   t.is(containerElements.length, 2);
-  containerElements.forEach((el: HTMLElement) => t.is(el.childNodes.length, 3));
+  containerElements.forEach((el: HTMLElement) => {
+    t.is(el.children.length, 1);
+    t.is(hasCssClass(el.children[0], CustomLink.subscribeClass), true);
+  });
+});
+
+test('customlink: push enabled text and state', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(true);
+  await CustomLink.initialize(config);
+
+  const subscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.subscribeSelector);
+  subscribeElements.forEach((el: HTMLElement) => {
+    t.is(el.textContent, config.text.unsubscribe);
+    t.is(hasCssClass(el, stateSubscribedClass), true);
+  });
+});
+
+test('customlink: push disabled text and state', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(false);
+  await CustomLink.initialize(config);
+
+  const subscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.subscribeSelector);
+  subscribeElements.forEach((el: HTMLElement) => {
+    t.is(el.textContent, config.text.subscribe);
+    t.is(hasCssClass(el, stateUnsubscribedClass), true);
+  });
+});
+
+test('customlink: subscribe: intitialized, push enabled', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(true);
+  await CustomLink.initialize(config);
+
+  const subscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.subscribeSelector);
+  subscribeElements.forEach((el: HTMLElement) => {
+    t.is(hasCssClass(el, CustomLink.subscribeClass), true);
+    t.is(hasCssClass(el, CustomLink.resetClass), true);
+    t.is(hasCssClass(el, config.size), true);
+    t.is(el.getAttribute(CustomLink.initializedAttribute), "true");
+    t.is(el.getAttribute(CustomLink.subscribeTextAttribute), config.text.subscribe);
+    t.is(el.getAttribute(CustomLink.unsubscribeTextAttribute), config.text.unsubscribe);
+    t.is(el.getAttribute(CustomLink.subscriptionStateAttribute), "true");
+  });
+});
+
+test('customlink: subscribe: intitialized, push disabled', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(false);
+  await CustomLink.initialize(config);
+
+  const subscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.subscribeSelector);
+  subscribeElements.forEach((el: HTMLElement) => {
+    t.is(hasCssClass(el, CustomLink.subscribeClass), true);
+    t.is(hasCssClass(el, CustomLink.resetClass), true);
+    t.is(hasCssClass(el, config.size), true);
+    t.is(el.getAttribute(CustomLink.initializedAttribute), "true");
+    t.is(el.getAttribute(CustomLink.subscribeTextAttribute), config.text.subscribe);
+    t.is(el.getAttribute(CustomLink.unsubscribeTextAttribute), config.text.unsubscribe);
+    t.is(el.getAttribute(CustomLink.subscriptionStateAttribute), "false");
+  });
+});
+
+test('customlink: subscribe: unsubscribe disabled', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(true);
+  config.unsubscribeEnabled = false;
+  await CustomLink.initialize(config);
+
+  const subscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.subscribeSelector);
+  subscribeElements.forEach((el: HTMLElement) => {
+    t.is(hasCssClass(el, "hide"), true);
+  });
+
+  const explanationElements = document.querySelectorAll<HTMLElement>(CustomLink.explanationSelector);
+  explanationElements.forEach((el: HTMLElement) => {
+    t.is(hasCssClass(el, "hide"), true);
+  });
+});
+
+test('customlink: subscribe: unsubscribe enabled', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(true);
+  await CustomLink.initialize(config);
+
+  const subscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.subscribeSelector);
+  subscribeElements.forEach((el: HTMLElement) => {
+    t.is(hasCssClass(el, "hide"), false);
+  });
+
+  const explanationElements = document.querySelectorAll<HTMLElement>(CustomLink.explanationSelector);
+  explanationElements.forEach((el: HTMLElement) => {
+    t.is(hasCssClass(el, "hide"), false);
+  });
+});
+
+test('customlink: subscribe: button', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(true);
+  config.style = "button";
+  await CustomLink.initialize(config);
 
   const subscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.subscribeSelector);
   t.is(subscribeElements.length, 3);
   subscribeElements.forEach((el: HTMLElement) => {
-    t.is(el.textContent, config.text.subscribe);
-    t.deepEqual(el.className.split(' '), 
-      [CustomLink.subscribeClass, CustomLink.resetClass,
-      stateUnsubscribedClass, config.style, config.size]);
+    t.is(hasCssClass(el, config.style.toString()), true);
+    t.is(el.style.backgroundColor, "rgb(0, 0, 0)");
+    t.is(el.style.color, "rgb(255, 255, 255)");
+  });
+});
+
+test('customlink: subscribe: link', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(true);
+  config.style = "link";
+  await CustomLink.initialize(config);
+
+  const subscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.subscribeSelector);
+  t.is(subscribeElements.length, 3);
+  subscribeElements.forEach((el: HTMLElement) => {
+    t.is(hasCssClass(el, config.style.toString()), true);
     t.not(el.style.backgroundColor, "rgb(0, 0, 0)");
     t.is(el.style.color, "rgb(255, 255, 255)");
   });
-
-  const unsubscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.unsubscribeSelector);
-  t.is(unsubscribeElements.length, 2);
-  unsubscribeElements.forEach((el: HTMLElement) => {
-    t.is(el.textContent, config.text.unsubscribe);
-    t.deepEqual(el.className.split(' '), 
-      [CustomLink.unsubscribeClass, CustomLink.resetClass,
-        stateUnsubscribedClass, config.style, config.size]);
-      t.not(el.style.backgroundColor, "rgb(0, 0, 0)");
-      t.is(el.style.color, "rgb(255, 255, 255)");
-  });
-
-  const explanationElements = document.querySelectorAll<HTMLElement>(CustomLink.explanationSelector);
-  t.is(explanationElements.length, 2);
-  explanationElements.forEach((el: HTMLElement) => {
-    t.is(el.textContent, config.text.explanation);
-    t.deepEqual(el.className.split(' '), 
-      [CustomLink.explanationClass, CustomLink.resetClass,
-        stateUnsubscribedClass, config.size]);
-  });
 });
 
-test('customlink: render if enabled and some properties present', async t => {
-  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(true);
-
-  const config: AppUserConfigCustomLinkOptions = {
-    enabled: true,
-    style: "button",
-    size: "medium",
-    color: {
-      button: "#000000",
-      text: "#ffffff",
-    },
-    text: {
-      subscribe: "Let's do it",
-      unsubscribe: "I don't want it anymore",
-      explanation: "",
-    },
-    unsubscribeEnabled: false,
-  };
+test('customlink: reinitialize', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(false);
   await CustomLink.initialize(config);
-
-  // Make sure that we advance in the initialization after css loaded
-  const sdkStylesLoadResult = await OneSignal.context.dynamicResourceLoader.loadSdkStylesheet();
-  t.is(sdkStylesLoadResult, ResourceLoadState.Loaded)
-
+  await CustomLink.initialize(config);
   const containerElements = document.querySelectorAll<HTMLElement>(CustomLink.containerSelector);
   t.is(containerElements.length, 2);
-  containerElements.forEach((el: HTMLElement) => t.is(el.childNodes.length, 1));
-
-  const subscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.subscribeSelector);
-  t.is(subscribeElements.length, 3);
-  subscribeElements.forEach((el: HTMLElement) => {
-    t.is(el.textContent, config.text.subscribe);
-    t.deepEqual(el.className.split(' '), 
-      [CustomLink.subscribeClass, CustomLink.resetClass,
-      stateSubscribedClass, config.style, config.size]);
-    t.is(el.style.backgroundColor, "rgb(0, 0, 0)");
-    t.is(el.style.color, "rgb(255, 255, 255)");
-  });
-
-  const unsubscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.unsubscribeSelector);
-  t.is(unsubscribeElements.length, 0);
-
-  const explanationElements = document.querySelectorAll<HTMLElement>(CustomLink.explanationSelector);
-  t.is(explanationElements.length, 0);
 });
 
-test('customlink: re-initialize', async t => {
+test('customlink: subscribe: clicked: subscribed -> unsubscribed', async t => {
   sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(true);
+  sandbox.stub(OneSignal, 'setSubscription').resolves();
+  sandbox.stub(Utils, 'isUsingSubscriptionWorkaround').returns(false);
+  sandbox.stub(OneSignal.context.subscriptionManager, 'getSubscriptionState').returns({
+    subscribed: true,
+    optedOut: false,
+  });
 
-  const config: AppUserConfigCustomLinkOptions = {
-    enabled: true,
-    style: "button",
-    size: "small",
-    color: {
-      button: "#000000",
-      text: "#ffffff",
-    },
-    text: {
-      subscribe: "Let's do it",
-      unsubscribe: "I don't want it anymore",
-      explanation: "Wanna stay in touch?",
-    },
-    unsubscribeEnabled: true,
-  };
-
-  // Intentionally calling it twice
   await CustomLink.initialize(config);
+  const subscribeElement = document.querySelector<HTMLElement>(CustomLink.subscribeSelector);
+  const explanationElement = document.querySelector<HTMLElement>(CustomLink.explanationSelector);
+  t.not(subscribeElement, null);
+  t.not(explanationElement, null);
+
+  if (subscribeElement && explanationElement) {
+    t.is(subscribeElement.textContent, config.text.unsubscribe);
+    t.is(hasCssClass(subscribeElement, stateSubscribedClass), true);
+    t.is(hasCssClass(explanationElement, stateSubscribedClass), true);
+    t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "true");
+
+    await CustomLink.handleClick(subscribeElement);
+
+    t.is(subscribeElement.textContent, config.text.subscribe);
+    t.is(hasCssClass(subscribeElement, stateUnsubscribedClass), true);
+    t.is(hasCssClass(explanationElement, stateUnsubscribedClass), true);
+    t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "false");
+  }
+});
+
+test('customlink: subscribe: clicked: unsubscribed -> subscribed. https. opted out', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(false);
+  sandbox.stub(OneSignal, 'setSubscription').resolves();
+  sandbox.stub(OneSignal, 'registerForPushNotifications').resolves();
+  sandbox.stub(Utils, 'isUsingSubscriptionWorkaround').returns(false);
+  sandbox.stub(OneSignal.context.subscriptionManager, 'getSubscriptionState').returns({
+    subscribed: true,
+    optedOut: true,
+  });
+
   await CustomLink.initialize(config);
+  const subscribeElement = document.querySelector<HTMLElement>(CustomLink.subscribeSelector);
+  const explanationElement = document.querySelector<HTMLElement>(CustomLink.explanationSelector);
+  t.not(subscribeElement, null);
+  t.not(explanationElement, null);
 
-  // Make sure that we advance in the initialization after css loaded
-  const sdkStylesLoadResult = await OneSignal.context.dynamicResourceLoader.loadSdkStylesheet();
-  t.is(sdkStylesLoadResult, ResourceLoadState.Loaded)
+  if (subscribeElement && explanationElement) {
+    t.is(subscribeElement.textContent, config.text.subscribe);
+    t.is(hasCssClass(subscribeElement, stateUnsubscribedClass), true);
+    t.is(hasCssClass(explanationElement, stateUnsubscribedClass), true);
+    t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "false");
 
-  const containerElements = document.querySelectorAll<HTMLElement>(CustomLink.containerSelector);
-  t.is(containerElements.length, 2);
-  containerElements.forEach((el: HTMLElement) => t.is(el.childNodes.length, 3));
+    await CustomLink.handleClick(subscribeElement);
 
-  const subscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.subscribeSelector);
-  t.is(subscribeElements.length, 3);
+    t.is(subscribeElement.textContent, config.text.unsubscribe);
+    t.is(hasCssClass(subscribeElement, stateSubscribedClass), true);
+    t.is(hasCssClass(explanationElement, stateSubscribedClass), true);
+    t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "true");
+  }
+});
 
-  const unsubscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.unsubscribeSelector);
-  t.is(unsubscribeElements.length, 2);
+test('customlink: subscribe: clicked: unsubscribed -> subscribed. https. never subscribed.', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(false);
+  sandbox.stub(OneSignal, 'setSubscription').resolves();
+  sandbox.stub(OneSignal, 'registerForPushNotifications').resolves();
+  sandbox.stub(Utils, 'isUsingSubscriptionWorkaround').returns(false);
+  sandbox.stub(OneSignal.context.subscriptionManager, 'getSubscriptionState').returns({
+    subscribed: false,
+    optedOut: false,
+  });
 
-  const explanationElements = document.querySelectorAll<HTMLElement>(CustomLink.explanationSelector);
-  t.is(explanationElements.length, 2);
+  await CustomLink.initialize(config);
+  const subscribeElement = document.querySelector<HTMLElement>(CustomLink.subscribeSelector);
+  const explanationElement = document.querySelector<HTMLElement>(CustomLink.explanationSelector);
+  t.not(subscribeElement, null);
+  t.not(explanationElement, null);
+
+  if (subscribeElement && explanationElement) {
+    t.is(subscribeElement.textContent, config.text.subscribe);
+    t.is(hasCssClass(subscribeElement, stateUnsubscribedClass), true);
+    t.is(hasCssClass(explanationElement, stateUnsubscribedClass), true);
+    t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "false");
+
+    await CustomLink.handleClick(subscribeElement);
+
+    t.is(subscribeElement.textContent, config.text.unsubscribe);
+    t.is(hasCssClass(subscribeElement, stateSubscribedClass), true);
+    t.is(hasCssClass(explanationElement, stateSubscribedClass), true);
+    t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "true");
+  }
+});
+
+test('customlink: subscribe: clicked: unsubscribed -> subscribed. http.', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(false);
+  sandbox.stub(OneSignal, 'setSubscription').resolves();
+  sandbox.stub(OneSignal, 'registerForPushNotifications').resolves();
+  sandbox.stub(Utils, 'isUsingSubscriptionWorkaround').returns(true);
+
+  await CustomLink.initialize(config);
+  const subscribeElement = document.querySelector<HTMLElement>(CustomLink.subscribeSelector);
+  const explanationElement = document.querySelector<HTMLElement>(CustomLink.explanationSelector);
+  t.not(subscribeElement, null);
+  t.not(explanationElement, null);
+
+  if (subscribeElement && explanationElement) {
+    t.is(subscribeElement.textContent, config.text.subscribe);
+    t.is(hasCssClass(subscribeElement, stateUnsubscribedClass), true);
+    t.is(hasCssClass(explanationElement, stateUnsubscribedClass), true);
+    t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "false");
+
+    await CustomLink.handleClick(subscribeElement);
+
+    t.is(subscribeElement.textContent, config.text.unsubscribe);
+    t.is(hasCssClass(subscribeElement, stateSubscribedClass), true);
+    t.is(hasCssClass(explanationElement, stateSubscribedClass), true);
+    t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "true");
+  }
 });

--- a/test/unit/prompts/CustomLink.ts
+++ b/test/unit/prompts/CustomLink.ts
@@ -111,10 +111,8 @@ test('customlink: subscribe: intitialized, push enabled', async t => {
   subscribeElements.forEach((el: HTMLElement) => {
     t.is(hasCssClass(el, CustomLink.subscribeClass), true);
     t.is(hasCssClass(el, CustomLink.resetClass), true);
-    t.is(hasCssClass(el, config.size), true);
+    t.is(hasCssClass(el, config.size.toString()), true);
     t.is(el.getAttribute(CustomLink.initializedAttribute), "true");
-    t.is(el.getAttribute(CustomLink.subscribeTextAttribute), config.text.subscribe);
-    t.is(el.getAttribute(CustomLink.unsubscribeTextAttribute), config.text.unsubscribe);
     t.is(el.getAttribute(CustomLink.subscriptionStateAttribute), "true");
   });
 });
@@ -127,10 +125,8 @@ test('customlink: subscribe: intitialized, push disabled', async t => {
   subscribeElements.forEach((el: HTMLElement) => {
     t.is(hasCssClass(el, CustomLink.subscribeClass), true);
     t.is(hasCssClass(el, CustomLink.resetClass), true);
-    t.is(hasCssClass(el, config.size), true);
+    t.is(hasCssClass(el, config.size.toString()), true);
     t.is(el.getAttribute(CustomLink.initializedAttribute), "true");
-    t.is(el.getAttribute(CustomLink.subscribeTextAttribute), config.text.subscribe);
-    t.is(el.getAttribute(CustomLink.unsubscribeTextAttribute), config.text.unsubscribe);
     t.is(el.getAttribute(CustomLink.subscriptionStateAttribute), "false");
   });
 });
@@ -204,7 +200,7 @@ test('customlink: reinitialize', async t => {
 
 test('customlink: subscribe: clicked: subscribed -> unsubscribed', async t => {
   sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(true);
-  sandbox.stub(OneSignal, 'setSubscription').resolves();
+  const subscriptionSpy = sandbox.stub(OneSignal, 'setSubscription').resolves();
   sandbox.stub(Utils, 'isUsingSubscriptionWorkaround').returns(false);
   sandbox.stub(OneSignal.context.subscriptionManager, 'getSubscriptionState').returns({
     subscribed: true,
@@ -218,23 +214,17 @@ test('customlink: subscribe: clicked: subscribed -> unsubscribed', async t => {
   t.not(explanationElement, null);
 
   if (subscribeElement && explanationElement) {
-    t.is(subscribeElement.textContent, config.text.unsubscribe);
-    t.is(hasCssClass(subscribeElement, stateSubscribedClass), true);
-    t.is(hasCssClass(explanationElement, stateSubscribedClass), true);
     t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "true");
-
     await CustomLink.handleClick(subscribeElement);
-
-    t.is(subscribeElement.textContent, config.text.subscribe);
-    t.is(hasCssClass(subscribeElement, stateUnsubscribedClass), true);
-    t.is(hasCssClass(explanationElement, stateUnsubscribedClass), true);
-    t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "false");
+    t.is(subscriptionSpy.calledOnce, true);
+    t.is(subscriptionSpy.getCall(0).args.length, 1);
+    t.is(subscriptionSpy.getCall(0).args[0], false);
   }
 });
 
 test('customlink: subscribe: clicked: unsubscribed -> subscribed. https. opted out', async t => {
   sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(false);
-  sandbox.stub(OneSignal, 'setSubscription').resolves();
+  const subscriptionSpy = sandbox.stub(OneSignal, 'setSubscription').resolves();
   sandbox.stub(OneSignal, 'registerForPushNotifications').resolves();
   sandbox.stub(Utils, 'isUsingSubscriptionWorkaround').returns(false);
   sandbox.stub(OneSignal.context.subscriptionManager, 'getSubscriptionState').returns({
@@ -249,24 +239,20 @@ test('customlink: subscribe: clicked: unsubscribed -> subscribed. https. opted o
   t.not(explanationElement, null);
 
   if (subscribeElement && explanationElement) {
-    t.is(subscribeElement.textContent, config.text.subscribe);
-    t.is(hasCssClass(subscribeElement, stateUnsubscribedClass), true);
-    t.is(hasCssClass(explanationElement, stateUnsubscribedClass), true);
     t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "false");
 
     await CustomLink.handleClick(subscribeElement);
 
-    t.is(subscribeElement.textContent, config.text.unsubscribe);
-    t.is(hasCssClass(subscribeElement, stateSubscribedClass), true);
-    t.is(hasCssClass(explanationElement, stateSubscribedClass), true);
-    t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "true");
+    t.is(subscriptionSpy.calledOnce, true);
+    t.is(subscriptionSpy.getCall(0).args.length, 1);
+    t.is(subscriptionSpy.getCall(0).args[0], true);
   }
 });
 
 test('customlink: subscribe: clicked: unsubscribed -> subscribed. https. never subscribed.', async t => {
   sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(false);
   sandbox.stub(OneSignal, 'setSubscription').resolves();
-  sandbox.stub(OneSignal, 'registerForPushNotifications').resolves();
+  const registerSpy = sandbox.stub(OneSignal, 'registerForPushNotifications').resolves();
   sandbox.stub(Utils, 'isUsingSubscriptionWorkaround').returns(false);
   sandbox.stub(OneSignal.context.subscriptionManager, 'getSubscriptionState').returns({
     subscribed: false,
@@ -280,24 +266,16 @@ test('customlink: subscribe: clicked: unsubscribed -> subscribed. https. never s
   t.not(explanationElement, null);
 
   if (subscribeElement && explanationElement) {
-    t.is(subscribeElement.textContent, config.text.subscribe);
-    t.is(hasCssClass(subscribeElement, stateUnsubscribedClass), true);
-    t.is(hasCssClass(explanationElement, stateUnsubscribedClass), true);
     t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "false");
-
     await CustomLink.handleClick(subscribeElement);
-
-    t.is(subscribeElement.textContent, config.text.unsubscribe);
-    t.is(hasCssClass(subscribeElement, stateSubscribedClass), true);
-    t.is(hasCssClass(explanationElement, stateSubscribedClass), true);
-    t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "true");
+    t.is(registerSpy.calledOnce, true);
   }
 });
 
 test('customlink: subscribe: clicked: unsubscribed -> subscribed. http.', async t => {
   sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(false);
   sandbox.stub(OneSignal, 'setSubscription').resolves();
-  sandbox.stub(OneSignal, 'registerForPushNotifications').resolves();
+  const registerSpy = sandbox.stub(OneSignal, 'registerForPushNotifications').resolves();
   sandbox.stub(Utils, 'isUsingSubscriptionWorkaround').returns(true);
 
   await CustomLink.initialize(config);
@@ -307,16 +285,8 @@ test('customlink: subscribe: clicked: unsubscribed -> subscribed. http.', async 
   t.not(explanationElement, null);
 
   if (subscribeElement && explanationElement) {
-    t.is(subscribeElement.textContent, config.text.subscribe);
-    t.is(hasCssClass(subscribeElement, stateUnsubscribedClass), true);
-    t.is(hasCssClass(explanationElement, stateUnsubscribedClass), true);
     t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "false");
-
     await CustomLink.handleClick(subscribeElement);
-
-    t.is(subscribeElement.textContent, config.text.unsubscribe);
-    t.is(hasCssClass(subscribeElement, stateSubscribedClass), true);
-    t.is(hasCssClass(explanationElement, stateSubscribedClass), true);
-    t.is(subscribeElement.getAttribute(CustomLink.subscriptionStateAttribute), "true");
+    t.is(registerSpy.calledOnce, true);
   }
 });

--- a/test/unit/prompts/CustomLink.ts
+++ b/test/unit/prompts/CustomLink.ts
@@ -1,0 +1,260 @@
+import test from 'ava';
+import sinon, { SinonSandbox } from 'sinon';
+import { TestEnvironment, HttpHttpsEnvironment } from '../../support/sdk/TestEnvironment';
+import { AppUserConfigCustomLinkOptions } from '../../../src/models/AppConfig';
+import CustomLink from '../../../src/CustomLink';
+import { ResourceLoadState } from '../../../src/services/DynamicResourceLoader';
+
+let sandbox: SinonSandbox;
+
+const stateSubscribedClass = "state-subscribed";
+const stateUnsubscribedClass = "state-unsubscribed";
+
+test.beforeEach(async () => {
+  sandbox = sinon.sandbox.create();
+
+  await TestEnvironment.initialize({
+    addPrompts: true,
+    httpOrHttps: HttpHttpsEnvironment.Https,
+  });
+  TestEnvironment.mockInternalOneSignal();
+  sandbox.stub(OneSignal.context.dynamicResourceLoader, 'loadSdkStylesheet')
+    .returns(ResourceLoadState.Loaded);
+});
+
+test.afterEach(function () {
+  sandbox.restore();
+});
+
+test('customlink: not render if disabled', async t => {
+  const config: AppUserConfigCustomLinkOptions = {
+    enabled: false,
+    style: "link",
+    size: "small",
+    color: {
+      button: "#000000",
+      text: "#ffffff",
+    },
+    text: {
+      subscribe: "Let's do it",
+      unsubscribe: "I don't want it anymore",
+      explanation: "Wanna stay in touch?",
+    },
+    unsubscribeEnabled: true,
+  };
+  await CustomLink.initialize(config);
+
+  const containerElements = document.querySelectorAll(CustomLink.containerSelector);
+  t.is(containerElements.length, 2);
+  containerElements.forEach((el: HTMLElement) => t.is(el.childNodes.length, 0));
+});
+
+test('customlink: render if enabled and all properties present, button style & push enabled', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(true);
+
+  const config: AppUserConfigCustomLinkOptions = {
+    enabled: true,
+    style: "button",
+    size: "small",
+    color: {
+      button: "#000000",
+      text: "#ffffff",
+    },
+    text: {
+      subscribe: "Let's do it",
+      unsubscribe: "I don't want it anymore",
+      explanation: "Wanna stay in touch?",
+    },
+    unsubscribeEnabled: true,
+  };
+  await CustomLink.initialize(config);
+
+  // Make sure that we advance in the initialization after css loaded
+  const sdkStylesLoadResult = await OneSignal.context.dynamicResourceLoader.loadSdkStylesheet();
+  t.is(sdkStylesLoadResult, ResourceLoadState.Loaded)
+
+  const containerElements = document.querySelectorAll<HTMLElement>(CustomLink.containerSelector);
+  t.is(containerElements.length, 2);
+  containerElements.forEach((el: HTMLElement) => {
+    t.is(el.childNodes.length, 3)
+    t.is(el.getAttribute(CustomLink.initializedAttribute), "1");
+  });
+
+  const subscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.subscribeSelector);
+  t.is(subscribeElements.length, 3);
+  subscribeElements.forEach((el: HTMLElement) => {
+    t.is(el.textContent, config.text.subscribe);
+    t.deepEqual(el.className.split(' '), 
+      [CustomLink.subscribeClass, CustomLink.resetClass,
+      stateSubscribedClass, config.style, config.size]);
+    t.is(el.style.backgroundColor, "rgb(0, 0, 0)");
+    t.is(el.style.color, "rgb(255, 255, 255)");
+  });
+
+  const unsubscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.unsubscribeSelector);
+  t.is(unsubscribeElements.length, 2);
+  unsubscribeElements.forEach((el: HTMLElement) => {
+    t.is(el.textContent, config.text.unsubscribe);
+    t.deepEqual(el.className.split(' '), 
+      [CustomLink.unsubscribeClass, CustomLink.resetClass,
+      stateSubscribedClass, config.style, config.size]);
+      t.is(el.style.backgroundColor, "rgb(0, 0, 0)");
+      t.is(el.style.color, "rgb(255, 255, 255)");
+  });
+
+  const explanationElements = document.querySelectorAll<HTMLElement>(CustomLink.explanationSelector);
+  t.is(explanationElements.length, 2);
+  explanationElements.forEach((el: HTMLElement) => {
+    t.is(el.textContent, config.text.explanation);
+    t.deepEqual(el.className.split(' '), 
+      [CustomLink.explanationClass, CustomLink.resetClass,
+      stateSubscribedClass, config.size]);
+  });
+});
+
+test('customlink: render if enabled and all properties present, link style & push disabled', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(false);
+
+  const config: AppUserConfigCustomLinkOptions = {
+    enabled: true,
+    style: "link",
+    size: "small",
+    color: {
+      button: "#000000",
+      text: "#ffffff",
+    },
+    text: {
+      subscribe: "Let's do it",
+      unsubscribe: "I don't want it anymore",
+      explanation: "Wanna stay in touch?",
+    },
+    unsubscribeEnabled: true,
+  };
+  await CustomLink.initialize(config);
+
+  // Make sure that we advance in the initialization after css loaded
+  const sdkStylesLoadResult = await OneSignal.context.dynamicResourceLoader.loadSdkStylesheet();
+  t.is(sdkStylesLoadResult, ResourceLoadState.Loaded)
+
+  const containerElements = document.querySelectorAll<HTMLElement>(CustomLink.containerSelector);
+  t.is(containerElements.length, 2);
+  containerElements.forEach((el: HTMLElement) => t.is(el.childNodes.length, 3));
+
+  const subscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.subscribeSelector);
+  t.is(subscribeElements.length, 3);
+  subscribeElements.forEach((el: HTMLElement) => {
+    t.is(el.textContent, config.text.subscribe);
+    t.deepEqual(el.className.split(' '), 
+      [CustomLink.subscribeClass, CustomLink.resetClass,
+      stateUnsubscribedClass, config.style, config.size]);
+    t.not(el.style.backgroundColor, "rgb(0, 0, 0)");
+    t.is(el.style.color, "rgb(255, 255, 255)");
+  });
+
+  const unsubscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.unsubscribeSelector);
+  t.is(unsubscribeElements.length, 2);
+  unsubscribeElements.forEach((el: HTMLElement) => {
+    t.is(el.textContent, config.text.unsubscribe);
+    t.deepEqual(el.className.split(' '), 
+      [CustomLink.unsubscribeClass, CustomLink.resetClass,
+        stateUnsubscribedClass, config.style, config.size]);
+      t.not(el.style.backgroundColor, "rgb(0, 0, 0)");
+      t.is(el.style.color, "rgb(255, 255, 255)");
+  });
+
+  const explanationElements = document.querySelectorAll<HTMLElement>(CustomLink.explanationSelector);
+  t.is(explanationElements.length, 2);
+  explanationElements.forEach((el: HTMLElement) => {
+    t.is(el.textContent, config.text.explanation);
+    t.deepEqual(el.className.split(' '), 
+      [CustomLink.explanationClass, CustomLink.resetClass,
+        stateUnsubscribedClass, config.size]);
+  });
+});
+
+test('customlink: render if enabled and some properties present', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(true);
+
+  const config: AppUserConfigCustomLinkOptions = {
+    enabled: true,
+    style: "button",
+    size: "medium",
+    color: {
+      button: "#000000",
+      text: "#ffffff",
+    },
+    text: {
+      subscribe: "Let's do it",
+      unsubscribe: "I don't want it anymore",
+      explanation: "",
+    },
+    unsubscribeEnabled: false,
+  };
+  await CustomLink.initialize(config);
+
+  // Make sure that we advance in the initialization after css loaded
+  const sdkStylesLoadResult = await OneSignal.context.dynamicResourceLoader.loadSdkStylesheet();
+  t.is(sdkStylesLoadResult, ResourceLoadState.Loaded)
+
+  const containerElements = document.querySelectorAll<HTMLElement>(CustomLink.containerSelector);
+  t.is(containerElements.length, 2);
+  containerElements.forEach((el: HTMLElement) => t.is(el.childNodes.length, 1));
+
+  const subscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.subscribeSelector);
+  t.is(subscribeElements.length, 3);
+  subscribeElements.forEach((el: HTMLElement) => {
+    t.is(el.textContent, config.text.subscribe);
+    t.deepEqual(el.className.split(' '), 
+      [CustomLink.subscribeClass, CustomLink.resetClass,
+      stateSubscribedClass, config.style, config.size]);
+    t.is(el.style.backgroundColor, "rgb(0, 0, 0)");
+    t.is(el.style.color, "rgb(255, 255, 255)");
+  });
+
+  const unsubscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.unsubscribeSelector);
+  t.is(unsubscribeElements.length, 0);
+
+  const explanationElements = document.querySelectorAll<HTMLElement>(CustomLink.explanationSelector);
+  t.is(explanationElements.length, 0);
+});
+
+test('customlink: re-initialize', async t => {
+  sandbox.stub(OneSignal, 'isPushNotificationsEnabled').returns(true);
+
+  const config: AppUserConfigCustomLinkOptions = {
+    enabled: true,
+    style: "button",
+    size: "small",
+    color: {
+      button: "#000000",
+      text: "#ffffff",
+    },
+    text: {
+      subscribe: "Let's do it",
+      unsubscribe: "I don't want it anymore",
+      explanation: "Wanna stay in touch?",
+    },
+    unsubscribeEnabled: true,
+  };
+
+  // Intentionally calling it twice
+  await CustomLink.initialize(config);
+  await CustomLink.initialize(config);
+
+  // Make sure that we advance in the initialization after css loaded
+  const sdkStylesLoadResult = await OneSignal.context.dynamicResourceLoader.loadSdkStylesheet();
+  t.is(sdkStylesLoadResult, ResourceLoadState.Loaded)
+
+  const containerElements = document.querySelectorAll<HTMLElement>(CustomLink.containerSelector);
+  t.is(containerElements.length, 2);
+  containerElements.forEach((el: HTMLElement) => t.is(el.childNodes.length, 3));
+
+  const subscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.subscribeSelector);
+  t.is(subscribeElements.length, 3);
+
+  const unsubscribeElements = document.querySelectorAll<HTMLElement>(CustomLink.unsubscribeSelector);
+  t.is(unsubscribeElements.length, 2);
+
+  const explanationElements = document.querySelectorAll<HTMLElement>(CustomLink.explanationSelector);
+  t.is(explanationElements.length, 2);
+});

--- a/test/unit/public-sdk-apis/init.ts
+++ b/test/unit/public-sdk-apis/init.ts
@@ -208,7 +208,7 @@ test("Test OneSignal.init, Basic HTTP", async t => {
 
   sinonSandbox.stub(document, "visibilityState").value("visible");
 
-  const serverAppConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom);
+  const serverAppConfig =TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom, false);
   serverAppConfig.config.subdomain = "test";
   InitTestHelpers.stubJSONP(serverAppConfig);
 
@@ -236,7 +236,7 @@ test("Test OneSignal.init, Basic HTTP, autoRegister", async t => {
 
   sinonSandbox.stub(document, "visibilityState").value("visible");
 
-  const serverAppConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom);
+  const serverAppConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom, false);
   serverAppConfig.config.subdomain = "test";
   InitTestHelpers.stubJSONP(serverAppConfig);
 


### PR DESCRIPTION
Adding the support for a new custom link prompt configured through the dashboard.
- Includes css for styling of its components;
- Initialization is based on the config coming from server;
- Supports Http and Https modes;
- Allows for multiple instances of the prompt on a page;

Corner case:
in https mode block notifications in browser, then click subscribe. There is only error in console but no guidance on how to unblock. Possibly show a tooltip dialog from bell with instructions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/377)
<!-- Reviewable:end -->
