### PR TITLE
Delaying evaluation of displayPredicate until sdk finishes initializing

### DIFF
--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -336,15 +336,17 @@ export default class InitHelper {
         };
       }
 
-     const displayPredicate: () => boolean = OneSignal.config.userConfig.notifyButton.displayPredicate;
+      const displayPredicate: () => boolean = OneSignal.config.userConfig.notifyButton.displayPredicate;
       if (displayPredicate && typeof displayPredicate === 'function') {
-        const predicateValue = await Promise.resolve(OneSignal.config.userConfig.notifyButton.displayPredicate());
-        if (predicateValue !== false) {
-          OneSignal.notifyButton = new Bell(OneSignal.config.userConfig.notifyButton);
-          OneSignal.notifyButton.create();
-        } else {
-          Log.debug('Notify button display predicate returned false so not showing the notify button.');
-        }
+        OneSignal.emitter.once(OneSignal.EVENTS.SDK_INITIALIZED, async () => {
+          const predicateValue = await Promise.resolve(OneSignal.config.userConfig.notifyButton.displayPredicate());
+          if (predicateValue !== false) {
+            OneSignal.notifyButton = new Bell(OneSignal.config.userConfig.notifyButton);
+            OneSignal.notifyButton.create();
+          } else {
+            Log.debug('Notify button display predicate returned false so not showing the notify button.');
+          }
+        });
       } else {
         OneSignal.notifyButton = new Bell(OneSignal.config.userConfig.notifyButton);
         OneSignal.notifyButton.create();


### PR DESCRIPTION
Creation of a bell prompt is part of initialization. However if hideWhenSubscribed for typical setup is enabled, or displayPredicate for custom code uses any code dependent on sdk initialization, its evaluation blocks the init. Delaying the evaluation until sdk finishes initializing seems to fix the issue. 

Will add tests later, need to hot fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/497)
<!-- Reviewable:end -->
