### PR TITLE
Resolve bug where navigator.permissions is undefined in Firefox

### DIFF
--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -873,7 +873,8 @@ export class ServiceWorker {
         If the permission is revoked, we should set the subscription state to permission revoked.
        */
       let subscriptionState: null | SubscriptionStateKind = null;
-      const pushPermission = await navigator.permissions.query({name:'push', userVisibleOnly:true});
+      const pushPermission: string = Notification["permission"];
+
       if (pushPermission !== "granted") {
         subscriptionState = SubscriptionStateKind.PermissionRevoked;
       } else if (!rawPushSubscription) {

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -20,7 +20,7 @@ import { Utils } from "../utils/Utils";
 
 ///<reference path="../../typings/globals/service_worker_api/index.d.ts"/>
 declare var self: ServiceWorkerGlobalScope;
-
+declare var Notification: Notification;
 
 /**
  * The main service worker script fetching and displaying notifications to users in the background even when the client
@@ -873,7 +873,7 @@ export class ServiceWorker {
         If the permission is revoked, we should set the subscription state to permission revoked.
        */
       let subscriptionState: null | SubscriptionStateKind = null;
-      const pushPermission: string = Notification["permission"];
+      const pushPermission= Notification.permission;
 
       if (pushPermission !== "granted") {
         subscriptionState = SubscriptionStateKind.PermissionRevoked;

--- a/test/support/mocks/service-workers/models/WorkerNavigator.ts
+++ b/test/support/mocks/service-workers/models/WorkerNavigator.ts
@@ -11,7 +11,7 @@ export default class WorkerNavigator {
   ) {
     this.permissions = {
       query: async function() {
-        return "granted";
+        return { state: "granted" };
       }
     };
   }

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -263,7 +263,8 @@ export class TestEnvironment {
         callback(config.pushIdentifier);
       }
     };
-    
+   
+    // window is only defined in DOM environment (not in SW)
     if (config.environment === "dom") {
       global.window.Notification = global.Notification;
     }

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -167,6 +167,8 @@ export class TestEnvironment {
     workerInstance.state = "activated";
     serviceWorkerScope.registration = new ServiceWorkerRegistration();
     serviceWorkerScope.registration.active = workerInstance;
+    config.environment = "serviceWorker";
+    TestEnvironment.stubNotification(config);
 
     Object.assign(global, serviceWorkerScope);
     global.self = global;
@@ -253,7 +255,7 @@ export class TestEnvironment {
   }
 
   static stubNotification(config: TestEnvironmentConfig) {
-    global.window.Notification = global.Notification = {
+    global.Notification = {
       permission: config.permission ? config.permission: NotificationPermission.Default,
       maxActions: 2,
       requestPermission: function(callback: Function) {
@@ -261,6 +263,10 @@ export class TestEnvironment {
         callback(config.pushIdentifier);
       }
     };
+    
+    if (config.environment === "dom") {
+      global.window.Notification = global.Notification;
+    }
   }
 
   static stubNotifyButtonTransitionEvents() {
@@ -289,6 +295,7 @@ export class TestEnvironment {
     SdkEnvironment.getTestEnv = () => TestEnvironmentKind.UnitTesting;
     await TestEnvironment.stubDomEnvironment(config);
     TestEnvironment.stubNotifyButtonTransitionEvents();
+    config.environment = "dom";
     TestEnvironment.stubNotification(config);
     return global.OneSignal;
   }

--- a/test/unit/serviceWorker/pushSubscriptionChange.ts
+++ b/test/unit/serviceWorker/pushSubscriptionChange.ts
@@ -34,13 +34,16 @@ test.beforeEach(async() => {
     userVisibleOnly: true,
     applicationServerKey: Random.getRandomUint8Array(65).buffer
   });
+  
   newSubscription = await new PushManager().subscribe({
     userVisibleOnly: true,
     applicationServerKey: Random.getRandomUint8Array(65).buffer
   });
+  
   await TestEnvironment.initializeForServiceWorker({
     url: new URL(`https://site.com/service-worker.js?appId=${appId}`)
   });
+  
   setBrowser(BrowserUserAgent.ChromeMacSupported);
 });
 
@@ -50,12 +53,12 @@ test.afterEach(function (_t: TestContext) {
 
 test(`called with an old and new subscription successfully updates the subscription`, async t => {
   /*
-      For this test, pretend the user revoked permissions, pushsubscriptionchange's event provides
-      an oldSubscription but not a new subscription, and the service worker tries to resubscribe
-      anyways.
+    For this test, pretend the user revoked permissions, pushsubscriptionchange's event provides
+    an oldSubscription but not a new subscription, and the service worker tries to resubscribe
+    anyways.
 
-      It's going to fail due to the blocked permission, so let's simulate that here.
-     */
+    It's going to fail due to the blocked permission, so let's simulate that here.
+   */
   sinonSandbox
     .stub(SubscriptionManager.prototype, 'subscribeFcmFromWorker')
     .throws('some-error');
@@ -70,6 +73,10 @@ test(`called with an old and new subscription successfully updates the subscript
   const event = new PushSubscriptionChangeEvent();
   event.oldSubscription = oldSubscription;
   event.newSubscription = newSubscription;
+
+  // navigator.permissions is undefined in Firefox service worker context, lets simulate that here
+  sinonSandbox.stub(navigator, 'permissions').value(undefined);
+  
   await runPushSubscriptionChange(event);
 
   // After pushsubscriptionchange


### PR DESCRIPTION
- Use `Notification` to get the push permission instead of `navigator.permissions`
- Added `navigator.permissions` = undefined mock to pushsubscriptionchange test to simulate SW environment in Firefox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/555)
<!-- Reviewable:end -->

Closes #545 
Fixes #545 
