### PR TITLE
Fix for OneSignal init in Chrome 69 on http

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,6 +55,13 @@ export function isPushNotificationsSupported() {
   const browser = redetectBrowserUserAgent();
   let userAgent = navigator.userAgent || '';
 
+  // Chrome 69+ returns undefined for serviceWorker in insecure context but our workaround will work.
+  // Returning true.
+  if ((browser.chrome || (<any>browser).chromium) &&
+    window.isSecureContext === false && typeof navigator.serviceWorker === "undefined") {
+    return true;
+  }
+
   if (!browser.safari && typeof navigator.serviceWorker === "undefined") {
     /**
      * Browsers like Firefox Extended Support Release don't support service workers

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -56,6 +56,7 @@ export enum BrowserUserAgent {
   ChromeAndroidSupported = "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/42 Mobile Safari/535.19",
   ChromeWindowsSupported = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2228.0 Safari/537.36",
   ChromeMacSupported = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.1636.0 Safari/537.36",
+  ChromeMacSupported69 = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.81 Safari/537.36",
   ChromeLinuxSupported = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.1636.0 Safari/537.36",
   ChromeTabletSupported = "Mozilla/5.0 (Linux; Android 4.3; Nexus 10 Build/JWR66Y) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.1547.72 Safari/537.36",
   ChromeAndroidUnsupported = "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/41 Mobile Safari/535.19",
@@ -166,10 +167,13 @@ export class TestEnvironment {
     if (!config)
       config = {};
     let url: string | undefined = undefined;
+    let isSecureContext: boolean | undefined = undefined;
     if (config.httpOrHttps == HttpHttpsEnvironment.Http) {
       url = 'http://localhost:3000/webpush/sandbox?http=1';
+      isSecureContext = false;
     } else {
       url = 'https://localhost:3001/webpush/sandbox?https=1';
+      isSecureContext = true;
     }
     if (config.url) {
       url = config.url.toString();
@@ -212,6 +216,7 @@ export class TestEnvironment {
     const { TextEncoder, TextDecoder } = require('text-encoding');
     (windowDef as any).TextEncoder = TextEncoder;
     (windowDef as any).TextDecoder = TextDecoder;
+    (windowDef as any).isSecureContext = isSecureContext;
     TestEnvironment.addCustomEventPolyfill(windowDef);
 
     let topWindow = config.initializeAsIframe ? {

--- a/test/unit/modules/browserSupport.ts
+++ b/test/unit/modules/browserSupport.ts
@@ -5,11 +5,11 @@ import { isPushNotificationsSupported } from "../../../src/utils";
 import { setUserAgent } from '../../support/tester/browser';
 
 
-function shouldSupport(t, userAgent: BrowserUserAgent) {
+function shouldSupport(t: any, userAgent: BrowserUserAgent) {
   setUserAgent(userAgent);
   t.true(isPushNotificationsSupported(), `Expected ${BrowserUserAgent[userAgent]} to be supported`)
 }
-function shouldNotSupport(t, userAgent: BrowserUserAgent) {
+function shouldNotSupport(t: any, userAgent: BrowserUserAgent) {
   setUserAgent(userAgent);
   t.false(isPushNotificationsSupported(), `Expected ${BrowserUserAgent[userAgent]} to be unsupported`)
 }
@@ -95,9 +95,27 @@ test('should not support environments without service workers (except Safari)', 
     writable: true,
     value: undefined
   });
+
   setUserAgent(BrowserUserAgent.ChromeMacSupported);
   t.false(isPushNotificationsSupported(), `Expected push to be unsupported if service workers don't exist in a non-Safari browser`);
 
   setUserAgent(BrowserUserAgent.SafariSupportedMac);
   t.true(isPushNotificationsSupported(), `Expected push to be supported if service workers don't exist in Safari`)
+});
+
+test('should support Chrome 69+ on http', async t => {
+  (global as any).BrowserUserAgent = BrowserUserAgent;
+  await TestEnvironment.stubDomEnvironment({
+    httpOrHttps: HttpHttpsEnvironment.Http
+  });
+  // Remove serviceWorker from navigator for testing
+  Object.defineProperty(navigator, 'serviceWorker', {
+    enumerable: true,
+    configurable: true,
+    writable: true,
+    value: undefined
+  });
+
+  setUserAgent(BrowserUserAgent.ChromeMacSupported69);
+  t.true(isPushNotificationsSupported(), `Expected push to be supported in Chrome 69 on http`);
 });


### PR DESCRIPTION
Chrome 69 introduced a change that navigator.serviceWorker returns undefined in an insecure context, which http is. Our logic to determine if push is supported relies on service worker to be present and returns prematurely not letting init to happen.

This PR adds another check to the isPushNotificationsSupported to cover for this new use-case. If any other required parameters, like subdomain, are missing, OneSignal will fail during init and at least give a better error message for what exactly is wrong with the setup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/405)
<!-- Reviewable:end -->
