### PR TITLE
Fix error caused by a user blocking localStorage

### DIFF
--- a/src/libraries/Log.ts
+++ b/src/libraries/Log.ts
@@ -10,11 +10,11 @@ export default class Log {
   private static proxyMethodsCreated: boolean;
 
   private static shouldLog(): boolean {
-    if (typeof window === "undefined" ||
-        typeof window.localStorage === "undefined") {
-      return false;
-    }
     try {
+      if (typeof window === "undefined" ||
+          typeof window.localStorage === "undefined") {
+        return false;
+      }
       const level = window.localStorage.getItem("loglevel");
       if (level && level.toLowerCase() === "trace") {
         return true;

--- a/src/modules/TimedLocalStorage.ts
+++ b/src/modules/TimedLocalStorage.ts
@@ -11,10 +11,10 @@ export default class TimedLocalStorage {
    * browser preferences set to prevent saving website data will disable LocalStorage.
    */
   public static isLocalStorageSupported(): boolean {
-    if (typeof localStorage === "undefined") {
-      return false;
-    }
     try {
+      if (typeof localStorage === "undefined") {
+        return false;
+      }
       localStorage.getItem("test");
       return true;
     } catch (e) {


### PR DESCRIPTION
Fix error caused by a user blocking localStorage
This PR fixes the error:

```
Failed to read the 'localStorage' property from 'Window': Access is denied for this document.
```

We host a high traffic website. We see a small percentage of users having this cookies/storage disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/379)
<!-- Reviewable:end -->
