### PR TITLE
Safari 12.1 prompt

### DIFF
--- a/src/CustomLink.ts
+++ b/src/CustomLink.ts
@@ -96,7 +96,7 @@ export class CustomLink {
     }
     element.setAttribute(CustomLink.subscriptionStateAttribute, isPushEnabled.toString());
     if (!CustomLink.isInitialized(element)) {
-      element.addEventListener("click", async () => {
+      element.addEventListener("click", () => {
         Log.info("CustomLink: subscribe clicked");
         CustomLink.handleClick(element);
       });
@@ -113,20 +113,7 @@ export class CustomLink {
         await OneSignal.setSubscription(false);
       }
     } else {
-      if (OneSignalUtils.isUsingSubscriptionWorkaround()) {
-        // Show the HTTP popup so users can re-allow notifications
-        OneSignal.registerForPushNotifications();
-      } else {
-        const subscriptionState: PushSubscriptionState =
-          await OneSignal.context.subscriptionManager.getSubscriptionState();
-        if (!subscriptionState.subscribed) {
-          OneSignal.registerForPushNotifications();
-          return;
-        }
-        if (subscriptionState.optedOut) {
-          OneSignal.setSubscription(true);
-        }
-      }
+      await OneSignal.registerForPushNotifications();
     }
   }
 

--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -210,7 +210,7 @@ export class ConfigHelper {
               autoPrompt: serverConfig.config.staticPrompts.slidedown.enabled,
               actionMessage: serverConfig.config.staticPrompts.slidedown.actionMessage,
               acceptButtonText: serverConfig.config.staticPrompts.slidedown.acceptButton,
-              cancelButtonText: serverConfig.config.staticPrompts.slidedown.cancelButton
+              cancelButtonText: serverConfig.config.staticPrompts.slidedown.cancelButton,
             },
             fullscreen: {
               actionMessage: serverConfig.config.staticPrompts.fullscreen.actionMessage,
@@ -275,16 +275,20 @@ export class ConfigHelper {
               'dialog.blocked.message': serverConfig.config.staticPrompts.bell.dialog.blocked.message,
             }
           },
-          persistNotification: serverConfig.config.notificationBehavior.display.persist,
+          persistNotification: serverConfig.config.notificationBehavior ?
+            serverConfig.config.notificationBehavior.display.persist : undefined,
           webhooks: {
             cors: serverConfig.config.webhooks.corsEnable,
             'notification.displayed': serverConfig.config.webhooks.notificationDisplayedHook,
             'notification.clicked': serverConfig.config.webhooks.notificationClickedHook,
             'notification.dismissed': serverConfig.config.webhooks.notificationDismissedHook,
           },
-          notificationClickHandlerMatch: serverConfig.config.notificationBehavior.click.match,
-          notificationClickHandlerAction: serverConfig.config.notificationBehavior.click.action,
-          allowLocalhostAsSecureOrigin: serverConfig.config.setupBehavior.allowLocalhostAsSecureOrigin,
+          notificationClickHandlerMatch: serverConfig.config.notificationBehavior ?
+            serverConfig.config.notificationBehavior.click.match : undefined,
+          notificationClickHandlerAction: serverConfig.config.notificationBehavior ?
+            serverConfig.config.notificationBehavior.click.action : undefined,
+          allowLocalhostAsSecureOrigin: serverConfig.config.setupBehavior ?
+            serverConfig.config.setupBehavior.allowLocalhostAsSecureOrigin : undefined,
           requiresUserPrivacyConsent: userConfig.requiresUserPrivacyConsent
         };
       case IntegrationConfigurationKind.JavaScript:

--- a/src/helpers/MainHelper.ts
+++ b/src/helpers/MainHelper.ts
@@ -2,7 +2,7 @@ import { InvalidStateError, InvalidStateReason } from '../errors/InvalidStateErr
 import Event from '../Event';
 import SdkEnvironment from '../managers/SdkEnvironment';
 import Database from '../services/Database';
