### PR TITLE
Removed old retrieveNotifications and manifest

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -250,10 +250,8 @@ export default class OneSignal {
     async function __init() {
       if (OneSignal.__initAlreadyCalled)
         return;
-      else
-        OneSignal.__initAlreadyCalled = true;
 
-      MainHelper.fixWordpressManifestIfMisplaced();
+      OneSignal.__initAlreadyCalled = true;
 
       OneSignal.emitter.on(OneSignal.EVENTS.NATIVE_PROMPT_PERMISSIONCHANGED, EventHelper.onNotificationPermissionChange);
       OneSignal.emitter.on(OneSignal.EVENTS.SUBSCRIPTION_CHANGED, EventHelper._onSubscriptionChanged);

--- a/src/helpers/MainHelper.ts
+++ b/src/helpers/MainHelper.ts
@@ -12,26 +12,6 @@ import { PermissionUtils } from "../utils/PermissionUtils";
 import { Utils } from "../utils/Utils";
 
 export default class MainHelper {
-  /**
-   * If there are multiple manifests, and one of them is our OneSignal manifest, we move it to the top of <head> to ensure our manifest is used for push subscription (manifests after the first are ignored as part of the spec).
-   */
-  static fixWordpressManifestIfMisplaced() {
-    var manifests = document.querySelectorAll('link[rel=manifest]');
-    if (!manifests || manifests.length <= 1) {
-      // Multiple manifests do not exist on this webpage; there is no issue
-      return;
-    }
-    for (let i = 0; i < manifests.length; i++) {
-      let manifest = manifests[i];
-      let url = (manifest as any).href;
-      if (Utils.contains(url, 'gcm_sender_id')) {
-        // Move the <manifest> to the first thing in <head>
-        const head = document.querySelector('head');
-        head.insertBefore(manifest, head.children[0]);
-        Log.info('OneSignal: Moved the WordPress push <manifest> to the first element in <head>.');
-      }
-    }
-  }
 
   public static async getCurrentNotificationType(): Promise<SubscriptionStateKind> {
     const currentPermission: NotificationPermission =

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -376,7 +376,7 @@ export class SubscriptionManager {
     const workerRegistration = await navigator.serviceWorker.ready;
     Log.debug('Service worker is ready to continue subscribing.');
 
-    return await this.subscribeFcmVapidOrLegacyKey(workerRegistration.pushManager, subscriptionStrategy);
+    return await this.subscribeWithVapidKey(workerRegistration.pushManager, subscriptionStrategy);
   }
 
   public async subscribeFcmFromWorker(
@@ -414,7 +414,7 @@ export class SubscriptionManager {
       throw new PushPermissionNotGrantedError(PushPermissionNotGrantedErrorReason.Default);
     }
 
-    return await this.subscribeFcmVapidOrLegacyKey(self.registration.pushManager, subscriptionStrategy);
+    return await this.subscribeWithVapidKey(self.registration.pushManager, subscriptionStrategy);
   }
 
   /**
@@ -457,15 +457,13 @@ export class SubscriptionManager {
    * push subscription is resubscribed as-is leaving it unchanged, or unsubscribed to make room for
    * a new push subscription.
    */
-  public async subscribeFcmVapidOrLegacyKey(
+  public async subscribeWithVapidKey(
     pushManager: PushManager,
     subscriptionStrategy: SubscriptionStrategyKind
   ): Promise<RawPushSubscription> {
     /*
       Always try subscribing using VAPID by providing an applicationServerKey, except for cases
-      where the user is already subscribed, handled below. If browser doesn't support VAPID's
-      applicationServerKey property, our extra options will be safely ignored, and a non-VAPID
-      subscription will be automatically returned.
+      where the user is already subscribed, handled below.
      */
 
     const existingPushSubscription = await pushManager.getSubscription();

--- a/test/unit/managers/SubscriptionManager.ts
+++ b/test/unit/managers/SubscriptionManager.ts
@@ -89,7 +89,7 @@ async function testCase(
   const spy = sandbox.spy(PushManager.prototype, 'subscribe');
 
   // Subscribe for push
-  await manager.subscribeFcmVapidOrLegacyKey(registration.pushManager as any, subscriptionStrategy);
+  await manager.subscribeWithVapidKey(registration.pushManager as any, subscriptionStrategy);
 
   // Allow each test to verify mock parameters independently
   if (onPushManagerSubscribed) {

--- a/test/unit/public-sdk-apis/onSession.ts
+++ b/test/unit/public-sdk-apis/onSession.ts
@@ -888,7 +888,7 @@ async function markUserAsSubscribedOnHttp(expired?: boolean) {
 
 function stubServiceWorkerInstallation() {
   const swRegistration = new ServiceWorkerRegistration();
-  sinonSandbox.stub(SubscriptionManager.prototype, "subscribeFcmVapidOrLegacyKey")
+  sinonSandbox.stub(SubscriptionManager.prototype, "subscribeWithVapidKey")
     .resolves(TestEnvironment.getFakeRawPushSubscription());
   sinonSandbox.stub((global as any).navigator.serviceWorker, 'ready')
     .get(() => new Promise((resolve) => { resolve(swRegistration); }));


### PR DESCRIPTION
* Removed retrieveNotifications
   - OneSignal backend no longer sends to tokens that aren't vapid
* No longer need `fixWordpressManifestIfMisplaced` as the manifest.json isn't needed any more

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/549)
<!-- Reviewable:end -->
