### PR TITLE
autoRegister backwards compatibility

### DIFF
--- a/src/utils/OneSignalUtils.ts
+++ b/src/utils/OneSignalUtils.ts
@@ -45,14 +45,30 @@ export class OneSignalUtils {
       return false;
     }
 
-    if (OneSignalUtils.isLocalhostAllowedAsSecureOrigin() &&
+    const allowLocalhostAsSecureOrigin: boolean = this.isLocalhostAllowedAsSecureOrigin();
+
+    return OneSignalUtils.internalIsUsingSubscriptionWorkaround(
+      OneSignal.config.subdomain, allowLocalhostAsSecureOrigin
+    );
+  }
+
+  public static internalIsUsingSubscriptionWorkaround(
+    subdomain: string | undefined,
+    allowLocalhostAsSecureOrigin: boolean | undefined
+  ): boolean {
+    if (bowser.safari) {
+      return false;
+    }
+
+    if (allowLocalhostAsSecureOrigin === true &&
       (location.hostname === "localhost" || location.hostname === "127.0.0.1")) {
       return false;
     }
 
+    const windowEnv = SdkEnvironment.getWindowEnv();
     return (
       (windowEnv === WindowEnvironmentKind.Host || windowEnv === WindowEnvironmentKind.CustomIframe) &&
-      (!!OneSignal.config.subdomain || location.protocol === "http:")
+      (!!subdomain || location.protocol === "http:")
     );
   }
 

--- a/test/unit/helpers1/ConfigHelper.ts
+++ b/test/unit/helpers1/ConfigHelper.ts
@@ -12,7 +12,8 @@ test.beforeEach(async () => {
   });
 });
 
