### PR TITLE
Reading autoRegister flag from server config for typical setup

### DIFF
--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -200,7 +200,7 @@ export class ConfigHelper {
         */
         return {
           appId: serverConfig.app_id,
-          autoRegister: false,
+          autoRegister: !!serverConfig.config.autoRegister,
           path: serverConfig.config.serviceWorker.path,
           serviceWorkerPath: serverConfig.config.serviceWorker.workerName,
           serviceWorkerUpdaterPath: serverConfig.config.serviceWorker.updaterWorkerName,

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -296,6 +296,7 @@ export interface ServerAppConfig {
     /**
      * The allowed origin this web push config is allowed to run on.
      */
+    autoRegister: boolean | undefined;
     origin: string;
     staticPrompts: ServerAppConfigPrompt;
     siteInfo: {

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -19,7 +19,6 @@ import ServiceWorkerRegistration from '../mocks/service-workers/models/ServiceWo
 import PushManager from "../mocks/service-workers/models/PushManager";
 import PushSubscription from "../mocks/service-workers/models/PushSubscription";
 import Context from "../../../src/models/Context";
-import { SessionManager } from "../../../src/managers/SessionManager";
 import CustomLink from "../../../src/CustomLink";
 
 var global = new Function('return this')();
@@ -345,6 +344,7 @@ export class TestEnvironment {
           }
         },
         config: {
+          autoRegister: undefined,
           siteInfo: {
             name: "localhost https",
             origin: "https://localhost:3001",
@@ -496,6 +496,7 @@ export class TestEnvironment {
         }
       },
       config: {
+        autoRegister: false,
         origin: "https://example.com",
         subdomain: undefined,
         http_use_onesignal_com: false,

--- a/test/unit/managers/ConfigManager.ts
+++ b/test/unit/managers/ConfigManager.ts
@@ -96,10 +96,14 @@ test('should initialize custom link config for custom code setup with correct us
     fakeServerConfig
   );
 
-  const customLinkConfig: AppUserConfigCustomLinkOptions = fakeUserConfig.promptOptions.customlink;
-  t.not(fakeMergedConfig.userConfig.promptOptions, undefined);
-  if (fakeMergedConfig.userConfig.promptOptions) {
-    t.deepEqual(fakeMergedConfig.userConfig.promptOptions.customlink, customLinkConfig);
+  if (!fakeUserConfig.promptOptions) {
+    t.fail();
+  } else {
+    const customLinkConfig: AppUserConfigCustomLinkOptions | undefined = fakeUserConfig.promptOptions.customlink;
+    t.not(fakeMergedConfig.userConfig.promptOptions, undefined);
+    if (fakeMergedConfig.userConfig.promptOptions) {
+      t.deepEqual(fakeMergedConfig.userConfig.promptOptions.customlink, customLinkConfig);
+    }
   }
 });
 
@@ -150,4 +154,20 @@ test('should have enableOnSession flag', t => {
   );
 
   t.not(fakeMergedConfig.enableOnSession, undefined);
+});
+
+test('should assign correct value for autoRegister for typical setup', t=> {
+  const fakeUserConfig: AppUserConfig = TestEnvironment.getFakeAppUserConfig();
+  const fakeServerConfig: ServerAppConfig =
+    TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.TypicalSite);
+  const configManager = new ConfigManager();
+
+  fakeServerConfig.config.autoRegister = false;
+  t.false(configManager.getMergedConfig(fakeUserConfig, fakeServerConfig).userConfig.autoRegister);
+
+  fakeServerConfig.config.autoRegister = true;
+  t.true(configManager.getMergedConfig(fakeUserConfig, fakeServerConfig).userConfig.autoRegister);
+
+  fakeServerConfig.config.autoRegister = undefined;
+  t.false(configManager.getMergedConfig(fakeUserConfig, fakeServerConfig).userConfig.autoRegister);
 });


### PR DESCRIPTION
Defaults to false if not passed.
Will be complemented with changes for dashboard but should first start supporting it in web sdk.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/471)
<!-- Reviewable:end -->
