### PR TITLE
Fixed catching serviceWorker status errors

### DIFF
--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -92,7 +92,7 @@ export class ServiceWorkerManager {
   public static async getRegistration(): Promise<ServiceWorkerRegistration | null> {
     try {
       // location.href is used for <base> tag compatibility when it is set to a different origin
-      return navigator.serviceWorker.getRegistration(location.href);
+      return await navigator.serviceWorker.getRegistration(location.href);
     } catch (e) {
       // This could be null in an HTTP context or error if the user doesn't accept cookies
       Log.warn("[Service Worker Status] Error Checking service worker registration");


### PR DESCRIPTION
* This was throwing on some sites HTTP sites
   - Uncaught (in promise) DOMException: Only secure origins are allowed (see: https://goo.gl/Y0ZkNV).
* Resolves #391

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/392)
<!-- Reviewable:end -->