-test('promptOptions - autoRegister backwards compatibility for custom integration 1', t => {
+test('promptOptions 1 - autoRegister = true backwards compatibility for custom integration (shows native on HTTPS)',
+  t => {
   const fakeUserConfig: AppUserConfig = {
     appId: Random.getRandomUuid(),
     autoRegister: true,
@@ -22,12 +23,8 @@ test('promptOptions - autoRegister backwards compatibility for custom integratio
   const finalPromptOptions = ConfigHelper.injectDefaultsIntoPromptOptions(
     fakeUserConfig.promptOptions,
     fakeServerConfig.config.staticPrompts,
-    fakeUserConfig
+    fakeUserConfig,
   );
-
-  if (!finalPromptOptions) {
-    throw new Error("Prompt options cannot be empty!");
-  }
 
   t.is(finalPromptOptions!.native!.enabled, true);
   t.is(finalPromptOptions!.native!.autoPrompt, true);
@@ -35,10 +32,35 @@ test('promptOptions - autoRegister backwards compatibility for custom integratio
   t.is(finalPromptOptions!.slidedown!.enabled, false);
   t.is(finalPromptOptions!.slidedown!.autoPrompt, false);
 
-  t.is(finalPromptOptions.autoPrompt, true);
+  t.is(finalPromptOptions!.autoPrompt, true);
 });
 
-test('promptOptions - autoRegister backwards compatibility for custom integration 2', t => {
+test('promptOptions 2 - autoRegister = true backwards compatibility for custom integration (shows slidedown on HTTP)',
+  t => {
+  const fakeUserConfig: AppUserConfig = {
+    appId: Random.getRandomUuid(),
+    autoRegister: true,
+  };
+
+  const fakeServerConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom);
+  const finalPromptOptions = ConfigHelper.injectDefaultsIntoPromptOptions(
+    fakeUserConfig.promptOptions,
+    fakeServerConfig.config.staticPrompts,
+    fakeUserConfig,
+    true
+  );
+
+  t.is(finalPromptOptions!.native!.enabled, false);
+  t.is(finalPromptOptions!.native!.autoPrompt, false);
+
+  t.is(finalPromptOptions!.slidedown!.enabled, true);
+  t.is(finalPromptOptions!.slidedown!.autoPrompt, true);
+
+  t.is(finalPromptOptions!.autoPrompt, true);
+});
+
+test('promptOptions 3 - autoRegister = false backwards compatibility for custom integration (no enabled prompts)',
+  t => {
   const fakeUserConfig: AppUserConfig = {
     appId: Random.getRandomUuid(),
     autoRegister: false,
@@ -51,20 +73,17 @@ test('promptOptions - autoRegister backwards compatibility for custom integratio
     fakeUserConfig
   );
 
-  if (!finalPromptOptions) {
-    throw new Error("Prompt options cannot be empty!");
-  }
-
   t.is(finalPromptOptions!.native!.enabled, false);
   t.is(finalPromptOptions!.native!.autoPrompt, false);
   
   t.is(finalPromptOptions!.slidedown!.enabled, false);
   t.is(finalPromptOptions!.slidedown!.autoPrompt, false);
 
-  t.is(finalPromptOptions.autoPrompt, false);
+  t.is(finalPromptOptions!.autoPrompt, false);
 });
 
-test('promptOptions - autoRegister backwards compatibility for custom integration 3', t => {
+test(`promptOptions 4 - autoRegister = true backwards compatibility for custom integration
+  (ignores config, shows native on HTTPS)`, t => {
   const fakeUserConfig: AppUserConfig = {
     appId: Random.getRandomUuid(),
     autoRegister: true,
@@ -82,9 +101,34 @@ test('promptOptions - autoRegister backwards compatibility for custom integratio
     fakeUserConfig
   );
 
-  if (!finalPromptOptions) {
-    throw new Error("Prompt options cannot be empty!");
-  }
+  t.is(finalPromptOptions!.native!.enabled, true);
+  t.is(finalPromptOptions!.native!.autoPrompt, true);
+  
+  t.is(finalPromptOptions!.slidedown!.enabled, true);
+  t.is(finalPromptOptions!.slidedown!.autoPrompt, true);
+
+  t.is(finalPromptOptions!.autoPrompt, true);
+});
+
+test(`promptOptions 5 - autoRegister backwards compatibility for custom integration
+  (ignores config, shows slidedown on HTTP)`, t => {
+  const fakeUserConfig: AppUserConfig = {
+    appId: Random.getRandomUuid(),
+    autoRegister: true,
+  };
+  (fakeUserConfig as any).promptOptions = {
+    slidedown: {
+      enabled: true,
+    }
+  };
+
+  const fakeServerConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom);
+  const finalPromptOptions = ConfigHelper.injectDefaultsIntoPromptOptions(
+    fakeUserConfig.promptOptions,
+    fakeServerConfig.config.staticPrompts,
+    fakeUserConfig,
+    true
+  );
 
   t.is(finalPromptOptions!.native!.enabled, false);
   t.is(finalPromptOptions!.native!.autoPrompt, false);
@@ -92,10 +136,11 @@ test('promptOptions - autoRegister backwards compatibility for custom integratio
   t.is(finalPromptOptions!.slidedown!.enabled, true);
   t.is(finalPromptOptions!.slidedown!.autoPrompt, true);
 
-  t.is(finalPromptOptions.autoPrompt, true);
+  t.is(finalPromptOptions!.autoPrompt, true);
 });
 
-test('promptOptions - autoRegister backwards compatibility for custom integration 4', t => {
+test(`promptOptions 6 - autoRegister = true backwards compatibility for custom integration
+  (ignores config, shows native on HTTPS)`, t => {
   const fakeUserConfig: AppUserConfig = {
     appId: Random.getRandomUuid(),
     autoRegister: true,
@@ -111,12 +156,9 @@ test('promptOptions - autoRegister backwards compatibility for custom integratio
   const finalPromptOptions = ConfigHelper.injectDefaultsIntoPromptOptions(
     fakeUserConfig.promptOptions,
     fakeServerConfig.config.staticPrompts,
-    fakeUserConfig
+    fakeUserConfig,
+    false
   );
-
-  if (!finalPromptOptions) {
-    throw new Error("Prompt options cannot be empty!");
-  }
 
   t.is(finalPromptOptions!.native!.enabled, true);
   t.is(finalPromptOptions!.native!.autoPrompt, true);
@@ -124,10 +166,41 @@ test('promptOptions - autoRegister backwards compatibility for custom integratio
   t.is(finalPromptOptions!.slidedown!.enabled, true);
   t.is(finalPromptOptions!.slidedown!.autoPrompt, false);
 
-  t.is(finalPromptOptions.autoPrompt, true);
+  t.is(finalPromptOptions!.autoPrompt, true);
 });
 
-test('promptOptions - autoRegister backwards compatibility for custom integration 5', t => {
+test(`promptOptions 7 - autoRegister = true backwards compatibility for custom integration
+  (ignores config, shows slidedown on HTTP)`, t => {
+  const fakeUserConfig: AppUserConfig = {
+    appId: Random.getRandomUuid(),
+    autoRegister: true,
+  };
+  (fakeUserConfig as any).promptOptions = {
+    slidedown: {
+      enabled: true,
+      autoPrompt: false,
+    }
+  };
+
+  const fakeServerConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom);
+  const finalPromptOptions = ConfigHelper.injectDefaultsIntoPromptOptions(
+    fakeUserConfig.promptOptions,
+    fakeServerConfig.config.staticPrompts,
+    fakeUserConfig,
+    true
+  );
+
+  t.is(finalPromptOptions!.native!.enabled, false);
+  t.is(finalPromptOptions!.native!.autoPrompt, false);
+  
+  t.is(finalPromptOptions!.slidedown!.enabled, true);
+  t.is(finalPromptOptions!.slidedown!.autoPrompt, true);
+
+  t.is(finalPromptOptions!.autoPrompt, true);
+});
+
+test(`promptOptions 8 - autoRegister = true backwards compatibility for custom integration
+  (ignores config, shows native on HTTPS)`, t => {
   const fakeUserConfig: AppUserConfig = {
     appId: Random.getRandomUuid(),
     autoRegister: true,
@@ -150,20 +223,17 @@ test('promptOptions - autoRegister backwards compatibility for custom integratio
     fakeUserConfig
   );
 
-  if (!finalPromptOptions) {
-    throw new Error("Prompt options cannot be empty!");
-  }
-
   t.is(finalPromptOptions!.native!.enabled, true);
   t.is(finalPromptOptions!.native!.autoPrompt, true);
 
   t.is(finalPromptOptions!.slidedown!.enabled, true);
   t.is(finalPromptOptions!.slidedown!.autoPrompt, false);
 
-  t.is(finalPromptOptions.autoPrompt, true);
+  t.is(finalPromptOptions!.autoPrompt, true);
 });
 
-test('promptOptions - autoRegister backwards compatibility for custom integration 6', t => {
+test(`promptOptions 9 - autoRegister= true backwards compatibility for custom integration
+  (ignores config, shows native on HTTPS)`, t => {
   const fakeUserConfig: AppUserConfig = {
     appId: Random.getRandomUuid(),
     autoRegister: true,
@@ -183,20 +253,51 @@ test('promptOptions - autoRegister backwards compatibility for custom integratio
   const finalPromptOptions = ConfigHelper.injectDefaultsIntoPromptOptions(
     fakeUserConfig.promptOptions,
     fakeServerConfig.config.staticPrompts,
-    fakeUserConfig
+    fakeUserConfig,
+    false
   );
 
-  if (!finalPromptOptions) {
-    throw new Error("Prompt options cannot be empty!");
-  }
-
   t.is(finalPromptOptions!.native!.enabled, true);
-  t.is(finalPromptOptions!.native!.autoPrompt, false);
+  t.is(finalPromptOptions!.native!.autoPrompt, true);
 
   t.is(finalPromptOptions!.slidedown!.enabled, true);
   t.is(finalPromptOptions!.slidedown!.autoPrompt, false);
 
-  t.is(finalPromptOptions.autoPrompt, false);
+  t.is(finalPromptOptions!.autoPrompt, true);
+});
+
+test(`promptOptions 10 - autoRegister backwards compatibility for custom integration
+  (ignores config, shows slidedown on HTTP)`, t => {
+  const fakeUserConfig: AppUserConfig = {
+    appId: Random.getRandomUuid(),
+    autoRegister: true,
+  };
+  (fakeUserConfig as any).promptOptions = {
+    native: {
+      enabled: true,
+      autoPrompt: false,
+    },
+    slidedown: {
+      enabled: true,
+      autoPrompt: false,
+    }
+  };
+
+  const fakeServerConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom);
+  const finalPromptOptions = ConfigHelper.injectDefaultsIntoPromptOptions(
+    fakeUserConfig.promptOptions,
+    fakeServerConfig.config.staticPrompts,
+    fakeUserConfig,
+    true
+  );
+
+  t.is(finalPromptOptions!.native!.enabled, false);
+  t.is(finalPromptOptions!.native!.autoPrompt, false);
+
+  t.is(finalPromptOptions!.slidedown!.enabled, true);
+  t.is(finalPromptOptions!.slidedown!.autoPrompt, true);
+
+  t.is(finalPromptOptions!.autoPrompt, true);
 });
 
 test('autoResubscribe - autoRegister backwards compatibility for custom integration 1', t => {


### PR DESCRIPTION
If autoRegister is present and it is set to true always show slidedown for http and native for https in custom code setup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/500)
<!-- Reviewable:end -->
