### PR TITLE
Fix for on_session not being sent for subscribed users

### DIFF
--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -184,7 +184,7 @@ export default class InitHelper {
      * If user's subscription was expiring and we processed it, our backend would get a player#create request.
      * If user was not subscribed before and autoPrompting is on, user would get subscribed through player#create if
      *  he clicks allow in an automatic prompt.
-     * It user has granted notification permissions but cleared the data and autoResubscribe is on, we will
+     * If user has granted notification permissions but cleared the data and autoResubscribe is on, we will
      *  resubscribe with autoResubscribe flag.
      * In all other cases we would send an on_session request.
      */

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -480,7 +480,6 @@ export default class InitHelper {
         await OneSignal.context.permissionManager.getNotificationPermission(
           OneSignal.context.appConfig.safariWebId
         );
-      console.log("currentPermission", currentPermission)
       if (currentPermission == NotificationPermission.Granted) {
         await SubscriptionHelper.registerForPush();
       }

--- a/src/helpers/TestHelper.ts
+++ b/src/helpers/TestHelper.ts
@@ -22,15 +22,19 @@ export default class TestHelper {
      * asynchronous.
      */
     if (isUsingSubscriptionWorkaround()) {
-      await new Promise((resolve, reject) => {
-        OneSignal.proxyFrameHost.message(OneSignal.POSTMAM_COMMANDS.MARK_PROMPT_DISMISSED, {}, reply => {
-          if (reply.data === OneSignal.POSTMAM_COMMANDS.REMOTE_OPERATION_COMPLETE) {
-            resolve();
-          } else {
-            reject();
-          }
+      try {
+        await new Promise((resolve, reject) => {
+          OneSignal.proxyFrameHost.message(OneSignal.POSTMAM_COMMANDS.MARK_PROMPT_DISMISSED, {}, reply => {
+            if (reply.data === OneSignal.POSTMAM_COMMANDS.REMOTE_OPERATION_COMPLETE) {
+              resolve();
+            } else {
+              reject();
+            }
+          });
         });
-      });
+      } catch(e) {
+        Log.debug("Proxy Frame possibly didn't not receive MARK_PROMPT_DISMISSED message", e || "");
+      }
     }
     let dismissCount = await Database.get<number>('Options', 'promptDismissCount');
     if (!dismissCount) {

--- a/src/managers/PermissionManager.ts
+++ b/src/managers/PermissionManager.ts
@@ -105,7 +105,7 @@ export default class PermissionManager {
    *
    * @param safariWebId The Safari web ID necessary to access the permission state on Safari.
    */
-  private async getOneSignalSubdomainNotificationPermission(safariWebId?: string): Promise<NotificationPermission> {
+  public async getOneSignalSubdomainNotificationPermission(safariWebId?: string): Promise<NotificationPermission> {
     return new Promise<NotificationPermission>(resolve => {
       OneSignal.proxyFrameHost.message(
         OneSignal.POSTMAM_COMMANDS.REMOTE_NOTIFICATION_PERMISSION,

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -245,7 +245,7 @@ export class SubscriptionManager {
     );
   }
 
-  public async isAlreadyRegisteredWithOneSignal() {
+  public async isAlreadyRegisteredWithOneSignal(): Promise<boolean> {
     const { deviceId } = await Database.getSubscription();
     return !!deviceId;
   }

--- a/test/support/mocks/service-workers/ServiceWorker.ts
+++ b/test/support/mocks/service-workers/ServiceWorker.ts
@@ -7,4 +7,6 @@ export default class ServiceWorker implements EventTarget {
   addEventListener = () => { throw new NotImplementedError(); };
   removeEventListener = () => { throw new NotImplementedError(); };
   dispatchEvent = () => { throw new NotImplementedError(); };
+  postMessage = () => { throw new NotImplementedError(); };
+  ready = new Promise((resolve) => { resolve(); })
 }

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -24,6 +24,7 @@ import Context from "../../../src/models/Context";
 import CustomLink from "../../../src/CustomLink";
 import Emitter from '../../../src/libraries/Emitter';
 import ConfigManager from '../../../src/managers/ConfigManager';
+import { RawPushSubscription } from '../../../src/models/RawPushSubscription';
 
 var global = new Function('return this')();
 
@@ -32,8 +33,8 @@ export interface ServiceWorkerTestEnvironment extends ServiceWorkerGlobalScope {
 }
 
 export enum HttpHttpsEnvironment {
-  Http,
-  Https
+  Http = "Http",
+  Https = "Https"
 }
 
 export enum BrowserUserAgent {
@@ -762,5 +763,13 @@ export class TestEnvironment {
       notificationClickHandlerAction: NotificationClickActionBehavior.Focus,
       allowLocalhostAsSecureOrigin: true,
     };
+  }
+
+  static getFakeRawPushSubscription(): RawPushSubscription {
+    const pushSubscription: RawPushSubscription = new RawPushSubscription();
+    pushSubscription.w3cAuth = "7QdgQYTjZIeiCuLgopqeww";
+    pushSubscription.w3cP256dh = "BBGhFwQ146CSOWhuz-r4ItRK2cQuZ4FZNkiW7uTEpf2JsPfxqbWtQvfGf4FvnaZ35hqjkwbtUUIn8wxwhhc3O_0";
+    pushSubscription.w3cEndpoint = new URL("https://fcm.googleapis.com/fcm/send/c8rEdO3xSaQ:APA91bH51jGBPBVSxoZVLq-xwen6oHYmGVpyjR8qG_869A-skv1a5G9PQ5g2S5O8ujJ2y8suHaPF0psX5590qrZj_WnWbVfx2q4u2Vm6_Ofq-QGBDcomRziLzTn6uWU9wbrrmL6L5YBh");
+    return pushSubscription;
   }
 }

--- a/test/unit/public-sdk-apis/init.ts
+++ b/test/unit/public-sdk-apis/init.ts
@@ -5,8 +5,7 @@ import Database from "../../../src/services/Database";
 import { TestEnvironment, HttpHttpsEnvironment } from '../../support/sdk/TestEnvironment';
 import Context from '../../../src/models/Context';
 import InitHelper from '../../../src/helpers/InitHelper';
-import OneSignalUtils from '../../../src/utils/OneSignalUtils';
-import { AppConfig, ConfigIntegrationKind } from '../../../src/models/AppConfig';
+import { AppConfig } from '../../../src/models/AppConfig';
 import nock from 'nock';
 import Random from "../../support/tester/Random";
 import OneSignalApiBase from "../../../src/OneSignalApiBase";
@@ -15,7 +14,7 @@ import OneSignalApiShared from "../../../src/OneSignalApiShared";
 import { EmailProfile } from "../../../src/models/EmailProfile";
 import { EmailDeviceRecord } from "../../../src/models/EmailDeviceRecord";
 import {
-  stubMessageChannel, mockIframeMessaging, mockWebPushAnalytics, InitTestHelper, AssertInitSDK
+  mockWebPushAnalytics, InitTestHelper, AssertInitSDK
 } from '../../support/tester/utils';
 
 
@@ -103,185 +102,6 @@ test("email session should be updated on first page view", async t => {
   t.is(emailDeviceRecord.appId, OneSignal.context.appConfig.appId);
 });
 
-async function expectPushRecordCreationRequest(t: TestContext, createRequestPostStub: SinonStub) {
-  const anyValues = [
-    "device_type",
-    "language",
-    "timezone",
-    "device_os",
-    "sdk",
-    "delivery_platform",
-    "browser_name",
-    "browser_version",
-    "operating_system",
-    "operating_system_version",
-    "device_platform",
-    "device_model",
-    "identifier"
-  ];
-  t.true(createRequestPostStub.calledOnce);
-  t.not(createRequestPostStub.getCall(0), null);
-  const data: any = createRequestPostStub.getCall(0).args[1];
-  anyValues.forEach((valueKey) => {
-    t.not(data[valueKey], undefined);
-  });
-}
-
-test("Test OneSignal.init, Basic HTTP", async t => {
-  stubMessageChannel(t);
-  mockIframeMessaging(sinonSandbox);
-  sinonSandbox.stub(OneSignalApiBase, "get").resolves({});
-
-  const testConfig = {
-    initOptions: { },
-    httpOrHttps: HttpHttpsEnvironment.Http,
-    pushIdentifier: (await TestEnvironment.getFakePushSubscription()).endpoint
-  };
-  await TestEnvironment.initialize(testConfig);
-  OneSignal.initialized = false;
-
-  sinonSandbox.stub(document, "visibilityState").value("visible");
-
-  const serverAppConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom, false);
-  serverAppConfig.config.subdomain = "test";
-  initTestHelper.stubJSONP(serverAppConfig);
-
-  const assertInit = new AssertInitSDK();
-  assertInit.setupEnsureInitEventFires(t);
-  const createPlayerPostStub = sinonSandbox.stub(OneSignalApiBase, "post")
-    .resolves({success: true, id: Random.getRandomUuid()});
-  await OneSignal.init({
-    appId: Random.getRandomUuid()
-  });
-  t.is(OneSignal.pendingInit, false);
-  t.true(createPlayerPostStub.notCalled);
-  assertInit.ensureInitEventFired();
-});
-
-test("Test OneSignal.init, Basic HTTP, autoRegister", async t => {
-  stubMessageChannel(t);
-  mockIframeMessaging(sinonSandbox);
-  sinonSandbox.stub(OneSignalApiBase, "get").resolves({});
-
-  const testConfig = {
-    initOptions: {
-      autoRegister: true,
-    },
-    httpOrHttps: HttpHttpsEnvironment.Http,
-    pushIdentifier: (await TestEnvironment.getFakePushSubscription()).endpoint
-  };
-  await TestEnvironment.initialize(testConfig);
-  OneSignal.initialized = false;
-
-  sinonSandbox.stub(document, "visibilityState").value("visible");
-
-  const serverAppConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom, false);
-  serverAppConfig.config.subdomain = "test";
-  initTestHelper.stubJSONP(serverAppConfig);
-
-  const assertInit = new AssertInitSDK();
-  assertInit.setupEnsureInitEventFires(t);
-
-  sinonSandbox.stub(InitHelper, "doInitialize").resolves();
-  sinonSandbox.stub(OneSignal, "internalIsOptedOut").resolves(false);
-  sinonSandbox.stub(OneSignalUtils, "isUsingSubscriptionWorkaround").returns(true);
-  sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(true);
-  sinonSandbox.stub(OneSignal.context.promptsManager, "internalShowAutoPrompt").resolves();
-  const createPlayerPostStub = sinonSandbox.stub(OneSignalApiBase, "post")
-    .resolves({success: true, id: Random.getRandomUuid()});
-  await OneSignal.init({
-    appId: Random.getRandomUuid(),
-    autoRegister: true
-  });
-  t.is(OneSignal.pendingInit, false);
-  t.true(createPlayerPostStub.notCalled);
-  assertInit.ensureInitEventFired();
-});
-
-test("Test OneSignal.init, Basic HTTPS, autoRegister = true with already granted push permissions", async t => {
-  const testConfig = {
-    initOptions: {},
-    httpOrHttps: HttpHttpsEnvironment.Https,
-    pushIdentifier: (await TestEnvironment.getFakePushSubscription()).endpoint
-  };
-  await TestEnvironment.initialize(testConfig);
-  initTestHelper.mockBasicInitEnv(testConfig);
-  TestEnvironment.mockInternalOneSignal();
-  (window as any).Notification.permission = "granted";
-
-  const createPlayerPostStub = sinonSandbox.stub(OneSignalApiBase, "post")
-    .resolves({success: true, id: Random.getRandomUuid()});
-
-  const assertInit = new AssertInitSDK();
-  assertInit.setupEnsureInitEventFires(t);
-
-  t.is(OneSignal.config.userConfig.autoResubscribe, true);
-
-  await OneSignal.init({
-    appId: Random.getRandomUuid(),
-    autoRegister: true
-  });
-
-  expectPushRecordCreationRequest(t, createPlayerPostStub);
-  assertInit.ensureInitEventFired();
-});
-
-test("Test OneSignal.init, Basic HTTPS, autoRegister = true with default push permissions", async t => {
-  const testConfig = {
-    initOptions: {},
-    httpOrHttps: HttpHttpsEnvironment.Https,
-    pushIdentifier: (await TestEnvironment.getFakePushSubscription()).endpoint
-  };
-  await TestEnvironment.initialize(testConfig);
-  initTestHelper.mockBasicInitEnv(testConfig);
-  TestEnvironment.mockInternalOneSignal();
-  (window as any).Notification.permission = "default";
-
-  const createPlayerPostStub = sinonSandbox.stub(OneSignalApiBase, "post")
-    .resolves({success: true, id: Random.getRandomUuid()});
-
-  const assertInit = new AssertInitSDK();
-  assertInit.setupEnsureInitEventFires(t);
-
-  const initPromise = OneSignal.init({
-    appId: Random.getRandomUuid(),
-    autoRegister: true
-  });
-
-  // set up event to change permission after native prompt is displayed
-  OneSignal.emitter.on(OneSignal.EVENTS.PERMISSION_PROMPT_DISPLAYED, () => {
-    (window as any).Notification.permission = "granted";
-  });
-
-  await initPromise;
-  expectPushRecordCreationRequest(t, createPlayerPostStub);
-  assertInit.ensureInitEventFired();
-});
-
-test("Test OneSignal.init, Basic HTTPS, Custom, with autoRegister, and delayed accept", async t => {
-  const testConfig = {
-    initOptions: {},
-    httpOrHttps: HttpHttpsEnvironment.Https,
-    pushIdentifier: 'granted'
-  };
-  await TestEnvironment.initialize(testConfig);
-
-  initTestHelper.mockBasicInitEnv(testConfig);
-
-  TestEnvironment.mockInternalOneSignal();
-  const createPlayerPostStub = sinonSandbox.stub(OneSignalApiBase, "post")
-    .resolves({success: true, id: Random.getRandomUuid()});
-
-  await OneSignal.init({
-    appId: Random.getRandomUuid(),
-    autoRegister: true
-  });
-  expectPushRecordCreationRequest(t, createPlayerPostStub);
-
-  // Check checkAndTriggerSubscriptionChanged if we get a 'Promise returned by test never resolved' Error
-  await OneSignal.isPushNotificationsEnabled();
-  t.pass();
-});
 
 test("Test OneSignal.init, Custom, with requiresUserPrivacyConsent", async t => {
   const testConfig = {
@@ -331,8 +151,6 @@ test("Test OneSignal.init, TypicalSite, with requiresUserPrivacyConsent", async 
     else
       t.pass();
   });
-
-  TestEnvironment.mockInternalOneSignal();
   // Don't need to mock create call, autoRegister not settable with TypicalSite
 
   const assertInit = new AssertInitSDK();
@@ -363,3 +181,5 @@ test("Test OneSignal.init, No app id or wrong format of app id", async t => {
   await t.throws(OneSignal.init({ appId: "" }), SdkInitError);
   await t.throws(OneSignal.init({ appId: "wrong-format" }), SdkInitError);
 });
+
+// more init tests in onSession.ts

--- a/test/unit/public-sdk-apis/init.ts
+++ b/test/unit/public-sdk-apis/init.ts
@@ -6,39 +6,21 @@ import { TestEnvironment, HttpHttpsEnvironment } from '../../support/sdk/TestEnv
 import Context from '../../../src/models/Context';
 import InitHelper from '../../../src/helpers/InitHelper';
 import OneSignalUtils from '../../../src/utils/OneSignalUtils';
-import {AppConfig, ConfigIntegrationKind, ServerAppConfig} from '../../../src/models/AppConfig';
+import { AppConfig, ConfigIntegrationKind } from '../../../src/models/AppConfig';
 import nock from 'nock';
 import Random from "../../support/tester/Random";
-import OneSignalApi from "../../../src/OneSignalApi";
 import OneSignalApiBase from "../../../src/OneSignalApiBase";
-import ProxyFrameHost from "../../../src/modules/frames/ProxyFrameHost";
-import AltOriginManager from "../../../src/managers/AltOriginManager";
 import { SdkInitError } from "../../../src/errors/SdkInitError";
 import OneSignalApiShared from "../../../src/OneSignalApiShared";
 import { EmailProfile } from "../../../src/models/EmailProfile";
 import { EmailDeviceRecord } from "../../../src/models/EmailDeviceRecord";
-import { stubMessageChannel } from '../../support/tester/utils';
+import {
+  stubMessageChannel, mockIframeMessaging, mockWebPushAnalytics, InitTestHelper, AssertInitSDK
+} from '../../support/tester/utils';
 
-// Helper class to ensure the public OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC event fires
-class AssertInitSDK {
-  private firedSDKInitializedPublic: boolean = false;
-
-  public setupEnsureInitEventFires(t: TestContext) {
-    OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
-      this.firedSDKInitializedPublic = true;
-      t.pass();
-    });
-  }
-
-  public ensureInitEventFired() {
-    if (!this.firedSDKInitializedPublic) {
-      throw new Error("OneSignal.Init did not finish!");
-    }
-    this.firedSDKInitializedPublic = false;
-  }
-}
 
 let sinonSandbox: SinonSandbox = sinon.sandbox.create();
+let initTestHelper = new InitTestHelper(sinonSandbox);
 
 test.beforeEach(function () {
   nock.disableNetConnect();
@@ -52,25 +34,6 @@ test.afterEach(function (_t: TestContext) {
   OneSignal.__initAlreadyCalled = false;
   OneSignal._sessionInitAlreadyRunning = false;
 });
-
-class InitTestHelpers {
-  static stubJSONP(serverAppConfig: ServerAppConfig) {
-    sinonSandbox.stub(OneSignalApi, "jsonpLib").callsFake(function (_url: string, callback: Function) {
-      callback(null, serverAppConfig);
-    });
-  }
-
-  static mockBasicInitEnv(configIntegrationKind: ConfigIntegrationKind) {
-    OneSignal.initialized = false;
-
-    sinonSandbox.stub(document, "visibilityState").value("visible");
-
-    const serverAppConfig = TestEnvironment.getFakeServerAppConfig(configIntegrationKind);
-    InitTestHelpers.stubJSONP(serverAppConfig);
-
-    sinonSandbox.stub(OneSignalApiBase, "get").resolves({});
-  }
-}
 
 test("correct degree of persistNotification setting should be stored", async t => {
   await TestEnvironment.initialize({
@@ -116,20 +79,6 @@ test("correct degree of persistNotification setting should be stored", async t =
   }
 });
 
-function mockWebPushAnalytics() {
-  nock('https://onesignal.com')
-    .get("/webPushAnalytics")
-    .reply(200, (_uri: string, _requestBody: string) => {
-      return { success: true };
-    }).persist(true);
-
-  nock('https://test.os.tc')
-    .get("/webPushAnalytics")
-    .reply(200, (_uri: string, _requestBody: string) => {
-      return { success: true };
-    }).persist(true);
-}
-
 test("email session should be updated on first page view", async t => {
   const testEmailProfile: EmailProfile = new EmailProfile(
     Random.getRandomUuid(),
@@ -143,7 +92,7 @@ test("email session should be updated on first page view", async t => {
   OneSignal.context.sessionManager.setPageViewCount(1);
   t.true(OneSignal.context.sessionManager.isFirstPageView());
   
-  await Database.setEmailProfile(testEmailProfile)
+  await Database.setEmailProfile(testEmailProfile);
 
   const onSessionStub = sinonSandbox.stub(OneSignalApiShared, "updateUserSession").resolves();
   await InitHelper.updateEmailSessionCount();
@@ -178,23 +127,9 @@ async function expectPushRecordCreationRequest(t: TestContext, createRequestPost
   });
 }
 
-// Mocks out any messages going to the *.os.tc iframe.
-function mockIframeMessaging() {
-  sinonSandbox.stub(ProxyFrameHost.prototype, 'load').resolves(undefined);
-  sinonSandbox.stub(AltOriginManager, 'removeDuplicatedAltOriginSubscription').resolves(undefined);
-  sinonSandbox.stub(ProxyFrameHost.prototype, 'isSubscribed').callsFake(() => {});
-  sinonSandbox.stub(ProxyFrameHost.prototype, 'runCommand').resolves(undefined);
-
-  const mockIframeMessageReceiver = function (_msg: string, _data: object, resolve: Function) {
-    // OneSignal.POSTMAM_COMMANDS.REMOTE_NOTIFICATION_PERMISSION
-    resolve(true);
-  };
-  sinonSandbox.stub(ProxyFrameHost.prototype, 'message').callsFake(mockIframeMessageReceiver);
-}
-
 test("Test OneSignal.init, Basic HTTP", async t => {
   stubMessageChannel(t);
-  mockIframeMessaging();
+  mockIframeMessaging(sinonSandbox);
   sinonSandbox.stub(OneSignalApiBase, "get").resolves({});
 
   const testConfig = {
@@ -209,7 +144,7 @@ test("Test OneSignal.init, Basic HTTP", async t => {
 
   const serverAppConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom, false);
   serverAppConfig.config.subdomain = "test";
-  InitTestHelpers.stubJSONP(serverAppConfig);
+  initTestHelper.stubJSONP(serverAppConfig);
 
   const assertInit = new AssertInitSDK();
   assertInit.setupEnsureInitEventFires(t);
@@ -225,7 +160,7 @@ test("Test OneSignal.init, Basic HTTP", async t => {
 
 test("Test OneSignal.init, Basic HTTP, autoRegister", async t => {
   stubMessageChannel(t);
-  mockIframeMessaging();
+  mockIframeMessaging(sinonSandbox);
   sinonSandbox.stub(OneSignalApiBase, "get").resolves({});
 
   const testConfig = {
@@ -242,7 +177,7 @@ test("Test OneSignal.init, Basic HTTP, autoRegister", async t => {
 
   const serverAppConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom, false);
   serverAppConfig.config.subdomain = "test";
-  InitTestHelpers.stubJSONP(serverAppConfig);
+  initTestHelper.stubJSONP(serverAppConfig);
 
   const assertInit = new AssertInitSDK();
   assertInit.setupEnsureInitEventFires(t);
@@ -270,7 +205,7 @@ test("Test OneSignal.init, Basic HTTPS, autoRegister = true with already granted
     pushIdentifier: (await TestEnvironment.getFakePushSubscription()).endpoint
   };
   await TestEnvironment.initialize(testConfig);
-  InitTestHelpers.mockBasicInitEnv(ConfigIntegrationKind.Custom);
+  initTestHelper.mockBasicInitEnv(testConfig);
   TestEnvironment.mockInternalOneSignal();
   (window as any).Notification.permission = "granted";
 
@@ -298,7 +233,7 @@ test("Test OneSignal.init, Basic HTTPS, autoRegister = true with default push pe
     pushIdentifier: (await TestEnvironment.getFakePushSubscription()).endpoint
   };
   await TestEnvironment.initialize(testConfig);
-  InitTestHelpers.mockBasicInitEnv(ConfigIntegrationKind.Custom);
+  initTestHelper.mockBasicInitEnv(testConfig);
   TestEnvironment.mockInternalOneSignal();
   (window as any).Notification.permission = "default";
 
@@ -331,7 +266,7 @@ test("Test OneSignal.init, Basic HTTPS, Custom, with autoRegister, and delayed a
   };
   await TestEnvironment.initialize(testConfig);
 
-  InitTestHelpers.mockBasicInitEnv(ConfigIntegrationKind.Custom);
+  initTestHelper.mockBasicInitEnv(testConfig);
 
   TestEnvironment.mockInternalOneSignal();
   const createPlayerPostStub = sinonSandbox.stub(OneSignalApiBase, "post")
@@ -356,7 +291,7 @@ test("Test OneSignal.init, Custom, with requiresUserPrivacyConsent", async t => 
   };
   await TestEnvironment.initialize(testConfig);
 
-  InitTestHelpers.mockBasicInitEnv(ConfigIntegrationKind.Custom);
+  initTestHelper.mockBasicInitEnv(testConfig);
 
   let delayInit = true;
   OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, function() {
@@ -387,7 +322,7 @@ test("Test OneSignal.init, TypicalSite, with requiresUserPrivacyConsent", async 
   };
   await TestEnvironment.initialize(testConfig);
 
-  InitTestHelpers.mockBasicInitEnv(ConfigIntegrationKind.TypicalSite);
+  initTestHelper.mockBasicInitEnv(testConfig);
 
   let delayInit = true;
   OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, function() {

--- a/test/unit/public-sdk-apis/onSession.ts
+++ b/test/unit/public-sdk-apis/onSession.ts
@@ -1,0 +1,531 @@
+import "../../support/polyfills/polyfills";
+import test, { TestContext } from "ava";
+import sinon, { SinonSandbox } from 'sinon';
+import nock from "nock";
+import {
+  TestEnvironment, HttpHttpsEnvironment, TestEnvironmentConfig
+} from '../../support/sdk/TestEnvironment';
+import { ConfigIntegrationKind, ServerAppConfig } from '../../../src/models/AppConfig';
+import Random from "../../support/tester/Random";
+import OneSignalApiBase from "../../../src/OneSignalApiBase";
+import OneSignalApiShared from "../../../src/OneSignalApiShared";
+import {
+  stubMessageChannel, mockIframeMessaging, mockWebPushAnalytics, InitTestHelper
+} from '../../support/tester/utils';
+import Popover from "../../../src/popover/Popover";
+import OneSignalEvent from "../../../src/Event";
+import { DynamicResourceLoader, ResourceLoadState } from "../../../src/services/DynamicResourceLoader";
+import { ServiceWorkerManager } from "../../../src/managers/ServiceWorkerManager";
+import { NotificationPermission } from "../../../src/models/NotificationPermission";
+import Database from "../../../src/services/Database";
+import { Subscription } from "../../../src/models/Subscription";
+import { SessionManager } from "../../../src/managers/SessionManager";
+import { SubscriptionManager } from "../../../src/managers/SubscriptionManager";
+import InitHelper from "../../../src/helpers/InitHelper";
+import ServiceWorker from '../../support/mocks/service-workers/ServiceWorker';
+import ServiceWorkerRegistration from '../../support/mocks/service-workers/models/ServiceWorkerRegistration';
+import { ServiceWorkerActiveState } from '../../../src/helpers/ServiceWorkerHelper';
+import { WorkerMessenger } from '../../../src/libraries/WorkerMessenger';
+
+const sinonSandbox: SinonSandbox = sinon.sandbox.create();
+const initTestHelper = new InitTestHelper(sinonSandbox);
+const playerId = Random.getRandomUuid();
+const appId = Random.getRandomUuid();
+
+test.beforeEach(function () {
+  mockWebPushAnalytics();
+});
+
+test.afterEach(function (_t: TestContext) {
+  sinonSandbox.restore();
+
+  OneSignal._initCalled = false;
+  OneSignal.__initAlreadyCalled = false;
+  OneSignal._sessionInitAlreadyRunning = false;
+});
+
+/**
+ * HTTP/HTTPS
+ * 1. user not subscribed and not opted out
+ *    1. first page view
+ *     + 1. autoPrompt -> click allow -> player create
+ *     + 2. autoPrompt -> click dismiss -> no requests
+ *     + 3. autoResubscribe and permissions granted -> player create
+ *     + 4. autoResubscribe and permissions default or blocked -> no requests
+ *     + 5. no autoResubscribe and no autoPrompt -> no requests
+ *    2. second page view - TODO
+ * 2. user opted out
+ *     + 1. new on session flag enabled and first page view -> on session
+ *     + 2. no flag and first page view -> no requests
+ *     + 3. second page view -> no requests
+ * 3. user subscribed
+ *     + 1. expiring subscription -> player update
+ *     + 2. not-expiring subscription and first page view -> on session
+ *       3. second page view -> no requests - TODO 
+ */
+
+test.serial(`HTTPS: User not subscribed and not opted out => first page view => slidedown's autoPrompt is on =>
+  click allow => sends player create`, async t => {
+    const testConfig: TestEnvironmentConfig = {
+      httpOrHttps: HttpHttpsEnvironment.Https,
+      integration: ConfigIntegrationKind.Custom,
+      pushIdentifier: 'granted'
+    };
+    const stubs = await beforeTest(testConfig);
+    
+    simulateSlidedownAllowAfterShown();
+    simulateNativeAllowAfterShown();
+  
+    const initializePromise = new Promise((resolve) => {
+      OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
+        t.is(stubs.onSessionStub.callCount, 0);
+        t.is(stubs.createPlayerPostStub.callCount, 0);
+        resolve();
+      });
+    });
+
+    const subscriptionPromise = new Promise((resolve) => {
+      OneSignal.on(OneSignal.EVENTS.SUBSCRIPTION_CHANGED, () => {
+        t.is(stubs.onSessionStub.callCount, 0);
+        t.is(stubs.createPlayerPostStub.callCount, 1);
+        resolve();
+      });
+    });
+
+    const initPromise = OneSignal.init({
+      appId,
+      promptOptions: {
+        slidedown: {
+          enabled: true,
+          autoPrompt: true,
+        }
+      },
+      autoResubscribe: false,
+    });
+    await initPromise;
+    t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+    await initializePromise;
+    await subscriptionPromise;
+    console.log("test 1 ends!!!!!")
+});
+
+test.serial(`HTTPS: User not subscribed and not opted out => first page view => slidedown's autoPrompt is on =>
+  click dismiss => no requests`, async t => {
+  const testConfig: TestEnvironmentConfig = {
+    httpOrHttps: HttpHttpsEnvironment.Https,
+    integration: ConfigIntegrationKind.Custom,
+    pushIdentifier: 'granted'
+  };
+
+  const stubs = await beforeTest(testConfig);
+  simulateSlidedownDismissAfterShown();
+
+  const subscribeSpy = sinonSandbox.stub(SubscriptionManager.prototype, "subscribe");
+
+  const initializePromise = new Promise((resolve) => {
+    OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
+      t.is(stubs.onSessionStub.callCount, 0);
+      t.is(stubs.createPlayerPostStub.callCount, 0);
+      resolve();
+    });
+  });
+
+  const initPromise = OneSignal.init({
+    appId,
+    promptOptions: {
+      slidedown: {
+        enabled: true,
+        autoPrompt: true,
+      }
+    },
+    autoResubscribe: false,
+  });
+  await initPromise;
+  t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+  await initializePromise;
+  t.is(subscribeSpy.callCount, 0);
+});
+
+test.serial(`HTTPS: User not subscribed and not opted out => first page view => autoResubscribe is on =>
+  permissions already granted => sends player create`, async t => {
+    const testConfig: TestEnvironmentConfig = {
+      httpOrHttps: HttpHttpsEnvironment.Https,
+      integration: ConfigIntegrationKind.Custom,
+      permission: NotificationPermission.Granted,
+    };
+
+    const stubs = await beforeTest(testConfig);
+    stubServiceWorkerInstallation();
+
+    const initializePromise = new Promise((resolve) => {
+      OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
+        t.is(stubs.onSessionStub.callCount, 0);
+        t.is(stubs.createPlayerPostStub.callCount, 1);
+        resolve();
+      });
+    });
+
+    const registrationPromise = new Promise((resolve) => {
+      OneSignal.on(OneSignal.EVENTS.REGISTERED, () => {
+        t.is(stubs.onSessionStub.callCount, 0);
+        t.is(stubs.createPlayerPostStub.callCount, 1);
+        resolve();
+      });
+    });
+
+    const subscriptionPromise = new Promise((resolve) => {
+      OneSignal.on(OneSignal.EVENTS.SUBSCRIPTION_CHANGED, () => {
+        resolve();
+      });
+    });
+
+    const initPromise = OneSignal.init({
+      appId,
+      autoResubscribe: true,
+    });
+    await initPromise;
+    t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+    await initializePromise;
+    await registrationPromise;
+    await subscriptionPromise;
+});
+
+test.serial(`HTTPS: User not subscribed and not opted out => first page view => autoResubscribe is on =>
+  permissions default => no requests`, async t => {
+    const testConfig: TestEnvironmentConfig = {
+      httpOrHttps: HttpHttpsEnvironment.Https,
+      integration: ConfigIntegrationKind.Custom,
+      permission: NotificationPermission.Default,
+    };
+    const stubs = await beforeTest(testConfig);
+    const subscribeSpy = sinonSandbox.stub(SubscriptionManager.prototype, "subscribe");
+    const initializePromise = new Promise((resolve) => {
+      OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
+        t.is(stubs.onSessionStub.callCount, 0);
+        t.is(stubs.createPlayerPostStub.callCount, 0);
+        resolve();
+      });
+    });
+    OneSignal.on(OneSignal.EVENTS.SUBSCRIPTION_CHANGED, () => {
+      t.is(stubs.onSessionStub.callCount, 0);
+      t.is(stubs.createPlayerPostStub.callCount, 0);
+    });
+
+    const initPromise = OneSignal.init({
+      appId,
+      autoResubscribe: true,
+    });
+    await initPromise;
+    t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+    await initializePromise;
+    t.is(subscribeSpy.callCount, 0);
+});
+
+// test.serial(`HTTPS: User not subscribed and not opted out => first page view => no autoResubscribe and no autoPrompt =>
+//   no requests`, async t => {
+//     const testConfig: TestEnvironmentConfig = {
+//       httpOrHttps: HttpHttpsEnvironment.Https,
+//       integration: ConfigIntegrationKind.Custom,
+//       pushIdentifier: 'granted',
+//       permission: NotificationPermission.Granted,
+//     };
+//     const stubs = await beforeTest(testConfig);
+  
+//     OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
+//       t.is(stubs.onSessionStub.callCount, 0);
+//       t.is(stubs.createPlayerPostStub.callCount, 0);
+//     });
+
+//     const initPromise = OneSignal.init({
+//       appId,
+//     });
+//     await initPromise;
+//     t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+// });
+
+// test.serial(`HTTPS: User opted out => first page view => onSession flag is on => sends on session`, async t => {
+//     const testConfig: TestEnvironmentConfig = {
+//       httpOrHttps: HttpHttpsEnvironment.Https,
+//       integration: ConfigIntegrationKind.Custom,
+//       permission: NotificationPermission.Granted,
+//       pushIdentifier: 'granted'
+//     };
+
+//     const serverAppConfig = TestEnvironment.getFakeServerAppConfig(testConfig.integration!);
+//     serverAppConfig.features.enable_on_session = true;
+//     const stubs = await beforeTest(testConfig, serverAppConfig);
+//     await markUserAsOptedOut();
+
+//     OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
+//       t.is(stubs.onSessionStub.callCount, 1);
+//       t.is(stubs.createPlayerPostStub.callCount, 0);
+//     });
+
+//     const initPromise = OneSignal.init({
+//       appId,
+//       autoResubscribe: true,
+//       promptOptions: {
+//         slidedown: {
+//           enabled: true,
+//           autoPrompt: true,
+//         }
+//       }
+//     });
+//     await initPromise;
+//     t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+// });
+
+// test.serial(`HTTPS: User opted out => first page view => onSession flag is off => no requests`, async t => {
+//   const testConfig: TestEnvironmentConfig = {
+//     httpOrHttps: HttpHttpsEnvironment.Https,
+//     integration: ConfigIntegrationKind.Custom,
+//     permission: NotificationPermission.Granted,
+//     pushIdentifier: 'granted'
+//   };
+
+//   const serverAppConfig = TestEnvironment.getFakeServerAppConfig(testConfig.integration!);
+//   serverAppConfig.features.enable_on_session = false;
+//   const stubs = await beforeTest(testConfig, serverAppConfig);
+//   await markUserAsOptedOut();
+
+//   OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
+//     t.is(stubs.onSessionStub.callCount, 0);
+//     t.is(stubs.createPlayerPostStub.callCount, 0);
+//   });
+
+//   const initPromise = OneSignal.init({
+//     appId,
+//     autoResubscribe: true,
+//     promptOptions: {
+//       slidedown: {
+//         enabled: true,
+//         autoPrompt: true,
+//       }
+//     }
+//   });
+//   await initPromise;
+//   t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+// });
+
+// test.serial(`HTTPS: User opted out => second page view => onSession flag is on => no requests`, async t => {
+//   const testConfig: TestEnvironmentConfig = {
+//     httpOrHttps: HttpHttpsEnvironment.Https,
+//     integration: ConfigIntegrationKind.Custom,
+//     permission: NotificationPermission.Granted,
+//     pushIdentifier: 'granted'
+//   };
+
+//   const serverAppConfig = TestEnvironment.getFakeServerAppConfig(testConfig.integration!);
+//   serverAppConfig.features.enable_on_session = true;
+//   const stubs = await beforeTest(testConfig, serverAppConfig);
+//   await markUserAsOptedOut();
+
+//   sinonSandbox.stub(SessionManager.prototype, "getPageViewCount").resolves(2);
+
+//   OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
+//     t.is(stubs.onSessionStub.callCount, 0);
+//     t.is(stubs.createPlayerPostStub.callCount, 0);
+//   });
+
+//   const initPromise = OneSignal.init({
+//     appId,
+//     autoResubscribe: true,
+//     promptOptions: {
+//       slidedown: {
+//         enabled: true,
+//         autoPrompt: true,
+//       }
+//     }
+//   });
+//   await initPromise;
+// });
+
+// test.serial(`HTTPS: User subscribed => first page view => expiring subscription => sends player update`, async t => {
+//   const testConfig: TestEnvironmentConfig = {
+//     httpOrHttps: HttpHttpsEnvironment.Https,
+//     integration: ConfigIntegrationKind.Custom,
+//     permission: NotificationPermission.Granted,
+//     pushIdentifier: 'granted'
+//   };
+
+//   const stubs = await beforeTest(testConfig);
+//   await markUserAsSubscribed(true);
+
+//   OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
+//     t.is(stubs.onSessionStub.callCount, 0);
+//     // TODO: uncomment after figuring out how to stub all service worker push subscription renewing stuff
+//     // t.is(stubs.createPlayerPostStub.callCount, 1);
+//     t.is(stubs.createPlayerPostStub.callCount, 0);
+//   });
+
+//   const initPromise = OneSignal.init({
+//     appId,
+//     autoResubscribe: true,
+//     promptOptions: {
+//       slidedown: {
+//         enabled: true,
+//         autoPrompt: true,
+//       }
+//     }
+//   });
+//   await initPromise;
+//   t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+// });
+
+// test.serial(`HTTPS: User subscribed => first page view => sends on session`, async t => {
+//   const testConfig: TestEnvironmentConfig = {
+//     httpOrHttps: HttpHttpsEnvironment.Https,
+//     integration: ConfigIntegrationKind.Custom,
+//     permission: NotificationPermission.Granted,
+//     pushIdentifier: 'granted'
+//   };
+
+//   const stubs = await beforeTest(testConfig);
+//   await markUserAsSubscribed();
+
+//   OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
+//     t.is(stubs.onSessionStub.callCount, 1);
+//     t.is(stubs.createPlayerPostStub.callCount, 0);
+//   });
+
+//   const initPromise = OneSignal.init({
+//     appId,
+//     autoResubscribe: true,
+//     promptOptions: {
+//       slidedown: {
+//         enabled: true,
+//         autoPrompt: true,
+//       }
+//     }
+//   });
+//   await initPromise;
+//   t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+// });
+
+// test.serial(`HTTP: User not subscribed and not opted out => first page view => slidedown's autoPrompt is on =>
+//   click allow => sends player create`, async t => {
+//     const testConfig: TestEnvironmentConfig = {
+//       httpOrHttps: HttpHttpsEnvironment.Http,
+//       integration: ConfigIntegrationKind.Custom,
+//       pushIdentifier: (await TestEnvironment.getFakePushSubscription()).endpoint
+//     };
+
+//     const stubs = await beforeTest(testConfig);
+//     stubMessageChannel(t);
+//     mockIframeMessaging(sinonSandbox);
+
+//     simulateSlidedownAllowAfterShown();
+//     simulateNativeAllowAfterShown();
+  
+//     OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
+//       t.is(stubs.onSessionStub.callCount, 0);
+//       t.is(stubs.createPlayerPostStub.callCount, 0);
+//       console.log(1)
+//     });
+//     OneSignal.on(OneSignal.EVENTS.SUBSCRIPTION_CHANGED, () => {
+//       t.is(stubs.onSessionStub.callCount, 0);
+//       t.is(stubs.createPlayerPostStub.callCount, 1);
+//       console.log(2)
+//     });
+
+//     const initPromise = OneSignal.init({
+//       appId,
+//       promptOptions: {
+//         slidedown: {
+//           enabled: true,
+//           autoPrompt: true,
+//         }
+//       },
+//       autoResubscribe: false,
+//     });
+//     await initPromise;
+//     t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+// });
+
+/** Helper methods */
+async function beforeTest(testConfig: TestEnvironmentConfig, customServerAppConfig?: ServerAppConfig) {
+  await TestEnvironment.initialize(testConfig);
+  initTestHelper.mockBasicInitEnv(testConfig, customServerAppConfig);
+  OneSignal.initialized = false;
+  OneSignal.__doNotShowWelcomeNotification = true;
+  (window as any).Notification.permission = testConfig.permission || "default";
+
+  const createPlayerPostStub = sinonSandbox.stub(OneSignalApiBase, "post")
+    .resolves({success: true, id: playerId});
+  const onSessionStub = sinonSandbox.stub(OneSignalApiShared, "updateUserSession")
+    .resolves({success: true, id: playerId});
+
+  sinonSandbox.stub(DynamicResourceLoader.prototype, "loadSdkStylesheet").resolves(ResourceLoadState.Loaded);
+  sinonSandbox.stub(ServiceWorkerManager.prototype, "installWorker").resolves();
+  nock('https://onesignal.com')
+    .get(/.*icon$/)
+    .reply(200, (_uri: string, _requestBody: string) => {
+      return { success: true };
+    });
+
+  return { createPlayerPostStub, onSessionStub };
+}
+
+function simulateSlidedownAllowAfterShown() {
+  OneSignal.on(Popover.EVENTS.SHOWN, () => {
+    OneSignalEvent.trigger(Popover.EVENTS.ALLOW_CLICK);
+  });
+}
+
+function simulateSlidedownDismissAfterShown() {
+  OneSignal.on(Popover.EVENTS.SHOWN, () => {
+    OneSignalEvent.trigger(Popover.EVENTS.CANCEL_CLICK);
+  });
+}
+
+function simulateNativeAllowAfterShown() {
+  OneSignal.emitter.on(OneSignal.EVENTS.PERMISSION_PROMPT_DISPLAYED, () => {
+    sinonSandbox.stub(SubscriptionManager.prototype, "getSubscriptionState")
+      .resolves({subscribed: true, isOptedOut: false});
+    stubServiceWorkerInstallation();
+  });
+}
+
+function simulateNativeBlockAfterShown() {
+  OneSignal.emitter.on(OneSignal.EVENTS.PERMISSION_PROMPT_DISPLAYED, () => {
+    (window as any).Notification.permission = "blocked";
+  });
+}
+
+async function markUserAsOptedOut() {
+  const subscription = new Subscription();
+  subscription.deviceId = playerId;
+  subscription.optedOut = true;
+  subscription.subscriptionToken = "some_token";
+  subscription.createdAt = Date.now();
+  await Database.setSubscription(subscription);
+}
+
+async function markUserAsSubscribed(expired?: boolean) {
+  const subscription = new Subscription();
+  subscription.deviceId = playerId;
+  subscription.optedOut = false;
+  subscription.subscriptionToken = "some_token";
+  subscription.createdAt = new Date(2017, 11, 13, 2, 3, 4, 0).getTime();
+  await Database.setSubscription(subscription);
+
+  sinonSandbox.stub(SubscriptionManager.prototype, "getSubscriptionState")
+    .resolves({subscribed: true, isOptedOut: false});
+  
+  if (expired) {
+    sinonSandbox.stub(InitHelper, "processExpiringSubscriptions").resolves(true);
+  }
+}
+
+function stubServiceWorkerInstallation() {
+  const swRegistration = new ServiceWorkerRegistration();
+  sinonSandbox.stub(SubscriptionManager.prototype, "subscribeFcmVapidOrLegacyKey")
+    .resolves(TestEnvironment.getFakeRawPushSubscription());
+  sinonSandbox.stub((global as any).navigator.serviceWorker, 'ready')
+    .get(() => new Promise((resolve) => { resolve(swRegistration); }));
+  sinonSandbox.stub(ServiceWorkerManager.prototype, "getActiveState")
+    .resolves(ServiceWorkerActiveState.WorkerA);
+  sinonSandbox.stub(ServiceWorkerManager, "getRegistration")
+    .resolves(swRegistration);
+  sinonSandbox.stub(WorkerMessenger.prototype, "unicast").resolves();
+}


### PR DESCRIPTION
 * If user's subscription was expiring and we processed it, our backend would get a player#update request.
 * If user was not subscribed before and autoPrompting is on, user would get subscribed through player#create if
     *  he clicks allow in an automatic prompt.
 * It user has granted notification permissions but cleared the data and autoResubscribe is on, we will
     *  resubscribe with autoResubscribe flag.
 * In all other cases we would send an on_session request.

PS. Tests will follow

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/504)
<!-- Reviewable:end -->
