### PR TITLE
on_session on every first page view

### DIFF
--- a/src/managers/ConfigManager.ts
+++ b/src/managers/ConfigManager.ts
@@ -107,6 +107,7 @@ export default class ConfigManager {
       onesignalVapidPublicKey: serverConfig.config.onesignal_vapid_public_key,
       emailAuthRequired: serverConfig.features.email && serverConfig.features.email.require_auth,
       userConfig: this.getUserConfigForConfigIntegrationKind(configIntegrationKind, userConfig, serverConfig),
+      enableOnSession: serverConfig.features.enable_on_session || false,
     };
   }
 

--- a/src/managers/PermissionManager.ts
+++ b/src/managers/PermissionManager.ts
@@ -1,10 +1,8 @@
 import { redetectBrowserUserAgent, isUsingSubscriptionWorkaround } from '../utils';
-import SubscriptionHelper from '../helpers/SubscriptionHelper';
 import bowser from 'bowser';
 import { InvalidArgumentError, InvalidArgumentReason } from '../errors/InvalidArgumentError';
 import Database from '../services/Database';
 import { NotificationPermission } from '../models/NotificationPermission';
-import MainHelper from '../helpers/MainHelper';
 import SdkEnvironment from './SdkEnvironment';
 
 /**
@@ -40,7 +38,7 @@ export default class PermissionManager {
    * @param safariWebId The Safari web ID necessary to access the permission
    * state on Safari.
    */
