### PR TITLE
Fix case sensitive pageSDKInit build issue

### DIFF
--- a/build/config/page-sdk-es6.config.js
+++ b/build/config/page-sdk-es6.config.js
@@ -62,7 +62,7 @@ async function generateWebpackConfig() {
   return {
     target: 'web',
     entry: {
-      'OneSignalPageSDKES6.js': path.resolve('build/ts-to-es6/src/entries/pageSDKInit.js'),
+      'OneSignalPageSDKES6.js': path.resolve('build/ts-to-es6/src/entries/pageSdkInit.js'),
     },
     output: {
       path: path.resolve('build/bundles'),


### PR DESCRIPTION
* pageSDKInit case issue was not present when running on docker for macOS.
  - Issue may be related only when running on a linux host or window host perhaps

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/546)
<!-- Reviewable:end -->
