### PR TITLE
Cleaned up extra create and on_session fields

### DIFF
--- a/src/bell/Dialog.ts
+++ b/src/bell/Dialog.ts
@@ -2,18 +2,16 @@ import bowser from 'bowser';
 
 import Event from '../Event';
 import SdkEnvironment from '../managers/SdkEnvironment';
-import { addDomElement, clearDomElementChildren, isChromeLikeBrowser } from '../utils';
+import {addDomElement, clearDomElementChildren, getPlatformNotificationIcon} from '../utils';
 import AnimatedElement from './AnimatedElement';
 import Bell from './Bell';
-
-
 
 export default class Dialog extends AnimatedElement {
 
   public bell: Bell;
   public subscribeButtonId: string;
   public unsubscribeButtonId: string;
-  public notificationIcons: any;
+  public notificationIcons: NotificationIcons | null;
 
   constructor(bell: Bell) {
     super('.onesignal-bell-launcher-dialog', 'onesignal-bell-launcher-dialog-opened', undefined, 'hidden',
@@ -23,18 +21,6 @@ export default class Dialog extends AnimatedElement {
     this.subscribeButtonId = '#onesignal-bell-container .onesignal-bell-launcher #subscribe-button';
     this.unsubscribeButtonId = '#onesignal-bell-container .onesignal-bell-launcher #unsubscribe-button';
     this.notificationIcons = null;
-  }
-
-  getPlatformNotificationIcon() {
-    if (this.notificationIcons) {
-      if (isChromeLikeBrowser() || bowser.firefox || bowser.msedge) {
-        return this.notificationIcons.chrome || this.notificationIcons.safari;
-      }
-      else if (bowser.safari) {
-        return this.notificationIcons.safari || this.notificationIcons.chrome;
-      }
-    }
-    else return null;
   }
 
   show() {
@@ -74,7 +60,7 @@ export default class Dialog extends AnimatedElement {
         this.bell.state === Bell.STATES.UNSUBSCRIBED && currentSetSubscription === false) {
 
         let notificationIconHtml = '';
-        let imageUrl = this.getPlatformNotificationIcon();
+        let imageUrl = getPlatformNotificationIcon(this.notificationIcons);
         if (imageUrl) {
           notificationIconHtml = `<div class="push-notification-icon"><img src="${imageUrl}"></div>`
         } else {

--- a/src/models/DevicePlatformKind.ts
+++ b/src/models/DevicePlatformKind.ts
@@ -1,5 +1,0 @@
-export enum DevicePlatformKind {
-  Mobile = "mobile",
-  Tablet = "tablet",
-  Desktop = "desktop",
-}

--- a/src/models/NotificationIcons.ts
+++ b/src/models/NotificationIcons.ts
@@ -1,0 +1,5 @@
+interface NotificationIcons {
+  chrome?: string;
+  firefox?: string;
+  safari?: string;
+}

--- a/src/popover/Popover.ts
+++ b/src/popover/Popover.ts
@@ -2,12 +2,12 @@ import bowser from 'bowser';
 
 import Event from '../Event';
 import MainHelper from '../helpers/MainHelper';
-import { addCssClass, addDomElement, once, removeDomElement, isChromeLikeBrowser } from '../utils';
+import {addCssClass, addDomElement, getPlatformNotificationIcon, once, removeDomElement} from '../utils';
 import { SlidedownPermissionMessageOptions } from '../models/AppConfig';
 
 export default class Popover {
   public options: SlidedownPermissionMessageOptions;
-  public notificationIcons: any;
+  public notificationIcons: NotificationIcons | null;
 
   static get EVENTS() {
     return {
@@ -83,18 +83,7 @@ export default class Popover {
   }
 
   getPlatformNotificationIcon(): string {
-    if (!this.notificationIcons)
-      return 'default-icon';
-
-    if (bowser.safari && this.notificationIcons.safari)
-      return this.notificationIcons.safari;
-    else if (bowser.firefox && this.notificationIcons.firefox)
-      return this.notificationIcons.firefox;
-
-    return this.notificationIcons.chrome ||
-      this.notificationIcons.firefox ||
-      this.notificationIcons.safari ||
-      'default-icon';
+    return getPlatformNotificationIcon(this.notificationIcons);
   }
 
   get container() {

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -499,27 +499,18 @@ export class ServiceWorker {
      * to 14 with requireInteraction and 28 without, we force Mac OS X Chrome
      * notifications to be transient.
      */
-    if (typeof options !== "object") {
-      return options;
-    } else {
-      const clone = {...options};
+    const clone = { ...options };
+    const browser = OneSignalUtils.redetectBrowserUserAgent();
 
-      if (bowser.name === '' && bowser.version === '') {
-        var browser = (bowser as any)._detect(navigator.userAgent);
-      } else {
-        var browser: any = bowser;
-      }
-
-      if (browser.chrome &&
-        browser.mac &&
-        clone) {
-        clone.requireInteraction = false;
-      }
-      if (forcePersistNotifications) {
-        clone.requireInteraction = true;
-      }
-      return clone;
+    if (browser.chrome &&
+      browser.mac &&
+      clone) {
+      clone.requireInteraction = false;
     }
+    if (forcePersistNotifications) {
+      clone.requireInteraction = true;
+    }
+    return clone;
   }
 
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,3 @@
-import bowser from 'bowser';
-
 import TimeoutError from './errors/TimeoutError';
 import SdkEnvironment from './managers/SdkEnvironment';
 import { WindowEnvironmentKind } from './models/WindowEnvironmentKind';
@@ -9,7 +7,7 @@ import { OneSignalUtils } from './utils/OneSignalUtils';
 import { PermissionUtils } from './utils/PermissionUtils';
 import { BrowserUtils } from './utils/BrowserUtils';
 import { Utils } from "./utils/Utils";
-
+import bowser from 'bowser';
 
 export function isArray(variable: any) {
   return Object.prototype.toString.call(variable) === '[object Array]';
@@ -17,13 +15,6 @@ export function isArray(variable: any) {
 
 export function decodeHtmlEntities(text: string) {
   return BrowserUtils.decodeHtmlEntities(text);
-}
-
-export function isChromeLikeBrowser() {
-  return bowser.chrome ||
-    (bowser as any).chromium ||
-    (bowser as any).opera ||
-    (bowser as any).yandexbrowser;
 }
 
 export function removeDomElement(selector: string) {
@@ -36,10 +27,6 @@ export function removeDomElement(selector: string) {
       }
     }
   }
-}
-
-export function isLocalhostAllowedAsSecureOrigin() {
-  return OneSignalUtils.isLocalhostAllowedAsSecureOrigin();
 }
 
 /**
@@ -409,13 +396,17 @@ export function incrementSdkLoadCount() {
   (<any>window).__oneSignalSdkLoadCount = getSdkLoadCount() + 1;
 }
 
-/**
- * Returns the email with all whitespace removed and converted to lower case.
- */
-export function prepareEmailForHashing(email: string): string {
-  return email.replace(/\s/g, '').toLowerCase();
-}
+export function getPlatformNotificationIcon(notificationIcons: NotificationIcons | null): string {
+  if (!notificationIcons)
+    return 'default-icon';
 
-export function encodeHashAsUriComponent(hash: any): string {
-  return Utils.encodeHashAsUriComponent(hash);
+  if (bowser.safari && notificationIcons.safari)
+    return notificationIcons.safari;
+  else if (bowser.firefox && notificationIcons.firefox)
+    return notificationIcons.firefox;
+
+  return notificationIcons.chrome ||
+    notificationIcons.firefox ||
+    notificationIcons.safari ||
+    'default-icon';
 }

--- a/src/utils/OneSignalUtils.ts
+++ b/src/utils/OneSignalUtils.ts
@@ -73,7 +73,7 @@ export class OneSignalUtils {
 
   public static redetectBrowserUserAgent(): IBowser {
     // During testing, the browser object may be initialized before the userAgent is injected
-    if (bowser.name === '' && bowser.version === '') {
+    if (bowser.name === "" && bowser.version === "") {
       return bowser._detect(navigator.userAgent);
     }
     return bowser;

--- a/test/support/tester/utils.ts
+++ b/test/support/tester/utils.ts
@@ -94,3 +94,12 @@ export class AssertInitSDK {
     this.firedSDKInitializedPublic = false;
   }
 }
+
+// PushSubscriptionOptions is a class present in browsers that support the Push API
+export function setupBrowserWithPushAPIWithVAPIDEnv(sandbox: SinonSandbox): void {
+  const classDef = function() {};
+  classDef.prototype.applicationServerKey = null;
+  classDef.prototype.userVisibleOnly = null;
+
+  sandbox.stub((<any>global), "PushSubscriptionOptions").value(classDef);
+}

--- a/test/unit/modules/browserSupport.ts
+++ b/test/unit/modules/browserSupport.ts
@@ -3,6 +3,7 @@ import test from "ava";
 import { TestEnvironment } from '../../support/sdk/TestEnvironment';
 import { isPushNotificationsSupported } from "../../../src/utils/BrowserSupportsPush";
 import sinon from 'sinon';
+import { setupBrowserWithPushAPIWithVAPIDEnv } from "../../support/tester/utils";
 
 const sandbox = sinon.sandbox.create();
 
@@ -14,16 +15,7 @@ test.afterEach(function () {
   sandbox.restore();
 });
 
-// PushSubscriptionOptions is a class present in browsers that support the Push API
-export function browserWithPushAPIWithVAPIDEnv(): void {
-  const classDef = function() {};
-  classDef.prototype.applicationServerKey = null;
-  classDef.prototype.userVisibleOnly = null;
-
-  sandbox.stub((<any>global), "PushSubscriptionOptions").value(classDef);
-}
-
-function browserWithPushAPIButNoVAPIDEnv(): void {
+function setupBrowserWithPushAPIButNoVAPIDEnv(): void {
   const classDef = function() {};
   classDef.prototype.userVisibleOnly = null;
 
@@ -31,17 +23,17 @@ function browserWithPushAPIButNoVAPIDEnv(): void {
 }
 
 // Define window.safari.pushNotification
-function safariWithPushEnv(): void {
+function setupSafariWithPushEnv(): void {
   sandbox.stub((<any>global).self, "safari").value({ pushNotification: {} });
 }
 
 // Define window.safari
-function safariWithoutPushEnv(): void {
+function setupSafariWithoutPushEnv(): void {
   sandbox.stub((<any>global).self, "safari").value({});
 }
 
 test('should support browsers that have PushSubscriptionOptions.applicationServerKey defined', async t => {
-  browserWithPushAPIWithVAPIDEnv();
+  setupBrowserWithPushAPIWithVAPIDEnv(sandbox);
   t.true(isPushNotificationsSupported());
 });
 
@@ -50,16 +42,16 @@ test('should not support browsers without PushSubscriptionOptions', async t => {
 });
 
 test('should not support browsers without VAPID', async t => {
-  browserWithPushAPIButNoVAPIDEnv();
+  setupBrowserWithPushAPIButNoVAPIDEnv();
   t.false(isPushNotificationsSupported());
 });
 
 test('should support Safari if window.safari.pushNotification is defined', async t => {
-  safariWithPushEnv();
+  setupSafariWithPushEnv();
   t.true(isPushNotificationsSupported());
 });
 
 test('should not support Safari unless pushNotification is defined on window.safari', async t => {
-  safariWithoutPushEnv();
+  setupSafariWithoutPushEnv();
   t.false(isPushNotificationsSupported());
 });

--- a/test/unit/modules/entryInitialization.ts
+++ b/test/unit/modules/entryInitialization.ts
@@ -11,7 +11,7 @@ import { OneSignalShimLoader } from "../../../src/utils/OneSignalShimLoader";
 import { SinonSandbox } from "sinon";
 import sinon from 'sinon';
 import Log from "../../../src/libraries/Log";
-import { browserWithPushAPIWithVAPIDEnv } from "./browserSupport";
+import { setupBrowserWithPushAPIWithVAPIDEnv } from "../../support/tester/utils";
 
 let sandbox: SinonSandbox;
 
@@ -399,7 +399,7 @@ test("Expect Promise to never resolve for ES5 stubs", async t => {
 });
 
 test("OneSignalSDK.js loads OneSignalStubES6 is loaded on a page on a browser supports push", async t => {
-  browserWithPushAPIWithVAPIDEnv();
+  setupBrowserWithPushAPIWithVAPIDEnv(sandbox);
   OneSignalShimLoader.start();
   t.true((<any>window).OneSignal instanceof OneSignalStubES6);
 });
@@ -459,7 +459,7 @@ test("Existing OneSignal array before OneSignalSDK.js loaded ES6", async t => {
   const preExistingArray = [() => {}, ["init", "test"]];
   (<any>window).OneSignal = preExistingArray;
 
-  browserWithPushAPIWithVAPIDEnv();
+  setupBrowserWithPushAPIWithVAPIDEnv(sandbox);
   OneSignalShimLoader.start();
 
   t.deepEqual(<object[]>(<OneSignalStubES6>(<any>window).OneSignal).preExistingArray, preExistingArray);

--- a/test/unit/public-sdk-apis/onSession.ts
+++ b/test/unit/public-sdk-apis/onSession.ts
@@ -859,12 +859,6 @@ function simulateNativeAllowAfterShown() {
   });
 }
 
-function simulateNativeBlockAfterShown() {
-  OneSignal.emitter.on(OneSignal.EVENTS.PERMISSION_PROMPT_DISPLAYED, () => {
-    (window as any).Notification.permission = "blocked";
-  });
-}
-
 async function markUserAsOptedOut() {
   const subscription = new Subscription();
   subscription.deviceId = playerId;
@@ -922,12 +916,6 @@ async function inspectPushRecordCreationRequest(t: TestContext, requestStub: Sin
     "timezone",
     "device_os",
     "sdk",
-    "delivery_platform",
-    "browser_name",
-    "browser_version",
-    "operating_system",
-    "operating_system_version",
-    "device_platform",
     "device_model",
     "identifier",
     "notification_types"
@@ -935,7 +923,7 @@ async function inspectPushRecordCreationRequest(t: TestContext, requestStub: Sin
   t.is(requestStub.callCount, 1);
   t.not(requestStub.getCall(0), null);
   const data: any = requestStub.getCall(0).args[1];
-  anyValues.forEach((valueKey) => {
+  anyValues.forEach(valueKey => {
     t.not(data[valueKey], undefined, `player create: ${valueKey} is undefined! => data: ${JSON.stringify(data)}`);
   });
 }
@@ -948,17 +936,13 @@ async function inspectOnSessionRequest(t: TestContext, requestStub: SinonStub) {
     "timezone",
     "browserVersion",
     "sdkVersion",
-    "browserName",
     "subscriptionState",
-    "operatingSystem",
-    "operatingSystemVersion",
-    "devicePlatform",
     "deviceModel",
   ];
   t.is(requestStub.callCount, 1);
   t.not(requestStub.getCall(0), null);
   const data: any = requestStub.getCall(0).args[1];
-  anyValues.forEach((valueKey) => {
+  anyValues.forEach(valueKey => {
     t.not(data[valueKey], undefined, `on_session: ${valueKey} is undefined! => data: ${JSON.stringify(data)}`);
   });
 }

--- a/test/unit/public-sdk-apis/setEmail.ts
+++ b/test/unit/public-sdk-apis/setEmail.ts
@@ -93,13 +93,7 @@ async function expectEmailRecordCreationRequest(
         "timezone",
         "device_os",
         "sdk",
-        "delivery_platform",
-        "browser_name",
-        "browser_version",
-        "operating_system",
-        "operating_system_version",
-        "device_platform",
-        "device_model",
+        "device_model"
       ];
       const parsedRequestBody = JSON.parse(requestBody);
       for (const sameValueKey of Object.keys(sameValues)) {
@@ -135,13 +129,7 @@ async function expectEmailRecordUpdateRequest(
         "timezone",
         "device_os",
         "sdk",
-        "delivery_platform",
-        "browser_name",
-        "browser_version",
-        "operating_system",
-        "operating_system_version",
-        "device_platform",
-        "device_model",
+        "device_model"
       ];
       const parsedRequestBody = JSON.parse(requestBody);
       for (const sameValueKey of Object.keys(sameValues)) {


### PR DESCRIPTION
* Cleaned up delivery_platform, browser_name, browser_version, operating_system, operating_system_version, device_platform
* These parameters are not valid on the api/v1/players endpoint so are unnecessary
* Also fixed issue where preview on the bell icon was not showing the notification icon for the Samsung browser.
   - Updated to use the function from the popover prompt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/543)
<!-- Reviewable:end -->
