### PR TITLE
Unsubscribe push instead of unregister sw

### DIFF
--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -392,6 +392,10 @@ export class ServiceWorkerManager {
   private async installAlternatingWorker() {
     const workerState = await this.getActiveState();
 
+    if (workerState === ServiceWorkerActiveState.ThirdParty) {
+      Log.info(`[Service Worker Installation] 3rd party service worker detected.`);
+    }
+
     const workerFullPath = ServiceWorkerHelper.getServiceWorkerHref(workerState, this.config);
     const installUrlQueryParams = Utils.encodeHashAsUriComponent({
       appId: this.context.appConfig.appId

--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -392,18 +392,6 @@ export class ServiceWorkerManager {
   private async installAlternatingWorker() {
     const workerState = await this.getActiveState();
 
-    if (workerState === ServiceWorkerActiveState.ThirdParty) {
-      /*
-         Always unregister 3rd party service workers.
-
-         Unregistering unsubscribes the existing push subscription and allows us
-         to register a new push subscription. This takes care of possible previous mismatched sender IDs
-       */
-      const workerRegistration = await ServiceWorkerManager.getRegistration();
-      if (workerRegistration)
-        await workerRegistration.unregister();
-    }
-
     const workerFullPath = ServiceWorkerHelper.getServiceWorkerHref(workerState, this.config);
     const installUrlQueryParams = Utils.encodeHashAsUriComponent({
       appId: this.context.appConfig.appId

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -330,33 +330,6 @@ export function unsubscribeFromPush() {
   }
 }
 
-
-/**
- * Unregisters the active service worker.
- */
-export function wipeServiceWorker() {
-  Log.warn('OneSignal: Unregistering service worker.');
-  if (SdkEnvironment.getWindowEnv() === WindowEnvironmentKind.OneSignalProxyFrame) {
-    return Promise.resolve();
-  }
-  if (!navigator.serviceWorker || !navigator.serviceWorker.controller)
-    return Promise.resolve();
-
-  return navigator.serviceWorker.ready
-      .then(registration => registration.unregister());
-}
-
-
-/**
- * Unsubscribe from push notifications and remove any active service worker.
- */
-export function wipeServiceWorkerAndUnsubscribe() {
-  return Promise.all([
-    unsubscribeFromPush(),
-    wipeServiceWorker()
-  ]);
-}
-
 export function wait(milliseconds: number) {
   return new Promise(resolve => setTimeout(resolve, milliseconds));
 }

--- a/test/support/mocks/service-workers/models/PushManager.ts
+++ b/test/support/mocks/service-workers/models/PushManager.ts
@@ -1,13 +1,12 @@
 import PushSubscription from './PushSubscription';
 import PushSubscriptionOptions from './PushSubscriptionOptions';
-import { arrayBufferToBase64 } from "../../../../../src/utils/Encoding";
 
 /**
  * The PushManager interface of the Push API provides a way to receive notifications from
  * third-party servers as well as request URLs for push notifications.
  */
 export default class PushManager {
-  private subscription: PushSubscription;
+  private subscription: PushSubscription | null;
 
   constructor() {
     this.subscription = null;
@@ -18,7 +17,7 @@ export default class PushManager {
    * PushSubscription object containing details of an existing subscription. If no existing
    * subscription exists, this resolves to a null value.
    */
-  public async getSubscription(): Promise<PushSubscription> {
+  public async getSubscription(): Promise<PushSubscription | null> {
     return this.subscription;
   }
 
@@ -36,9 +35,16 @@ export default class PushManager {
    * service worker does not have an existing subscription.
    */
   public async subscribe(options: PushSubscriptionOptions): Promise<PushSubscription> {
-    if (!this.subscription) {
-      this.subscription = new PushSubscription(this, options);
+    if (this.subscription) {
+      if (this.subscription.options.applicationServerKey != options.applicationServerKey) {
+        // Simulate browser throwing if you don't unsubscribe first if applicationServerKey has changed.
+        throw {
+          name: "InvalidStateError",
+          message: "Can not change keys without calling unsubscribe first!"
+        };
+      }
     }
+    this.subscription = new PushSubscription(this, options);
     return this.subscription;
   }
 

--- a/test/support/mocks/service-workers/models/PushManager.ts
+++ b/test/support/mocks/service-workers/models/PushManager.ts
@@ -52,6 +52,9 @@ export default class PushManager {
    * Only to be used internally from PushSubscription.unsubscribe().
    */
   public __unsubscribe() {
+    if (!this.subscription) {
+      throw new Error("No Existing subscription!");
+    }
     this.subscription = null;
   }
 }

--- a/test/support/mocks/service-workers/models/PushSubscription.ts
+++ b/test/support/mocks/service-workers/models/PushSubscription.ts
@@ -71,7 +71,7 @@ export default class PushSubscription {
    * Returns an ArrayBuffer which contains the client's public key, which can then be sent to a
    * server and used in encrypting push message data.
    */
-  getKey(param): ArrayBufferLike {
+  getKey(param: string): ArrayBufferLike | null {
     switch (param) {
       case 'p256dh':
         return this.p256dhArray.buffer;


### PR DESCRIPTION
## Stop unregistering ServiceWorkers before replacing

* Stop unregistering the existing 3rd party ServiceWorker before registering ours over the top.
* We did this to make sure we didn't end up using a possible existing push subscription from it.
* Instead we're now calling pushManager.getSubscription().unsubscribe() to unsubscribe from the old push keys if we can't replace the push subscription with our own keys.
* This different strategy has the following benefits;
  - Fixes compatibly with the ServiceWorkerContainer.register.prototype importScripts multiple serviceworker support that Akamai does.
    - Possibly some other libraries / SDKs do this.
  - The extra handling around catching VAPID key changes when subscribing for push means changing OneSignal app_ids won't result in a mis-match server key issue.
  - Under the hood in the browser this is most likely more efficient, it doesn't need to remove anything attached to the service worker.

## Testing
### Test 1 - Changing OneSignal App Id issue
1. Visit https://onesignal.com
2. Subscribe for push
3. Go to https://onesignal.com/404
4. Copy the following in the javascript console
*Replace `YOUR_APP_ID_HERE` before doing so.*
```javascript
function addScriptToPage(url) {
  const scriptElement = document.createElement('script');
  scriptElement.src = url;
  document.head.appendChild(scriptElement);
}
addScriptToPage("https://cdn.onesignal.com/sdks/OneSignalSDK.js");
var OneSignal = window.OneSignal || [];
  OneSignal.push(function() {
    OneSignal.log.setLevel('trace');
    OneSignal.init({
      appId: "YOUR_APP_ID_HERE",
    });
  });
```
5. Go to 2nd app and send yourself a push
6. Observer it errors out

### Test 2 - Akamai compatibility
Tested on a live site with OneSignal and Akamai setup, used Charles proxy to test the issue was fixed.

## Unit tests
List of coverage and tests, new as well as existing that cover behavior already.
### test/unit/managers/SubscriptionManager
1. **NEW test, NEW behavior** - `applicationServerKey = undefined`
   -  "null applicationServerKey throws when subscribing"
2. **Modified test, NEW behavior** - `existingSubscription` & different `applicationServerKey`
   - 'resubscribe-existing strategy uses new subscription applicationServerKey'
3. **NEW test** - `SubscriptionStrategyKind.ResubscribeExisting` & `existingSubscription.options != null`
   -  "resubscribe existing strategy does not unsubscribes if options are not null"
4. `SubscriptionStrategyKind.ResubscribeExisting` & `existingSubscription.options = null`
   - 'resubscribe existing strategy unsubscribes and creates new subscription if existing subscription options are null'
5. `SubscriptionStrategyKind.SubscribeNew` & `existingSubscription`
   -  'subscribe new strategy unsubscribes existing subscription to create new subscription'


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/521)
<!-- Reviewable:end -->
