### PR TITLE
Fixes registering for push with the akam-sw.js

### DIFF
--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -117,10 +117,8 @@ export class ServiceWorkerManager {
       return ServiceWorkerActiveState.ThirdParty;
     }
 
-    /*
-      At this point, there is an active service worker registration controlling this page.
-      Check the filename to see if it belongs to our A / B worker.
-    */
+    // At this point, there is an active service worker registration controlling this page.
+    // We are now; 1. Getting the filename of the SW; 2. Checking if it is ours or a 3rd parties.
     const swFileName = ServiceWorkerManager.activeSwFileName(workerRegistration);
     const workerState = this.swActiveStateByFileName(swFileName);
 
@@ -142,6 +140,7 @@ export class ServiceWorkerManager {
     return workerState;
   }
 
+  // Get the file name of the active ServiceWorker
   private static activeSwFileName(workerRegistration: ServiceWorkerRegistration): string | null {
     if (!workerRegistration.active)
       return null;
@@ -150,18 +149,19 @@ export class ServiceWorkerManager {
     const swFileName = new Path(workerScriptPath).getFileName();
 
     // If the current service worker is Akamai's
-    //    Check if it is importing our's with a query param name "othersw"
     if (swFileName == "akam-sw.js") {
+      // Check if its importing a ServiceWorker under it's "othersw" query param
       const searchParams = new URLSearchParams(new URL(workerRegistration.active.scriptURL).search);
       const importedSw = searchParams.get("othersw");
       if (importedSw) {
-        Log.debug("Found OneSignal ServiceWorker under Akamai's akam-sw.js?othersw=", importedSw);
+        Log.debug("Found a ServiceWorker under Akamai's akam-sw.js?othersw=", importedSw);
         return new Path(new URL(importedSw).pathname).getFileName();
       }
     }
     return swFileName;
   }
 
+  // Check if the ServiceWorker file name is ours or a third party's
   private swActiveStateByFileName(fileName: string | null): ServiceWorkerActiveState {
     if (!fileName)
       return ServiceWorkerActiveState.None;

--- a/test/unit/managers/ServiceWorkerManager.ts
+++ b/test/unit/managers/ServiceWorkerManager.ts
@@ -141,6 +141,26 @@ test('getActiveState() detects an activated third-party service worker not contr
   t.is(await manager.getActiveState(), ServiceWorkerActiveState.ThirdParty);
 });
 
+test('getActiveState() should detect Akamai akam-sw.js?othersw= when our is contain within', async t => {
+  await navigator.serviceWorker.register('/akam-sw.js?othersw=https://domain.com/Worker-A.js?appId=12345');
+
+  const manager = LocalHelpers.getServiceWorkerManager();
+  t.is(await manager.getActiveState(), ServiceWorkerActiveState.WorkerA);
+});
+
+test('getActiveState() should detect Akamai akam-sw.js as 3rd party if no othersw=', async t => {
+  await navigator.serviceWorker.register('/akam-sw.js?othersw=https://domain.com/someothersw.js');
+
+  const manager = LocalHelpers.getServiceWorkerManager();
+  t.is(await manager.getActiveState(), ServiceWorkerActiveState.ThirdParty);
+});
+
+test('getActiveState() should detect Akamai akam-sw.js as 3rd party if othersw= is not our worker', async t => {
+  await navigator.serviceWorker.register('/akam-sw.js');
+
+  const manager = LocalHelpers.getServiceWorkerManager();
+  t.is(await manager.getActiveState(), ServiceWorkerActiveState.ThirdParty);
+});
 
 test('notification clicked - While page is opened in background', async t => {
   await TestEnvironment.initialize({


### PR DESCRIPTION
* If we detect akam-sw.js as the active ServiceWorker we check the query param othersw= to see if ours is included
   - If we detect our ServiceWorker name then correctly count it as registered.
   - This fixes an issue where our SDK thought our ServiceWorker never registered when in fact it did.
* This fix is a continuation of PR #521, which fixed service worker unregistering loop with akam-sw.js.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/530)
<!-- Reviewable:end -->