-  public async getNotificationPermission(safariWebId?: string) {
+  public async getNotificationPermission(safariWebId?: string): Promise<NotificationPermission> {
     const reportedPermission = await this.getReportedNotificationPermission(safariWebId);
     if (await this.isPermissionEnvironmentAmbiguous(reportedPermission))
       return await this.getInterpretedAmbiguousPermission(reportedPermission);

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -148,9 +148,13 @@ export class SubscriptionManager {
     if (await this.isAlreadyRegisteredWithOneSignal()) {
       const { deviceId } = await Database.getSubscription();
 
-      await OneSignalApi.updatePlayer(this.context.appConfig.appId, deviceId, {
-        notification_types: SubscriptionStateKind.Subscribed,
-      });
+      if (!pushSubscription || pushSubscription.isNewSubscription()) {
+        // send update player only for new subscriptions
+        // for existing players on_session will send the update instead
+        await OneSignalApi.updatePlayer(this.context.appConfig.appId, deviceId, {
+          notification_types: SubscriptionStateKind.Subscribed,
+        });
+      }
     } else {      
       const id = await OneSignalApi.createUser(deviceRecord);
       newDeviceId = id;

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -29,6 +29,7 @@ export interface AppConfig {
     enable: boolean;
     mixpanelReportingToken: string | null;
   };
+  enableOnSession?: boolean;
 
   safariWebId?: string;
 
@@ -285,6 +286,7 @@ export interface ServerAppConfig {
     email?: {
       require_auth: boolean;
     };
+    enable_on_session?: boolean;
   };
   config: {
     /**

--- a/src/models/PushDeviceRecord.ts
+++ b/src/models/PushDeviceRecord.ts
@@ -15,12 +15,12 @@ import { DeviceRecord } from './DeviceRecord';
  * Describes a push notification device record.
  */
 export class PushDeviceRecord extends DeviceRecord {
-  public subscription: RawPushSubscription;
+  public subscription: RawPushSubscription | undefined;
 
   /**
    * @param subscription Omitting this parameter does not void the record's identifier.
    */
-  constructor(subscription: RawPushSubscription) {
+  constructor(subscription?: RawPushSubscription) {
     super();
     this.subscription = subscription;
   }
@@ -39,7 +39,7 @@ export class PushDeviceRecord extends DeviceRecord {
     return serializedBundle;
   }
 
-  static createFromPushSubscription(
+  public static createFromPushSubscription(
     appId: string,
     rawPushSubscription: RawPushSubscription,
     subscriptionState?: SubscriptionStateKind,

--- a/src/models/Subscription.ts
+++ b/src/models/Subscription.ts
@@ -6,25 +6,25 @@ export class Subscription implements Serializable {
   /**
    * The OneSignal player ID.
    */
-  deviceId: string;
+  deviceId: string | undefined;
   /**
    * The GCM/FCM registration token, as a stringified URL, or the Safari device token.
    */
-  subscriptionToken: string;
+  subscriptionToken: string | null | undefined;
   /**
    * Whether the user is opted out of notifications, set by setSubscription().
    */
-  optedOut: boolean;
+  optedOut: boolean | undefined;
   /**
    * A UTC timestamp of when this subscription was created. This value is not modified when a
    * subscription is merely refreshed, only when a subscription is created anew.
    */
-  createdAt: number;
+  createdAt: number | undefined;
   /**
    * For HTTP sites only. This property is stored on the native PushSubscription object, but it's inaccessible
    * in cross-origin frames.
    */
-  expirationTime: number;
+  expirationTime: number | null | undefined;
 
   serialize() {
     return {

--- a/src/models/SubscriptionStateKind.ts
+++ b/src/models/SubscriptionStateKind.ts
@@ -1,4 +1,5 @@
 export enum SubscriptionStateKind {
+  Default = 0,
   Subscribed = 1,
   MutedByApi = -2,
   NotSubscribed = -10,

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -315,6 +315,7 @@ export class TestEnvironment {
         enable: true,
         mixpanelReportingToken: 'mixpanel-token'
       },
+      enableOnSession: true,
       safariWebId: undefined,
       vapidPublicKey: 'ImZRmh5eOX2onbZDIrSuC6ym6nyMRQ03OwxYQWYgejhN30Zs9VKKuKydxdppZiDlGLvuN3dGuFb66tD2wO1pm9e',
       onesignalVapidPublicKey: '3y84Zfh6QXKVidhc0RvBciX5DUEznaaiJY5aoB05TWvfvKn2duHcrm1mMyIboDLGc5jC8I5YncqDz2ERRn6QnZ5',

--- a/test/unit/helpers/readme.ts
+++ b/test/unit/helpers/readme.ts
@@ -1,0 +1,4 @@
+/**
+ * Directories named fixtures, helpers and node_modules are always ignored by ava. -> https://github.com/avajs/ava#cli
+ * Don't put any tests in this directory. 
+ */

--- a/test/unit/helpers1/InitHelper.ts
+++ b/test/unit/helpers1/InitHelper.ts
@@ -33,6 +33,45 @@ test.afterEach(function (_t: TestContext) {
 /**
  * on_session
  */
+test("doesn't send on_session if enable flag not set for https", async t => {
+  OneSignal.context.appConfig.enableOnSession = false;
+  const apiSpy = sinonSandbox.spy(OneSignalApi, "updateUserSession");
+  await InitHelper.sendOnSessionUpdate();
+  t.is(apiSpy.notCalled, true);
+});
+
+test("doesn't send on_session if enable flag not set for http and not subscribed", async t => {
+  sinonSandbox.restore();
+  sinonSandbox = sinon.sandbox.create();
+  await TestEnvironment.initialize({
+    httpOrHttps: HttpHttpsEnvironment.Http
+  });
+
+  // Required for sessionContext, not async
+  TestEnvironment.mockInternalOneSignal();
+
+  OneSignal.context.appConfig.enableOnSession = false;
+  sinonSandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.MutedByApi);
+
+  const apiSpy = sinonSandbox.spy(OneSignalApi, "updateUserSession");
+  await InitHelper.sendOnSessionUpdate();
+  t.is(apiSpy.notCalled, true);
+});
+
+test("send on_session if enable flag not set for http and subscribed", async t => {
+  sinonSandbox.restore();
+  sinonSandbox = sinon.sandbox.create();
+  await TestEnvironment.initialize({
+    httpOrHttps: HttpHttpsEnvironment.Http
+  });
+
+  // Required for sessionContext, not async
+  TestEnvironment.mockInternalOneSignal();
+
+  OneSignal.context.appConfig.enableOnSession = false;
+  await testUpdateSessionForSuscriptionState(t, SubscriptionStateKind.Subscribed);
+});
+
 test("doesn't send on_session if not first page view", async t => {
   sinonSandbox.stub(OneSignal.context.sessionManager, "isFirstPageView").returns(false);
   const apiSpy = sinonSandbox.spy(OneSignalApi, "updateUserSession");

--- a/test/unit/helpers1/InitHelper.ts
+++ b/test/unit/helpers1/InitHelper.ts
@@ -1,0 +1,95 @@
+import test from "ava";
+import sinon, { SinonSandbox } from 'sinon';
+
+import InitHelper from "../../../src/helpers/InitHelper";
+import OneSignal from "../../../src/OneSignal";
+import OneSignalApi from "../../../src/OneSignalApi";
+import Database from "../../../src/services/Database";
+import MainHelper from "../../../src/helpers/MainHelper";
+import { Subscription } from "../../../src/models/Subscription";
+import { SubscriptionStateKind } from "../../../src/models/SubscriptionStateKind";
+import Random from "../../support/tester/Random";
+import { TestEnvironment, HttpHttpsEnvironment } from '../../support/sdk/TestEnvironment';
+import { PushDeviceRecord } from '../../../src/models/PushDeviceRecord';
+import Log from '../../../src/libraries/Log';
+
+const testDeviceId = Random.getRandomUuid();
+let sinonSandbox: SinonSandbox;
+
+test.beforeEach(async () => {
+  sinonSandbox = sinon.sandbox.create();
+  await TestEnvironment.initialize({
+    httpOrHttps: HttpHttpsEnvironment.Https
+  });
+
+  // Required for sessionContext, not async
+  TestEnvironment.mockInternalOneSignal();
+});
+
+test.afterEach(function (_t: TestContext) {
+  sinonSandbox.restore();
+});
+
+/**
+ * on_session
+ */
+test("doesn't send on_session if not first page view", async t => {
+  sinonSandbox.stub(OneSignal.context.sessionManager, "isFirstPageView").returns(false);
+  const apiSpy = sinonSandbox.spy(OneSignalApi, "updateUserSession");
+  await InitHelper.sendOnSessionUpdate();
+  t.is(apiSpy.notCalled, true);
+});
+
+test("doesn't send on_session if never registered before", async t => {
+  sinonSandbox.stub(OneSignal.context.sessionManager, "isFirstPageView").returns(true);
+  sinonSandbox.stub(Database, "getSubscription").returns({} as Subscription);
+  
+  const apiSpy = sinonSandbox.spy(OneSignalApi, "updateUserSession");
+  await InitHelper.sendOnSessionUpdate();
+  t.is(apiSpy.notCalled, true);
+});
+
+test("sends on_session for subscribed", async t => {
+  await testUpdateSessionForSuscriptionState(t, SubscriptionStateKind.Subscribed);
+});
+
+test("sends on_session for opted out", async t => {
+  await testUpdateSessionForSuscriptionState(t, SubscriptionStateKind.MutedByApi);
+});
+
+test("sends on_session for native notification permission blocked", async t => {
+  await testUpdateSessionForSuscriptionState(t, SubscriptionStateKind.PushSubscriptionRevoked);
+});
+
+test("sends on_session for native notification permission set to default", async t => {
+  await testUpdateSessionForSuscriptionState(t, SubscriptionStateKind.Default);
+});
+
+test("safely recover from failed on_session call and log error", async t => {
+  sinonSandbox.stub(OneSignal.context.sessionManager, "isFirstPageView").returns(true);
+  sinonSandbox.stub(Database, "getSubscription").returns({deviceId: testDeviceId} as Subscription);
+  sinonSandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.Subscribed);
+
+  const apiSpy = sinonSandbox.stub(OneSignalApi, "updateUserSession").rejects(new Error("Network error"));
+  const logSpy = sinonSandbox.stub(Log, "error").resolves();
+  await InitHelper.sendOnSessionUpdate();
+  t.is(apiSpy.calledOnce, true);
+  t.is(logSpy.calledOnce, true);
+});
+
+
+
+// private
+const testUpdateSessionForSuscriptionState = async function(t: any, subscriptionState: SubscriptionStateKind) {
+  sinonSandbox.stub(OneSignal.context.sessionManager, "isFirstPageView").returns(true);
+  sinonSandbox.stub(Database, "getSubscription").returns({deviceId: testDeviceId} as Subscription);
+  sinonSandbox.stub(MainHelper, "getCurrentNotificationType").resolves(subscriptionState);
+  const apiSpy = sinonSandbox.stub(OneSignalApi, "updateUserSession").resolves(testDeviceId);
+  await InitHelper.sendOnSessionUpdate();
+  t.is(apiSpy.calledOnce, true);
+
+  const callArgs = apiSpy.getCall(0).args
+  t.is(callArgs.length, 2);
+  t.is(callArgs[0], testDeviceId);
+  t.is((callArgs[1] as PushDeviceRecord).subscriptionState, subscriptionState);
+}

--- a/test/unit/helpers1/MainHelper.ts
+++ b/test/unit/helpers1/MainHelper.ts
@@ -1,0 +1,74 @@
+import test from "ava";
+import sinon, { SinonSandbox } from 'sinon';
+
+import MainHelper from "../../../src/helpers/MainHelper";
+import OneSignal from "../../../src/OneSignal";
+import { NotificationPermission } from "../../../src/models/NotificationPermission";
+import { SubscriptionStateKind } from '../../../src/models/SubscriptionStateKind';
+import { TestEnvironment, HttpHttpsEnvironment } from '../../support/sdk/TestEnvironment';
+import { Utils } from '../../../src/utils/Utils';
+
+let sinonSandbox: SinonSandbox;
+
+test.beforeEach(async () => {
+  sinonSandbox = sinon.sandbox.create();
+  await TestEnvironment.initialize({
+    httpOrHttps: HttpHttpsEnvironment.Https
+  });
+
+  // Required for sessionContext, not async
+  TestEnvironment.mockInternalOneSignal();
+});
+
+test.afterEach(function (_t: TestContext) {
+  sinonSandbox.restore();
+});
+
+test("getCurrentNotificationType for default permission", async t => {
+  sinonSandbox.stub(OneSignal.context.permissionManager, "getNotificationPermission")
+    .resolves(NotificationPermission.Default);
+    
+  t.is(await MainHelper.getCurrentNotificationType(), SubscriptionStateKind.Default);
+});
+
+test("getCurrentNotificationType for denied permission in HTTP context", async t => {
+  sinonSandbox.stub(OneSignal.context.permissionManager, "getNotificationPermission")
+    .resolves(NotificationPermission.Denied);
+  sinonSandbox.stub(Utils, "isUsingSubscriptionWorkaround").returns(true);
+
+  t.is(await MainHelper.getCurrentNotificationType(), SubscriptionStateKind.Default);
+});
+
+test("getCurrentNotificationType for denied permission in HTTPS context", async t => {
+  sinonSandbox.stub(OneSignal.context.permissionManager, "getNotificationPermission")
+    .resolves(NotificationPermission.Denied);
+  sinonSandbox.stub(Utils, "isUsingSubscriptionWorkaround").returns(false);
+
+  t.is(await MainHelper.getCurrentNotificationType(), SubscriptionStateKind.NotSubscribed);
+});
+
+test("getCurrentNotificationType for granted permission: subscribed", async t => {
+  sinonSandbox.stub(OneSignal.context.permissionManager, "getNotificationPermission")
+    .resolves(NotificationPermission.Granted);
+  sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(true);
+  sinonSandbox.stub(OneSignal.context.subscriptionManager, "isAlreadyRegisteredWithOneSignal").resolves(true);
+    
+  t.is(await MainHelper.getCurrentNotificationType(), SubscriptionStateKind.Subscribed);
+});
+
+test("getCurrentNotificationType for granted permission: opted out", async t => {
+  sinonSandbox.stub(OneSignal.context.permissionManager, "getNotificationPermission")
+    .resolves(NotificationPermission.Granted);
+  sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(false);
+  sinonSandbox.stub(OneSignal.context.subscriptionManager, "isAlreadyRegisteredWithOneSignal").resolves(true);
+    
+  t.is(await MainHelper.getCurrentNotificationType(), SubscriptionStateKind.MutedByApi);
+});
+
+test("getCurrentNotificationType for granted permission: new user", async t => {
+  sinonSandbox.stub(OneSignal.context.permissionManager, "getNotificationPermission")
+    .resolves(NotificationPermission.Granted);
+  sinonSandbox.stub(OneSignal.context.subscriptionManager, "isAlreadyRegisteredWithOneSignal").resolves(false);
+    
+  t.is(await MainHelper.getCurrentNotificationType(), SubscriptionStateKind.Default);
+});

--- a/test/unit/public-sdk-apis/init.ts
+++ b/test/unit/public-sdk-apis/init.ts
@@ -15,9 +15,6 @@ import OneSignalApi from "../../../src/OneSignalApi";
 import ProxyFrameHost from "../../../src/modules/frames/ProxyFrameHost";
 import AltOriginManager from "../../../src/managers/AltOriginManager";
 import { SdkInitError } from "../../../src/errors/SdkInitError";
-import {NotificationPermission} from "../../../src/models/NotificationPermission";
-import {WindowEnvironmentKind} from "../../../src/models/WindowEnvironmentKind";
-import SdkEnvironment from "../../../src/managers/SdkEnvironment";
 
 
 // Helper class to ensure the public OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC event fires

--- a/typings/globals/onesignal.d.ts
+++ b/typings/globals/onesignal.d.ts
@@ -15,5 +15,5 @@ interface PushSubscriptionState {
 
 interface SafarPushSubscriptionState {
   deviceToken: string | null;
-  permission: "granted" | "denied" | "default";
+  permission: NotificationPermission;
 }


### PR DESCRIPTION
- moved out of registration call, otherwise it was called with every re-subscription if done multiple times during the first page view
- now it's part of InitHelper.onSdkInitialized, works uniformly for all use-cases including safari which was before relying on registration call just for on_session reporting
- sends detected subscription status based on reported browser permission (environment aware)
- includes logic to handle special case with http and default/denied permission as described here in more details https://github.com/OneSignal/OneSignal-Website-SDK/issues/289
- added tests for new logic in InitHelper and MainHelper
- refactored pushsubscriptionchange in service worker test mostly due to one test breaking after replacing on_session with simple player update in registration call

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/400)
<!-- Reviewable:end -->
