### PR TITLE
Now always loading ES6 stub as an intermediate

### DIFF
--- a/build/config/sdk.config.js
+++ b/build/config/sdk.config.js
@@ -129,7 +129,8 @@ async function generateWebpackConfig() {
                 'PushNotSupportedError',
                 'PushPermissionNotGrantedError',
                 'SdkInitError',
-                'TimeoutError'
+                'TimeoutError',
+                'OneSignalStubES6'
               ]
             } : false,
             output: {

--- a/src/entries/pageSdkInit.ts
+++ b/src/entries/pageSdkInit.ts
@@ -20,9 +20,9 @@ function oneSignalSdkInit() {
 
   // We're running in the host page, iFrame of the host page, or popup window
   // Load OneSignal's web SDK
-  const predefinedOneSignal: OneSignalStubES6 | object[] | undefined | null = (window as any).OneSignal;
+  const predefinedOneSignal: OneSignalStubES6 | object[] | undefined | null = (<any>window).OneSignal;
 
-  (window as any).OneSignal = require('../OneSignal').default;
+  (<any>window).OneSignal = require('../OneSignal').default;
 
   ReplayCallsOnOneSignal.doReplay(predefinedOneSignal);
 }

--- a/src/entries/sdk.ts
+++ b/src/entries/sdk.ts
@@ -1,6 +1,7 @@
 /**
  * This is OneSignalSDK.js (ES5)
  *   * This is an entry point for pages and older service workers.
+ *       - Developers are now instructed to use OneSignalSDKWorker.js directly for service workers
  *   * Also we define a ES5 Stub for OneSignal for browsers that do not support push.
  * This is a shim to detect and load either;
  *   * ServiceWorkerSDK (ES6) - OneSignalSDKWorker.js

--- a/src/utils/OneSignalStub.ts
+++ b/src/utils/OneSignalStub.ts
@@ -1,6 +1,8 @@
 // NOTE: This is used with the OneSignalSDK.js shim
 // Careful if adding imports, ES5 targets can't clean up functions never called.
 
+export type PossiblePredefinedOneSignal = Array<Object[] | Function> | undefined | null;
+
 export abstract class OneSignalStub<T> implements IndexableByString<any> {
   public VERSION = (typeof __VERSION__) === "undefined" ? 1 : Number(__VERSION__);
   public SERVICE_WORKER_UPDATER_PATH: string | undefined;

--- a/src/utils/OneSignalStubES6.ts
+++ b/src/utils/OneSignalStubES6.ts
@@ -1,7 +1,7 @@
 // NOTE: This is used with the OneSignalSDK.js shim
 // Careful if adding imports, ES5 targets can't clean up functions never called.
 
-import { OneSignalStub } from "./OneSignalStub";
+import { OneSignalStub, PossiblePredefinedOneSignal } from "./OneSignalStub";
 
 export class OneSignalStubES6 extends OneSignalStub<OneSignalStubES6> {
 
@@ -10,10 +10,19 @@ export class OneSignalStubES6 extends OneSignalStub<OneSignalStubES6> {
     return true;
   }
 
-  public constructor() {
+  public constructor(preExistingArray?: PossiblePredefinedOneSignal) {
     super(Object.getOwnPropertyNames(OneSignalStubES6.prototype));
+    this.preExistingArray = preExistingArray;
   }
 
+  // These 2 arrays contain calls that need to be made on the OneSignal class
+  //   after OneSignalPageSDKES6.js is load.
+  // ReplayCallsOnOneSignal.doReplay() will do the processing on these.
+
+  // This array will contain any pre-existing array BEFORE OneSignalSDK.js was loaded
+  public preExistingArray: PossiblePredefinedOneSignal;
+  // This array will contain calls made on windows.OneSignal (w/ push or direct method calls)
+  //   AFTER OneSignalSDK.js was loaded, BUT before OneSignalPageSDKES6.js was loaded.
   public directFunctionCallsArray = new Array<DelayedFunctionCall<any>>();
 
   // @Override

--- a/src/utils/ReplayCallsOnOneSignal.ts
+++ b/src/utils/ReplayCallsOnOneSignal.ts
@@ -43,7 +43,13 @@ export class ReplayCallsOnOneSignal {
     if (stubOneSignal.SERVICE_WORKER_PARAM)
       OneSignal.SERVICE_WORKER_PARAM = stubOneSignal.SERVICE_WORKER_PARAM;
 
-    // Run methods in order, including firing any promises
+    // 1. Process any array defined BEFORE stubOneSignal was loaded
+    if (stubOneSignal.preExistingArray) {
+      ReplayCallsOnOneSignal.processAsArray(stubOneSignal.preExistingArray);
+    }
+
+    // 2. Process any array defined AFTER stubOneSignal was loaded
+    //    Runs methods in order, including firing any promises
     for(const item of stubOneSignal.directFunctionCallsArray) {
       const functionToCall = OneSignal[item.functionName];
 


### PR DESCRIPTION
* Now always loading the ES6 stub on browsers that support push as some site expect window.OneSignal always be present after OneSignalSDK.js is loaded
  - Example: Using script.onload = () => { var oneSignal || []; oneSignal.push(...); }
* Now uses predefinedOneSignal array if it exists before even a stub is loaded. Both ES5 and ES6.
   - Defined as stubOneSignal.preExistingArray and is replayed first, to maintain call order.
* Added tests to cover these cases.
* Added OneSignalStubES6 to the mangle.reserved list so stubOneSignal.constructor.name works in ReplayCallsOnOneSignal
  - Prevents the class name from being minified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/491)
<!-- Reviewable:end -->
