### PR TITLE
Fix isPush support on safari in an iframe

### DIFF
--- a/src/utils/BrowserSupportsPush.ts
+++ b/src/utils/BrowserSupportsPush.ts
@@ -3,27 +3,38 @@
 
 // Checks if the browser supports push notifications by checking if specific
 //   classes and properties on them exist
+export function isPushNotificationsSupported() {
+  return supportsVapidPush() || supportsSafariPush();
+}
 
+// Does the browser support Safari's proprietary push
+function supportsSafariPush(): boolean {
+  if (typeof window.safari !== "undefined" &&
+      typeof window.safari.pushNotification !== "undefined") {
+    return true;
+  }
+
+  // Fallback detection for Safari on macOS in an iframe context
+  return window.top !== window && // isContextIframe
+         navigator.vendor === "Apple Computer, Inc." && // isSafari
+         navigator.platform === "MacIntel"; // isMacOS
+}
+
+// Does the browser support the standard Push API
+function supportsVapidPush(): boolean {
+  return typeof PushSubscriptionOptions !== "undefined" &&
+         PushSubscriptionOptions.prototype.hasOwnProperty("applicationServerKey");
+}
+
+/* Notes on browser results which lead the logic of the functions above */
 // Safari
 //   macOS - typeof safari.pushNotification == "object"
+//         - iframe context - typeof safari == "undefined"
 //   iOS -  typeof safari == "undefined"
 // Chrome
 //   HTTP & HTTPS - typeof PushSubscriptionOptions == "function"
+//   HTTP - navigator.serviceWorker == "undefined"
 // Firefox
 //   Normal - typeof PushSubscriptionOptions == "function"
 //     HTTP & HTTPS - typeof PushSubscriptionOptions == "function"
 //   ESR - typeof PushSubscriptionOptions == "undefined"
-
-export function isPushNotificationsSupported() {
-  // window.safari will be present on macOS only
-  if (typeof window.safari !== "undefined") {
-    return typeof window.safari.pushNotification !== "undefined";
-  }
-
-  if (typeof PushSubscriptionOptions !== "undefined") {
-    // applicationServerKey required for VAPID
-    return PushSubscriptionOptions.prototype.hasOwnProperty("applicationServerKey");
-  }
-
-  return false;
-}

--- a/test/unit/modules/browserSupport.ts
+++ b/test/unit/modules/browserSupport.ts
@@ -24,12 +24,19 @@ function setupBrowserWithPushAPIButNoVAPIDEnv(): void {
 
 // Define window.safari.pushNotification
 function setupSafariWithPushEnv(): void {
-  sandbox.stub((<any>global).self, "safari").value({ pushNotification: {} });
+  sandbox.stub(window, "safari").value({ pushNotification: {} });
 }
 
 // Define window.safari
 function setupSafariWithoutPushEnv(): void {
-  sandbox.stub((<any>global).self, "safari").value({});
+  sandbox.stub(window, "safari").value({});
+}
+
+// Safari on macOS when running in iframe context
+function setupSafariMacOSInIframeContext(): void {
+  sandbox.stub(window, "top").value("someOtherWindow");
+  sandbox.stub(navigator, "vendor").value("Apple Computer, Inc.");
+  sandbox.stub(navigator, "platform").value("MacIntel");
 }
 
 test('should support browsers that have PushSubscriptionOptions.applicationServerKey defined', async t => {
@@ -54,4 +61,9 @@ test('should support Safari if window.safari.pushNotification is defined', async
 test('should not support Safari unless pushNotification is defined on window.safari', async t => {
   setupSafariWithoutPushEnv();
   t.false(isPushNotificationsSupported());
+});
+
+test('should support macOS Safari if running in iframe', async t => {
+  setupSafariMacOSInIframeContext();
+  t.true(isPushNotificationsSupported());
 });


### PR DESCRIPTION
* Unfortunately window.safari is not defined on Safari if in an iframe context
* Due to this there is no other way than to have fallback logic to
   check navigator properties if we are on macOS Safari.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/548)
<!-- Reviewable:end -->
