### PR TITLE
Script which fetches all Firefox ESR build versions

### DIFF
--- a/build/scripts/FIREFOX_ESR_SCRIPT.sh
+++ b/build/scripts/FIREFOX_ESR_SCRIPT.sh
@@ -1,0 +1,26 @@
+echo '{
+    "aggs": {
+        "buildid": {
+            "terms": {
+                "field": "build.id",
+                "size": 1000
+            }
+        }
+    },
+    "query": {
+        "bool": {
+            "filter": [
+                {
+                    "term": {
+                        "source.product": "firefox"
+                    }
+                }, {
+                    "term": {
+                        "target.channel": "esr"
+                    }
+                }
+            ]
+        }
+    },
+    "size": 0
+}' | curl https://buildhub.prod.mozaws.net/v1/buckets/build-hub/collections/releases/search --data @- | jq -r '.aggregations.buildid.buckets[].key' | sort -u


### PR DESCRIPTION
Just to make sure we don't loose this script, saving it into the repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/489)
<!-- Reviewable:end -->
