### PR TITLE
Fixes registration with non-root service workers

### DIFF
--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -88,10 +88,11 @@ export class ServiceWorkerManager {
     this.config = config;
   }
 
+  // Gets details on the service-worker (if any) that controls the current page
   public static async getRegistration(): Promise<ServiceWorkerRegistration | null> {
     try {
-      // location.origin is used for <base> tag compatibility when it is set to a different origin
-      return navigator.serviceWorker.getRegistration(location.origin);
+      // location.href is used for <base> tag compatibility when it is set to a different origin
+      return navigator.serviceWorker.getRegistration(location.href);
     } catch (e) {
       // This could be null in an HTTP context or error if the user doesn't accept cookies
       Log.warn("[Service Worker Status] Error Checking service worker registration");

--- a/test/unit/managers/ServiceWorkerManager.ts
+++ b/test/unit/managers/ServiceWorkerManager.ts
@@ -53,7 +53,7 @@ test.beforeEach(async function() {
 
 test.afterEach(function () {
   if (getRegistrationStub.callCount > 0)
-    sandbox.assert.alwaysCalledWith(getRegistrationStub, sinon.match.string);
+    sandbox.assert.alwaysCalledWithExactly(getRegistrationStub, location.href);
   sandbox.restore();
 });
 


### PR DESCRIPTION
* Should always use the current page as the scope of querying service workers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/389)
<!-- Reviewable:end -->
