### PR TITLE
Fixed ES5 console errors with OneSignal.push(())

### DIFF
--- a/src/utils/OneSignalStubES5.ts
+++ b/src/utils/OneSignalStubES5.ts
@@ -12,6 +12,7 @@ export class OneSignalStubES5 extends OneSignalStub<OneSignalStubES5> {
 
   public constructor(stubOneSignal?: PossiblePredefinedOneSignal) {
     super(Object.getOwnPropertyNames(OneSignalStubES5.prototype));
+    (<any>window).OneSignal = this;
     this.playPushes(stubOneSignal);
   }
 

--- a/test/unit/modules/entryInitialization.ts
+++ b/test/unit/modules/entryInitialization.ts
@@ -11,6 +11,7 @@ import { OneSignalShimLoader } from "../../../src/utils/OneSignalShimLoader";
 import { SinonSandbox } from "sinon";
 import sinon from 'sinon';
 import { setUserAgent } from "../../support/tester/browser";
+import Log from "../../../src/libraries/Log";
 
 let sandbox: SinonSandbox;
 
@@ -466,12 +467,17 @@ test("Existing OneSignal array before OneSignalSDK.js loaded ES6", async t => {
 
 test("Existing OneSignal array before OneSignalSDK.js loaded ES5", async t => {
   setUserAgent(BrowserUserAgent.IE11); // ES5 browser
+  const logErrorSpy = sandbox.spy(Log, "error");
 
   let didCallFunction = false;
-  const preExistingArray = [() => { didCallFunction = true; }];
+  const preExistingArray = [() => {
+    didCallFunction = true;
+    (<any>window).OneSignal.setDefaultNotificationUrl("test");
+  }];
   (<any>window).OneSignal = preExistingArray;
 
   OneSignalShimLoader.start();
 
   t.true(didCallFunction);
+  t.false(logErrorSpy.called);
 });


### PR DESCRIPTION
* If OneSignal.push(function() {...}) contains calls to OneSignal they print an error to the console.
* This won't have effected behavior for most functions called on OneSignal.
  - Exceptions being isPushNotificationsEnabled, isPushNotificationsSupported, and push.
* Fixes #494

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/495)
<!-- Reviewable:end -->
