### PR TITLE
S3 upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
     - node_modules
 script:
   - 'yarn run test:noWatch'
+  - 'yarn clean && yarn build:prod && ./.travis/s3-simple-upload-all.sh build/releases s3://onesignal-build/websdk'
 git:
   depth: 5
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ cache:
   directories:
     - node_modules
 script:
-  - 'yarn run test:noWatch'
-  - if [ "$TRAVIS_BRANCH" = "master" ]; then yarn clean && yarn build:prod && ./.travis/s3-simple-upload-all.sh build/releases s3://onesignal-build/websdk/$TRAVIS_COMMIT; fi
+  - yarn run test:noWatch
+  # thanks to https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
+  - BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+  - if [ "$BRANCH" = "master" ]; then yarn clean && yarn build:prod && ./.travis/s3-simple-upload-all.sh build/releases s3://onesignal-build/websdk/$TRAVIS_COMMIT; fi
 git:
   depth: 5
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
     - node_modules
 script:
   - 'yarn run test:noWatch'
-  - 'yarn clean && yarn build:prod && ./.travis/s3-simple-upload-all.sh build/releases s3://onesignal-build/websdk'
+  - if [ "$TRAVIS_BRANCH" = "master" ]; then yarn clean && yarn build:prod && ./.travis/s3-simple-upload-all.sh build/releases s3://onesignal-build/websdk/$TRAVIS_COMMIT; fi
 git:
   depth: 5
 env:

--- a/.travis/s3-simple-upload-all.sh
+++ b/.travis/s3-simple-upload-all.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Similar to the 'sync' command, but with less features.
+#
+# Given a local folder structure like:
+# DirA -> FileA
+#      -> DirB  -> FileB
+#
+# Running: `s3-simple-upload-all.sh DirA s3://BucketA`
+# Will result in uplading s3 folder structure:
+# BucketA -> FileA
+#         -> DirB  -> FileB
+#
+# Requires s3-simple.sh command in the same directory as s3-simple-upload-all.sh.
+
+# Exit on error
+set -e
+
+s3simple_upload_all() {
+  local local_path="$1"
+  local s3_url="$2"
+
+  local script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+  if [ "${s3_url:0:5}" != "s3://" ]; then
+    echo "Need an s3 url, got: $s3_url!"
+    return 1
+  fi
+
+  if [ ! -d $local_path ]; then
+    echo "Local path is not a directory, got: $local_path"
+    return 1
+  fi
+
+  local s3_path="${url:4}"
+
+  for file_path in `find $local_path -type f`
+  do
+    relative_path=${file_path#"$local_path/"}
+
+    # Add a trailing slash if missing
+    [[ "${s3_url}" != */ ]] && s3_url="${s3_url}/"
+
+    echo "Uploading $relative_path to $s3_url.."
+    $script_dir/s3-simple.sh put $s3_url$relative_path $file_path
+  done
+}
+
+s3simple_upload_all $1 $2

--- a/.travis/s3-simple.sh
+++ b/.travis/s3-simple.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# bin/compile <build-dir> <cache-dir> <env-dir>
+# See https://github.com/paulhammond/s3-tarball-buildpack for license and docs
+
+# s3simple is a small, simple bash s3 client with minimal dependencies.
+# See http://github.com/paulhammond/s3simple for documentation and licence.
+s3simple() {
+  local command="$1"
+  local url="$2"
+  local file="${3:--}"
+
+  if [ "${url:0:5}" != "s3://" ]; then
+    echo "Need an s3 url"
+    return 1
+  fi
+  local path="${url:4}"
+
+  if [ -z "${AWS_ACCESS_KEY_ID-}"  ]; then
+    echo "Need AWS_ACCESS_KEY_ID to be set"
+    return 1
+  fi
+
+  if [ -z "${AWS_SECRET_ACCESS_KEY-}" ]; then
+    echo "Need AWS_SECRET_ACCESS_KEY to be set"
+    return 1
+  fi
+
+  local method md5 args
+  case "$command" in
+  get)
+    method="GET"
+    md5=""
+    args="-o $file"
+    ;;
+  put)
+    method="PUT"
+    if [ ! -f "$file" ]; then
+      echo "file not found"
+      exit 1
+    fi
+    md5="$(openssl md5 -binary $file | openssl base64)"
+    args="-T $file -H Content-MD5:$md5"
+    ;;
+  *)
+    echo "Unsupported command"
+    return 1
+  esac
+
+  local date="$(date -u '+%a, %e %b %Y %H:%M:%S +0000')"
+  local string_to_sign
+  printf -v string_to_sign "%s\n%s\n\n%s\n%s" "$method" "$md5" "$date" "$path"
+  local signature=$(echo -n "$string_to_sign" | openssl sha1 -binary -hmac "${AWS_SECRET_ACCESS_KEY}" | openssl base64)
+  local authorization="AWS ${AWS_ACCESS_KEY_ID}:${signature}"
+
+  curl $args -s -f -H Date:"${date}" -H Authorization:"${authorization}" "https://s3.amazonaws.com${path}"
+}
+
+case "$1" in
+get)
+  s3simple $1 $2 > $3
+  ;;
+*)
+  s3simple $1 $2 $3
+  ;;
+esac

--- a/build/scripts/publish.sh
+++ b/build/scripts/publish.sh
@@ -23,8 +23,6 @@ cp build/bundles/OneSignalPageSDKES6.js.map build/releases/$PREFIX"OneSignalPage
 
 cp build/bundles/OneSignalSDKWorker.js build/releases/$PREFIX"OneSignalSDKWorker.js"
 cp build/bundles/OneSignalSDKWorker.js.map build/releases/$PREFIX"OneSignalSDKWorker.js.map"
-cp build/bundles/OneSignalSDKWorker.js build/releases/$PREFIX"OneSignalSDKUpdaterWorker.js"
-cp build/bundles/OneSignalSDKWorker.js.map build/releases/$PREFIX"OneSignalSDKUpdaterWorker.js.map"
 
 cp build/bundles/OneSignalSDKStyles.css build/releases/$PREFIX"OneSignalSDKStyles.css"
 cp build/bundles/OneSignalSDKStyles.css.map build/releases/$PREFIX"OneSignalSDKStyles.css.map"


### PR DESCRIPTION
Makes Travis CI to upload built PROD SDK files to S3 bucket for downloading from turbine. Also:
- create a new directory for the commit;
- makes sure it's run on master only;
- access credentials for S3 set in Travis and limited for use on master only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/558)
<!-- Reviewable:end -->