-import { AppUserConfigPromptOptions } from '../models/AppConfig';
+import { AppUserConfigPromptOptions, SlidedownPermissionMessageOptions } from '../models/AppConfig';
 import TimedLocalStorage from '../modules/TimedLocalStorage';
 import Log from '../libraries/Log';
 import { SubscriptionStateKind } from '../models/SubscriptionStateKind';
@@ -120,20 +120,37 @@ export default class MainHelper {
     return data;
   }
 
-  static getSlidedownPermissionMessageOptions(): AppUserConfigPromptOptions | null {
+  public static getSlidedownPermissionMessageOptions():
+    SlidedownPermissionMessageOptions {
+    const defaultActionMessage = "We'd like to show you notifications for the latest news and updates.";
+    const defaultAcceptButtonText = "Allow";
+    const defaultCancelButtonText = "No Thanks";
+
     const promptOptions: AppUserConfigPromptOptions = OneSignal.config.userConfig.promptOptions;
     if (!promptOptions) {
-      return null;
+      return {
+        autoPrompt: false,
+        actionMessage: defaultActionMessage,
+        acceptButtonText: defaultAcceptButtonText,
+        cancelButtonText: defaultCancelButtonText,
+      } as SlidedownPermissionMessageOptions;
     }
-    if (promptOptions && !promptOptions.slidedown) {
-      return promptOptions;
+
+    if (!promptOptions.slidedown) {
+      return {
+        autoPrompt: false,
+        actionMessage: promptOptions.actionMessage || defaultActionMessage,
+        acceptButtonText: promptOptions.acceptButtonText || defaultAcceptButtonText,
+        cancelButtonText: promptOptions.cancelButtonText || defaultCancelButtonText,
+      } as SlidedownPermissionMessageOptions;
     }
 
     return {
-      actionMessage: promptOptions.slidedown.actionMessage,
-      acceptButtonText: promptOptions.slidedown.acceptButtonText,
-      cancelButtonText: promptOptions.slidedown.cancelButtonText,
-    };
+      autoPrompt: promptOptions.slidedown.autoPrompt,
+      actionMessage: promptOptions.slidedown.actionMessage || defaultActionMessage,
+      acceptButtonText: promptOptions.slidedown.acceptButtonText || defaultAcceptButtonText,
+      cancelButtonText: promptOptions.slidedown.cancelButtonText || defaultCancelButtonText,
+    } as SlidedownPermissionMessageOptions;
   }
 
   static getFullscreenPermissionMessageOptions(): AppUserConfigPromptOptions | null {
@@ -141,7 +158,7 @@ export default class MainHelper {
     if (!promptOptions) {
       return null;
     }
-    if (promptOptions && !promptOptions.fullscreen) {
+    if (!promptOptions.fullscreen) {
       return promptOptions;
     }
 

--- a/src/helpers/SubscriptionHelper.ts
+++ b/src/helpers/SubscriptionHelper.ts
@@ -13,9 +13,14 @@ import SdkEnvironment from '../managers/SdkEnvironment';
 import { PermissionUtils } from "../utils/PermissionUtils";
 
 export default class SubscriptionHelper {
-  static async registerForPush(): Promise<Subscription | null> {
-    let subscription: Subscription;
+  public static async registerForPush(): Promise<Subscription | null> {
+    const isPushEnabled = await OneSignal.privateIsPushNotificationsEnabled();
+    return await SubscriptionHelper.internalRegisterForPush(isPushEnabled);
+  }
+
+  public static async internalRegisterForPush(isPushEnabled: boolean): Promise<Subscription | null> {
     const context: ContextSWInterface = OneSignal.context;
+    let subscription: Subscription;
 
     /*
       Within the same page navigation (the same session), do not register for
@@ -23,8 +28,6 @@ export default class SubscriptionHelper {
       session count incremented on each page refresh. However, if the user is
       not subscribed, subscribe.
     */
-    const isPushEnabled = await OneSignal.privateIsPushNotificationsEnabled();
-
     if (isPushEnabled && !context.sessionManager.isFirstPageView()) {
       Log.debug('Not registering for push because the user is subscribed and this is not the first page view.');
       return null;

--- a/src/popover/Popover.ts
+++ b/src/popover/Popover.ts
@@ -3,131 +3,123 @@ import bowser from 'bowser';
 import Event from '../Event';
 import MainHelper from '../helpers/MainHelper';
 import { addCssClass, addDomElement, once, removeDomElement, isChromeLikeBrowser } from '../utils';
-import { AppUserConfigPromptOptions } from '../models/AppConfig';
+import { SlidedownPermissionMessageOptions } from '../models/AppConfig';
 
 export default class Popover {
-
-    public options: AppUserConfigPromptOptions;
+    public options: SlidedownPermissionMessageOptions;
     public notificationIcons: any;
 
     static get EVENTS() {
-        return {
-            ALLOW_CLICK: 'popoverAllowClick',
-            CANCEL_CLICK: 'popoverCancelClick',
-            SHOWN: 'popoverShown',
-            CLOSED: 'popoverClosed',
-        };
+      return {
+        ALLOW_CLICK: 'popoverAllowClick',
+        CANCEL_CLICK: 'popoverCancelClick',
+        SHOWN: 'popoverShown',
+        CLOSED: 'popoverClosed',
+      };
     }
 
-    constructor(options: AppUserConfigPromptOptions) {
-        if (!options) {
-            (this.options as any) = {};
-        } else {
-            this.options = {...options};
-        }
-        if (!this.options['actionMessage'] || typeof this.options['actionMessage'] !== "string")
-            this.options['actionMessage'] = "We'd like to show you notifications for the latest news and updates.";
-        if (!this.options['acceptButtonText'] || typeof this.options['acceptButtonText'] !== "string")
-            this.options['acceptButtonText'] = "Allow";
-        if (!this.options['cancelButtonText'] || typeof this.options['cancelButtonText'] !== "string")
-            this.options['cancelButtonText'] = "No Thanks";
-        this.options['actionMessage'] = this.options['actionMessage'].substring(0, 90);
-        this.options['acceptButtonText'] = this.options['acceptButtonText'].substring(0, 15);
-        this.options['cancelButtonText'] = this.options['cancelButtonText'].substring(0, 15);
+    constructor(options?: SlidedownPermissionMessageOptions) {
+      if (!options) {
+          options = MainHelper.getSlidedownPermissionMessageOptions();
+      }
+      this.options = options;
+      this.options.actionMessage = options.actionMessage.substring(0, 90);
+      this.options.acceptButtonText = options.acceptButtonText.substring(0, 15);
+      this.options.cancelButtonText = options.cancelButtonText.substring(0, 15);
 
-        this.notificationIcons = null;
+      this.notificationIcons = null;
     }
 
     async create() {
-        if (this.notificationIcons === null) {
-            const icons = await MainHelper.getNotificationIcons();
+      if (this.notificationIcons === null) {
+        const icons = await MainHelper.getNotificationIcons();
 
-            this.notificationIcons = icons;
+        this.notificationIcons = icons;
 
-            // Remove any existing container
-            if (this.container) {
-                removeDomElement('#onesignal-popover-container');
-            }
-
-            let icon = this.getPlatformNotificationIcon();
-            let defaultIcon = `data:image/svg+xml;charset=utf-8,%3Csvg%20width%3D%2239.5%22%20height%3D%2240.5%22%20viewBox%3D%220%200%2079%2081%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EOneSignal-Bell%3C%2Ftitle%3E%3Cg%20fill%3D%22%23BBB%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M39.96%2067.12H4.12s-3.2-.32-3.2-3.36%202.72-3.2%202.72-3.2%2010.72-5.12%2010.72-8.8c0-3.68-1.76-6.24-1.76-21.28%200-15.04%209.6-26.56%2021.12-26.56%200%200%201.6-3.84%206.24-3.84%204.48%200%206.08%203.84%206.08%203.84%2011.52%200%2021.12%2011.52%2021.12%2026.56s-1.6%2017.6-1.6%2021.28c0%203.68%2010.72%208.8%2010.72%208.8s2.72.16%202.72%203.2c0%202.88-3.36%203.36-3.36%203.36H39.96zM27%2070.8h24s-1.655%2010.08-11.917%2010.08S27%2070.8%2027%2070.8z%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E`;
-
-            let dialogHtml = `<div id="normal-popover"><div class="popover-body"><div class="popover-body-icon"><img alt="notification icon" class="${icon === 'default-icon' ? 'default-icon' : ''}" src="${icon === 'default-icon' ? defaultIcon : icon}"></div><div class="popover-body-message">${this.options['actionMessage']}</div><div class="clearfix"></div></div><div class="popover-footer"><button id="onesignal-popover-allow-button" class="align-right primary popover-button">${this.options['acceptButtonText']}</button><button id="onesignal-popover-cancel-button" class="align-right secondary popover-button">${this.options['cancelButtonText']}</button><div class="clearfix"></div></div></div>`;
-
-            // Insert the container
-            addDomElement('body', 'beforeend',
-              '<div id="onesignal-popover-container" class="onesignal-popover-container onesignal-reset"></div>');
-            // Insert the dialog
-            addDomElement(this.container, 'beforeend',
-              `<div id="onesignal-popover-dialog" class="onesignal-popover-dialog">${dialogHtml}</div>`);
-            // Animate it in depending on environment
-            addCssClass(this.container, bowser.mobile ? 'slide-up' : 'slide-down');
-            // Add click event handlers
-            this.allowButton.addEventListener('click', this.onPopoverAllowed.bind(this));
-            this.cancelButton.addEventListener('click', this.onPopoverCanceled.bind(this));
-            Event.trigger(Popover.EVENTS.SHOWN);
+        // Remove any existing container
+        if (this.container) {
+            removeDomElement('#onesignal-popover-container');
         }
+
+        let icon = this.getPlatformNotificationIcon();
+        let defaultIcon = `data:image/svg+xml;charset=utf-8,%3Csvg%20width%3D%2239.5%22%20height%3D%2240.5%22%20viewBox%3D%220%200%2079%2081%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Ctitle%3EOneSignal-Bell%3C%2Ftitle%3E%3Cg%20fill%3D%22%23BBB%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M39.96%2067.12H4.12s-3.2-.32-3.2-3.36%202.72-3.2%202.72-3.2%2010.72-5.12%2010.72-8.8c0-3.68-1.76-6.24-1.76-21.28%200-15.04%209.6-26.56%2021.12-26.56%200%200%201.6-3.84%206.24-3.84%204.48%200%206.08%203.84%206.08%203.84%2011.52%200%2021.12%2011.52%2021.12%2026.56s-1.6%2017.6-1.6%2021.28c0%203.68%2010.72%208.8%2010.72%208.8s2.72.16%202.72%203.2c0%202.88-3.36%203.36-3.36%203.36H39.96zM27%2070.8h24s-1.655%2010.08-11.917%2010.08S27%2070.8%2027%2070.8z%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E`;
+
+        let dialogHtml = `<div id="normal-popover"><div class="popover-body"><div class="popover-body-icon"><img alt="notification icon" class="${icon === 'default-icon' ? 'default-icon' : ''}" src="${icon === 'default-icon' ? defaultIcon : icon}"></div><div class="popover-body-message">${this.options['actionMessage']}</div><div class="clearfix"></div></div><div class="popover-footer"><button id="onesignal-popover-allow-button" class="align-right primary popover-button">${this.options['acceptButtonText']}</button><button id="onesignal-popover-cancel-button" class="align-right secondary popover-button">${this.options['cancelButtonText']}</button><div class="clearfix"></div></div></div>`;
+
+        // Insert the container
+        addDomElement('body', 'beforeend',
+            '<div id="onesignal-popover-container" class="onesignal-popover-container onesignal-reset"></div>');
+        // Insert the dialog
+        addDomElement(this.container, 'beforeend',
+            `<div id="onesignal-popover-dialog" class="onesignal-popover-dialog">${dialogHtml}</div>`);
+        // Animate it in depending on environment
+        addCssClass(this.container, bowser.mobile ? 'slide-up' : 'slide-down');
+        // Add click event handlers
+        this.allowButton.addEventListener('click', this.onPopoverAllowed.bind(this));
+        this.cancelButton.addEventListener('click', this.onPopoverCanceled.bind(this));
+        Event.trigger(Popover.EVENTS.SHOWN);
+      }
     }
 
-    onPopoverAllowed(_) {
-        Event.trigger(Popover.EVENTS.ALLOW_CLICK);
+    async onPopoverAllowed(_: any) {
+      await Event.trigger(Popover.EVENTS.ALLOW_CLICK);
     }
 
-    onPopoverCanceled(_) {
-        Event.trigger(Popover.EVENTS.CANCEL_CLICK);
-        this.close();
+    onPopoverCanceled(_: any) {
+      Event.trigger(Popover.EVENTS.CANCEL_CLICK);
+      this.close();
     }
 
     close() {
-        addCssClass(this.container, 'close-popover');
-        once(this.dialog, 'animationend', (event, destroyListenerFn) => {
-            if (event.target === this.dialog &&
-                (event.animationName === 'slideDownExit' || event.animationName === 'slideUpExit')) {
-                // Uninstall the event listener for animationend
-                removeDomElement('#onesignal-popover-container');
-                destroyListenerFn();
-                Event.trigger(Popover.EVENTS.CLOSED);
-            }
-        }, true);
+      addCssClass(this.container, 'close-popover');
+      once(this.dialog, 'animationend', (event, destroyListenerFn) => {
+        if (event.target === this.dialog &&
+            (event.animationName === 'slideDownExit' || event.animationName === 'slideUpExit')) {
+            // Uninstall the event listener for animationend
+            removeDomElement('#onesignal-popover-container');
+            destroyListenerFn();
+            Event.trigger(Popover.EVENTS.CLOSED);
+        }
+      }, true);
     }
 
     getPlatformNotificationIcon() {
-        if (this.notificationIcons) {
-            if (isChromeLikeBrowser() || bowser.firefox || bowser.msedge) {
-                if (this.notificationIcons.chrome) {
-                    return this.notificationIcons.chrome;
-                } else if (this.notificationIcons.firefox) {
-                    return this.notificationIcons.firefox;
-                } else {
-                    return 'default-icon';
-                }
-            }
-            else if (bowser.safari) {
-                if (this.notificationIcons.safari) {
-                    return this.notificationIcons.safari;
-                } else if (this.notificationIcons.chrome) {
-                    return this.notificationIcons.chrome;
-                } else {
-                    return 'default-icon';
-                }
-            }
+      if (this.notificationIcons) {
+        if (isChromeLikeBrowser() || bowser.firefox || bowser.msedge) {
+          if (this.notificationIcons.chrome) {
+            return this.notificationIcons.chrome;
+          } else if (this.notificationIcons.firefox) {
+            return this.notificationIcons.firefox;
+          } else {
+            return 'default-icon';
+          }
         }
-        else return 'default-icon';
+        else if (bowser.safari) {
+          if (this.notificationIcons.safari) {
+            return this.notificationIcons.safari;
+          } else if (this.notificationIcons.chrome) {
+            return this.notificationIcons.chrome;
+          } else {
+            return 'default-icon';
+          }
+        }
+      }
+      else return 'default-icon';
     }
 
     get container() {
-        return document.querySelector('#onesignal-popover-container');
+      return document.querySelector('#onesignal-popover-container');
     }
 
     get dialog() {
-        return document.querySelector('#onesignal-popover-dialog');
+      return document.querySelector('#onesignal-popover-dialog');
     }
 
     get allowButton() {
-        return document.querySelector('#onesignal-popover-allow-button');
+      return document.querySelector('#onesignal-popover-allow-button');
     }
 
     get cancelButton() {
-        return document.querySelector('#onesignal-popover-cancel-button');
+      return document.querySelector('#onesignal-popover-cancel-button');
     }
 }

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -97,10 +97,10 @@ export default class Database {
    * @returns {Promise} Returns a promise that fulfills when the value(s) are available.
    */
   async get<T>(table: OneSignalDbTable, key?: string): Promise<T> {
-    return await new Promise<T>(async (resolve) => {
-      if (SdkEnvironment.getWindowEnv() !== WindowEnvironmentKind.ServiceWorker &&
-          OneSignalUtils.isUsingSubscriptionWorkaround() &&
-          SdkEnvironment.getTestEnv() === TestEnvironmentKind.None) {
+    if (SdkEnvironment.getWindowEnv() !== WindowEnvironmentKind.ServiceWorker &&
+        OneSignalUtils.isUsingSubscriptionWorkaround() &&
+        SdkEnvironment.getTestEnv() === TestEnvironmentKind.None) {
+      return await new Promise<T>(async (resolve) => {
         OneSignal.proxyFrameHost.message(OneSignal.POSTMAM_COMMANDS.REMOTE_DATABASE_GET, [{
           table: table,
           key: key
@@ -108,12 +108,12 @@ export default class Database {
           let result = reply.data[0];
           resolve(result);
         });
-      } else {
-        const result = await this.database.get(table, key);
-        let cleanResult = Database.applyDbResultFilter(table, key, result);
-        resolve(cleanResult);
-      }
-    });
+      });
+    } else {
+      const result = await this.database.get(table, key);
+      let cleanResult = Database.applyDbResultFilter(table, key, result);
+      return cleanResult;
+    }
   }
 
   /**
@@ -341,55 +341,63 @@ export default class Database {
   }
 
   static async setEmailProfile(emailProfile: EmailProfile) {
-    return Database.singletonInstance.setEmailProfile.call(Database.singletonInstance, emailProfile);
+    return await Database.singletonInstance.setEmailProfile(emailProfile);
   }
+
   static async getEmailProfile(): Promise<EmailProfile> {
-    return Database.singletonInstance.getEmailProfile.call(Database.singletonInstance);
+    return await Database.singletonInstance.getEmailProfile();
   }
 
   static async setSubscription(subscription: Subscription) {
-    return Database.singletonInstance.setSubscription.call(Database.singletonInstance, subscription);
+    return await Database.singletonInstance.setSubscription(subscription);
   }
+
   static async getSubscription(): Promise<Subscription> {
-    return Database.singletonInstance.getSubscription.call(Database.singletonInstance);
+    return await Database.singletonInstance.getSubscription();
   }
 
   static async setProvideUserConsent(consent: boolean): Promise<void> {
-    return Database.singletonInstance.setProvideUserConsent.call(Database.singletonInstance, consent);
+    return await Database.singletonInstance.setProvideUserConsent(consent);
   }
+
   static async getProvideUserConsent(): Promise<boolean> {
-    return Database.singletonInstance.getProvideUserConsent.call(Database.singletonInstance);
+    return await Database.singletonInstance.getProvideUserConsent();
   }
 
   static async setServiceWorkerState(workerState: ServiceWorkerState) {
-    return Database.singletonInstance.setServiceWorkerState.call(Database.singletonInstance, workerState);
+    return await Database.singletonInstance.setServiceWorkerState(workerState);
   }
+
   static async getServiceWorkerState(): Promise<ServiceWorkerState> {
-    return Database.singletonInstance.getServiceWorkerState.call(Database.singletonInstance);
+    return await Database.singletonInstance.getServiceWorkerState();
   }
 
   static async setAppState(appState: AppState) {
-    return Database.singletonInstance.setAppState.call(Database.singletonInstance, appState);
+    return await Database.singletonInstance.setAppState(appState);
   }
+
   static async getAppState(): Promise<AppState> {
-    return Database.singletonInstance.getAppState.call(Database.singletonInstance);
+    return await Database.singletonInstance.getAppState();
   }
 
   static async setAppConfig(appConfig: AppConfig) {
-    return Database.singletonInstance.setAppConfig.call(Database.singletonInstance, appConfig);
-  }
-  static async getAppConfig(): Promise<AppConfig> {
-    return Database.singletonInstance.getAppConfig.call(Database.singletonInstance);
+    return await Database.singletonInstance.setAppConfig(appConfig);
   }
 
-  static async remove(table: string, keypath?: string) {
-    return Database.singletonInstance.remove.call(Database.singletonInstance, table, keypath);
+  static async getAppConfig(): Promise<AppConfig> {
+    return await Database.singletonInstance.getAppConfig();
   }
-  static async put(table: string, keypath: any) {
-    return Database.singletonInstance.put.call(Database.singletonInstance, table, keypath);
+
+  static async remove(table: OneSignalDbTable, keypath?: string) {
+    return await Database.singletonInstance.remove(table, keypath);
   }
-  static async get<T>(table: string, key?: string): Promise<T> {
-    return Database.singletonInstance.get.call(Database.singletonInstance, table, key);
+
+  static async put(table: OneSignalDbTable, keypath: any) {
+    return await Database.singletonInstance.put(table, keypath);
   }
-  // END: Static mappings to instance methods
+
+  static async get<T>(table: OneSignalDbTable, key?: string): Promise<T> {
+    return await Database.singletonInstance.get<T>(table, key);
+  }
+    // END: Static mappings to instance methods
 }

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -51,6 +51,7 @@ export enum BrowserUserAgent {
   FirefoxLinuxSupported = "Mozilla/5.0 (X11; Linux i686 on x86_64; rv:44.0) Gecko/20100101 Firefox/44.0",
   SafariUnsupportedMac= "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/538.32 (KHTML, like Gecko) Version/7.0 Safari/538.4",
   SafariSupportedMac= "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/538.32 (KHTML, like Gecko) Version/7.1 Safari/538.4",
+  SafariSupportedMac121= "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Safari/605.1.15",
   FacebookBrowseriOS = "Mozilla/5.0 (iPhone; CPU iPhone OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12D508 [FBAN/FBIOS;FBAV/27.0.0.10.12;FBBV/8291884;FBDV/iPhone7,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/8.2;FBSS/3;]",
   FacebookBrowserAndroid = "Mozilla/5.0 (Linux; Android 5.1; Archos Diamond S Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.81 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/87.0.0.17.79;]",
   ChromeAndroidSupported = "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/42 Mobile Safari/535.19",

--- a/test/unit/onesignal/registerForPushNotifications.ts
+++ b/test/unit/onesignal/registerForPushNotifications.ts
@@ -1,0 +1,81 @@
+import "../../support/polyfills/polyfills";
+import test from 'ava';
+import sinon, { SinonSandbox } from 'sinon';
+import { TestEnvironment, HttpHttpsEnvironment, BrowserUserAgent } from '../../support/sdk/TestEnvironment';
+import OneSignalUtils from "../../../src/utils/OneSignalUtils";
+import InitHelper from "../../../src/helpers/InitHelper";
+import { setBrowser } from '../../support/tester/browser';
+import SubscriptionHelper from "../../../src/helpers/SubscriptionHelper";
+import Event from '../../../src/Event';
+
+let sandbox: SinonSandbox;
+
+test.beforeEach(async () => {
+  sandbox = sinon.sandbox.create();
+  await TestEnvironment.initialize({
+    addPrompts: true,
+    httpOrHttps: HttpHttpsEnvironment.Https,
+  });
+  TestEnvironment.mockInternalOneSignal();
+});
+
+test.afterEach(function () {
+  sandbox.restore();
+});
+
+test('registerForPushNotifications: before OneSignal.initialized', async (t) => {
+  (global as any).OneSignal.initialized = false;
+  (global as any).OneSignal._initCalled = false;
+
+  const utilsStub = sandbox.stub(OneSignalUtils, 'isUsingSubscriptionWorkaround').returns(false);
+  sandbox.stub(InitHelper, 'sessionInit').resolves();
+  const promise = OneSignal.registerForPushNotifications();
+  const newPromise = new Promise((resolve, reject) => {
+    promise.then(() => {
+      t.is(OneSignal.initialized, true);
+      t.is(utilsStub.calledOnce, true);
+      resolve();
+    });
+  });
+
+  Event.trigger(OneSignal.EVENTS.SDK_INITIALIZED);
+  await newPromise;
+});
+
+test('registerForPushNotifications: after OneSignal.initialized and using subscription workaround', async (t) => {
+  t.is(OneSignal.initialized, true);
+
+  const utilsStub = sandbox.stub(OneSignalUtils, 'isUsingSubscriptionWorkaround').returns(true);
+  const loadStub = sandbox.stub(InitHelper, 'loadSubscriptionPopup').resolves();
+  await OneSignal.registerForPushNotifications();
+
+  t.is(utilsStub.calledOnce, true);
+  t.is(loadStub.calledOnce, true);
+});
+
+test(
+  'registerForPushNotifications: after OneSignal.initialized and not using subscription workaround and safari < 12.1',
+  async (t) => {
+    setBrowser(BrowserUserAgent.ChromeMacSupported);
+
+    t.is(OneSignal.initialized, true);
+
+    const utilsStub = sandbox.stub(OneSignalUtils, 'isUsingSubscriptionWorkaround').returns(false);
+    const loadStub = sandbox.stub(InitHelper, 'sessionInit').resolves();
+    await OneSignal.registerForPushNotifications();
+    t.is(utilsStub.calledOnce, true);
+    t.is(loadStub.calledOnce, true);
+});
+
+test('registerForPushNotifications: after OneSignal.initialized and not using subscription workaround and safari 12.1',
+  async (t) => {
+    setBrowser(BrowserUserAgent.SafariSupportedMac121);
+    t.is(OneSignal.initialized, true);
+
+
+    sandbox.stub(OneSignalUtils, 'isUsingSubscriptionWorkaround').returns(false);
+
+    const loadStub = sandbox.stub(SubscriptionHelper, 'internalRegisterForPush').resolves();
+    await OneSignal.registerForPushNotifications();
+    t.is(loadStub.calledOnce, true);
+});

--- a/test/unit/prompts/CustomLink.ts
+++ b/test/unit/prompts/CustomLink.ts
@@ -6,6 +6,7 @@ import CustomLink from '../../../src/CustomLink';
 import OneSignalUtils from '../../../src/utils/OneSignalUtils';
 import { ResourceLoadState } from '../../../src/services/DynamicResourceLoader';
 import { hasCssClass } from '../../../src/utils';
+import MainHelper from "../../../src/helpers/MainHelper";
 
 let sandbox: SinonSandbox;
 let config: AppUserConfigCustomLinkOptions;
@@ -225,8 +226,9 @@ test('customlink: subscribe: clicked: subscribed -> unsubscribed', async t => {
 test('customlink: subscribe: clicked: unsubscribed -> subscribed. https. opted out', async t => {
   sandbox.stub(OneSignal, 'privateIsPushNotificationsEnabled').returns(false);
   const subscriptionSpy = sandbox.stub(OneSignal, 'setSubscription').resolves();
-  sandbox.stub(OneSignal, 'registerForPushNotifications').resolves();
   sandbox.stub(OneSignalUtils, 'isUsingSubscriptionWorkaround').returns(false);
+  sandbox.stub(MainHelper, 'wasHttpsNativePromptDismissed').returns(false);
+  sandbox.stub(OneSignal, 'internalIsOptedOut').returns(true);
   sandbox.stub(OneSignal.context.subscriptionManager, 'getSubscriptionState').returns({
     subscribed: true,
     optedOut: true,


### PR DESCRIPTION
Prompting for push notifications in Safari will start requiring user interaction.
https://webkit.org/blog/8406/release-notes-for-safari-technology-preview-64/

Show our slide down prompt if auto prompt is on or if it is called directly from the site's JS without any interaction.

Safari interaction seems to have conflicts with accessing IndexedDB, added a workaround for specific version of safari in registerForPushNotification because it was affecting all prompts and this is the most logical place to do it.

Also made registerForPushNotifications async so that it can be awaited in tests if needed and it now works as setSubscription(true) if user previously subscribed, no need to call it separately. Yay!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/418)
<!-- Reviewable:end -->
