### PR TITLE
Session refactoring

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -820,6 +820,7 @@ export default class OneSignal {
   static proxyFrameHost: ProxyFrameHost;
   static proxyFrame: ProxyFrame;
   static emitter: Emitter = new Emitter();
+  static cache: any = {};
 
   /**
    * The additional path to the worker file.

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -51,6 +51,7 @@ import ConfigManager from "./managers/ConfigManager";
 import OneSignalUtils from "./utils/OneSignalUtils";
 import { ProcessOneSignalPushCalls } from "./utils/ProcessOneSignalPushCalls";
 import { AutoPromptOptions } from "./managers/PromptsManager";
+import { SessionManager } from './managers/SessionManager';
 
 export default class OneSignal {
   /**
@@ -268,6 +269,15 @@ export default class OneSignal {
          */
         if (!OneSignal.config || !OneSignal.config.subdomain)
           throw new SdkInitError(SdkInitErrorKind.MissingSubdomain);
+
+
+        /**
+         * We'll need to set up page activity tracking events on the main page but we can do so
+         * only after the main initialization in the iframe is successful and a new session
+         * is initiated.
+         */
+        OneSignal.emitter.on(OneSignal.EVENTS.SESSION_STARTED, SessionManager.setupSessionEventListenersForHttp);
+
         /**
          * The iFrame may never load (e.g. OneSignal might be down), in which
          * case the rest of the SDK's initialization will be blocked. This is a
@@ -900,6 +910,8 @@ export default class OneSignal {
     SUBSCRIPTION_EXPIRATION_STATE: 'postmam.subscriptionExpirationState',
     PROCESS_EXPIRING_SUBSCRIPTIONS: 'postmam.processExpiringSubscriptions',
     GET_SUBSCRIPTION_STATE: 'postmam.getSubscriptionState',
+    SESSION_UPSERT: 'postmam.sessionUpsert',
+    SESSION_DEACTIVATE: 'postmam.sessionDeactivate'
   };
 
   static EVENTS = {
@@ -969,6 +981,7 @@ export default class OneSignal {
     TEST_INIT_OPTION_DISABLED: 'testInitOptionDisabled',
     TEST_WOULD_DISPLAY: 'testWouldDisplay',
     POPUP_WINDOW_TIMEOUT: 'popupWindowTimeout',
+    SESSION_STARTED: "sessionStarted",
   };
 }
 

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -911,7 +911,9 @@ export default class OneSignal {
     PROCESS_EXPIRING_SUBSCRIPTIONS: 'postmam.processExpiringSubscriptions',
     GET_SUBSCRIPTION_STATE: 'postmam.getSubscriptionState',
     SESSION_UPSERT: 'postmam.sessionUpsert',
-    SESSION_DEACTIVATE: 'postmam.sessionDeactivate'
+    SESSION_DEACTIVATE: 'postmam.sessionDeactivate',
+    ARE_YOU_VISIBLE_REQUEST: 'postmam.areYouVisibleRequest',
+    ARE_YOU_VISIBLE_RESPONSE: 'postmam.areYouVisibleResponse',
   };
 
   static EVENTS = {

--- a/src/OneSignalApiBase.ts
+++ b/src/OneSignalApiBase.ts
@@ -37,6 +37,7 @@ export class OneSignalApiBase {
     }
 
     let callHeaders: any = new Headers();
+    callHeaders.append("Origin", "https://localhost:3001");
     callHeaders.append('SDK-Version', `onesignal/web/${Environment.version()}`);
     callHeaders.append('Content-Type', 'application/json;charset=UTF-8');
     if (headers) {

--- a/src/OneSignalApiSW.ts
+++ b/src/OneSignalApiSW.ts
@@ -65,6 +65,27 @@ export class OneSignalApiSW {
       } else throw e;
     }
   };
+
+  public static async sendSessionDuration(
+    appId: string, deviceId: string, sessionDuration: number, deviceType: number): Promise<void> {
+      try {
+        Utils.enforceAppId(appId);
+        Utils.enforcePlayerId(deviceId);
+        const payload = {
+          app_id: appId,
+          type: 1,
+          state: "ping",
+          active_time: sessionDuration,
+          device_type: deviceType,
+        }
+        await OneSignalApiBase.post(`players/${deviceId}/on_focus`, payload);
+      } catch (e) {
+        if (e && Array.isArray(e.errors) && e.errors.length > 0 &&
+          Utils.contains(e.errors[0], 'app_id not found')) {
+          throw new OneSignalApiError(OneSignalApiErrorKind.MissingAppId);
+        } else throw e;
+      }
+  }
 }
 
 export default OneSignalApiSW;

--- a/src/OneSignalApiSW.ts
+++ b/src/OneSignalApiSW.ts
@@ -1,8 +1,10 @@
 import { ServerAppConfig } from "./models/AppConfig";
 import { OneSignalApiBase } from "./OneSignalApiBase";
 import { SubscriptionStateKind } from "./models/SubscriptionStateKind";
+import { FlattenedDeviceRecord } from "./models/DeviceRecord";
 import Log from "./libraries/Log";
 import { Utils } from "./utils/Utils";
+import { OneSignalApiErrorKind, OneSignalApiError } from "./errors/OneSignalApiError";
 
 export class OneSignalApiSW {
   static async downloadServerAppConfig(appId: string): Promise<ServerAppConfig> {
@@ -41,6 +43,28 @@ export class OneSignalApiSW {
     Utils.enforcePlayerId(playerId);
     return OneSignalApiBase.put(`players/${playerId}`, {app_id: appId, ...options});
   }
+
+  public static async updateUserSession(
+    userId: string,
+    serializedDeviceRecord: FlattenedDeviceRecord,
+  ): Promise<string> {
+    try {
+      Utils.enforceAppId(serializedDeviceRecord.app_id);
+      Utils.enforcePlayerId(userId);
+      const response = await OneSignalApiBase.post(`players/${userId}/on_session`, serializedDeviceRecord);
+      if (response.id) {
+        // A new user ID can be returned
+        return response.id;
+      } else {
+        return userId;
+      }
+    } catch (e) {
+      if (e && Array.isArray(e.errors) && e.errors.length > 0 &&
+        Utils.contains(e.errors[0], 'app_id not found')) {
+        throw new OneSignalApiError(OneSignalApiErrorKind.MissingAppId);
+      } else throw e;
+    }
+  };
 }
 
 export default OneSignalApiSW;

--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -113,6 +113,8 @@ export class ConfigHelper {
       emailAuthRequired: serverConfig.features.email && serverConfig.features.email.require_auth,
       userConfig: mergedUserConfig,
       enableOnSession: serverConfig.features.enable_on_session || false,
+      sessionThreshold: serverConfig.config.sessionThreshold || 30,
+      enableSessionDuration: !!serverConfig.features.enableSessionDuration,
     };
   }
 

--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -113,8 +113,8 @@ export class ConfigHelper {
       emailAuthRequired: serverConfig.features.email && serverConfig.features.email.require_auth,
       userConfig: mergedUserConfig,
       enableOnSession: serverConfig.features.enable_on_session || false,
-      sessionThreshold: serverConfig.config.sessionThreshold || 30,
-      enableSessionDuration: !!serverConfig.features.enableSessionDuration,
+      sessionThreshold: serverConfig.config.sessionThreshold || 10,
+      enableSessionDuration: true || !!serverConfig.features.enableSessionDuration,
     };
   }
 

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -194,6 +194,7 @@ export default class InitHelper {
      */
     const isExistingUser: boolean = await OneSignal.context.subscriptionManager.isAlreadyRegisteredWithOneSignal();
     if (isExistingUser) {
+      OneSignal.context.sessionManager.setupSessionEventListeners();
       if (!wasUserResubscribed) {
         await OneSignal.context.updateManager.sendOnSessionUpdate();
       }

--- a/src/helpers/MainHelper.ts
+++ b/src/helpers/MainHelper.ts
@@ -7,6 +7,7 @@ import TimedLocalStorage from '../modules/TimedLocalStorage';
 import Log from '../libraries/Log';
 import { SubscriptionStateKind } from '../models/SubscriptionStateKind';
 import { NotificationPermission } from "../models/NotificationPermission";
+import { PushDeviceRecord } from "../models/PushDeviceRecord";
 import { OneSignalUtils } from "../utils/OneSignalUtils";
 import { PermissionUtils } from "../utils/PermissionUtils";
 import { Utils } from "../utils/Utils";
@@ -225,5 +226,17 @@ export default class MainHelper {
       const appId = await Database.get<string>('Ids', 'appId');
       return appId;
     }
+  }
+
+  public static async createDeviceRecord(appId: string): Promise<PushDeviceRecord> {
+    const deviceRecord = new PushDeviceRecord();
+    deviceRecord.appId = appId;
+    deviceRecord.subscriptionState = await MainHelper.getCurrentNotificationType();
+    return deviceRecord;
+  }
+
+  public static async getDeviceId(): Promise<string | undefined> {
+    const subscription = await OneSignal.database.getSubscription();
+    return subscription.deviceId || undefined;
   }
 }

--- a/src/helpers/ServiceWorkerHelper.ts
+++ b/src/helpers/ServiceWorkerHelper.ts
@@ -47,7 +47,7 @@ export default class ServiceWorkerHelper {
   }
 
   public static async upsertSession(
-    sessionThresholdInSeconds: number, sendOnFocus: boolean, timerId: number | undefined,
+    sessionThresholdInSeconds: number, sendOnFocus: boolean,
     deviceRecord: SerializedPushDeviceRecord, deviceId: string | undefined, sessionOrigin: SessionOrigin
   ): Promise<void> {
     if (!deviceId) {
@@ -89,11 +89,6 @@ export default class ServiceWorkerHelper {
     const timeSinceLastDeactivatedInSeconds: number = Math.floor(
       (currentTimestamp - existingSession.lastDeactivatedTimestamp)/ 1000
     );
-
-    if (timerId) {
-      Log.debug("Clearing timeout from previous session deactivation");
-      self.clearTimeout(timerId);
-    }
 
     if (timeSinceLastDeactivatedInSeconds < sessionThresholdInSeconds) {
       existingSession.status = SessionStatus.Active;

--- a/src/helpers/SubscriptionHelper.ts
+++ b/src/helpers/SubscriptionHelper.ts
@@ -28,7 +28,7 @@ export default class SubscriptionHelper {
       session count incremented on each page refresh. However, if the user is
       not subscribed, subscribe.
     */
-    if (isPushEnabled && !context.sessionManager.isFirstPageView()) {
+    if (isPushEnabled && !context.pageViewManager.isFirstPageView()) {
       Log.debug('Not registering for push because the user is subscribed and this is not the first page view.');
       return null;
     }
@@ -48,7 +48,7 @@ export default class SubscriptionHelper {
             SubscriptionStrategyKind.ResubscribeExisting
           );
           subscription = await context.subscriptionManager.registerSubscription(rawSubscription);
-          context.sessionManager.incrementPageViewCount();
+          context.pageViewManager.incrementPageViewCount();
           await PermissionUtils.triggerNotificationPermissionChanged();
           await EventHelper.checkAndTriggerSubscriptionChanged();
         } catch (e) {

--- a/src/libraries/Log.ts
+++ b/src/libraries/Log.ts
@@ -59,7 +59,8 @@ export default class Log {
       const methodToMapTo = methods[nativeMethod];
       const shouldMap = nativeMethodExists &&
         (
-          (typeof __LOGGING__ !== "undefined" && __LOGGING__ === true) ||
+          (true) ||
+          // (typeof __LOGGING__ !== "undefined" && __LOGGING__ === true) ||
           (Log.shouldLog()) ||
           methodToMapTo === "error"
         );

--- a/src/libraries/WorkerMessenger.ts
+++ b/src/libraries/WorkerMessenger.ts
@@ -23,6 +23,8 @@ export enum WorkerMessengerCommand {
   NotificationClicked = 'notification.clicked',
   NotificationDismissed = 'notification.dismissed',
   RedirectPage = 'command.redirect',
+  SessionUpsert = 'os.session.upsert',
+  SessionDeactivate = 'os.session.deactivate',
 }
 
 export interface WorkerMessengerMessage {

--- a/src/libraries/WorkerMessenger.ts
+++ b/src/libraries/WorkerMessenger.ts
@@ -142,11 +142,16 @@ export class WorkerMessenger {
       }
       await this.waitUntilWorkerControlsPage();
       Log.debug(`[Worker Messenger] [Page -> SW] Unicasting '${command.toString()}' to service worker.`)
-      navigator.serviceWorker.controller.postMessage({
-        command: command,
-        payload: payload
-      })
+      this.directPostMessageToSW(command, payload);
     }
+  }
+
+  public directPostMessageToSW(command: WorkerMessengerCommand, payload?: WorkerMessengerPayload) {
+    Log.debug(`[Worker Messenger] [Page -> SW] Unicasting '${command.toString()}' to service worker.`)
+    navigator.serviceWorker!.controller!.postMessage({
+      command: command,
+      payload: payload
+    });
   }
 
   /**

--- a/src/libraries/WorkerMessenger.ts
+++ b/src/libraries/WorkerMessenger.ts
@@ -25,6 +25,8 @@ export enum WorkerMessengerCommand {
   RedirectPage = 'command.redirect',
   SessionUpsert = 'os.session.upsert',
   SessionDeactivate = 'os.session.deactivate',
+  AreYouVisible = "os.page_focused_request",
+  AreYouVisibleResponse = "os.page_focused_response"
 }
 
 export interface WorkerMessengerMessage {
@@ -338,13 +340,13 @@ export class WorkerMessenger {
         const env = SdkEnvironment.getWindowEnv();
 
         if (env === WindowEnvironmentKind.ServiceWorker) {
-          self.addEventListener('activate', async e => {
+          self.addEventListener('activate', async (_e: Event) => {
             if (await this.isWorkerControllingPage())
               resolve();
           });
         }
         else {
-          navigator.serviceWorker.addEventListener('controllerchange', async e => {
+          navigator.serviceWorker.addEventListener('controllerchange', async (_e: Event) => {
             if (await this.isWorkerControllingPage())
               resolve();
           });

--- a/src/libraries/WorkerMessenger.ts
+++ b/src/libraries/WorkerMessenger.ts
@@ -141,13 +141,13 @@ export class WorkerMessenger {
         Log.debug("[Worker Messenger] The page is not controlled by the service worker yet. Waiting...", (<ServiceWorkerGlobalScope><any>self).registration);
       }
       await this.waitUntilWorkerControlsPage();
-      Log.debug(`[Worker Messenger] [Page -> SW] Unicasting '${command.toString()}' to service worker.`)
+      Log.debug(`[Worker Messenger] [Page -> SW] Unicasting '${command.toString()}' to service worker.`);
       this.directPostMessageToSW(command, payload);
     }
   }
 
   public directPostMessageToSW(command: WorkerMessengerCommand, payload?: WorkerMessengerPayload) {
-    Log.debug(`[Worker Messenger] [Page -> SW] Unicasting '${command.toString()}' to service worker.`)
+    Log.debug(`[Worker Messenger] [Page -> SW] Direct command '${command.toString()}' to service worker.`);
     navigator.serviceWorker!.controller!.postMessage({
       command: command,
       payload: payload
@@ -273,7 +273,7 @@ export class WorkerMessenger {
     Subscribes a callback to be notified every time a service worker sends a
     message to the window frame with the specific command.
    */
-  on(command: WorkerMessengerCommand, callback: (WorkerMessengerPayload) => void): void {
+  on(command: WorkerMessengerCommand, callback: (payload: any) => void): void {
     this.replies.addListener(command, callback, false);
   }
 
@@ -283,7 +283,7 @@ export class WorkerMessenger {
 
   The callback is executed once at most.
   */
-  once(command: WorkerMessengerCommand, callback: (WorkerMessengerPayload) => void): void {
+  once(command: WorkerMessengerCommand, callback: (payload: any) => void): void {
     this.replies.addListener(command, callback, true);
   }
 

--- a/src/managers/PageViewManager.ts
+++ b/src/managers/PageViewManager.ts
@@ -1,11 +1,11 @@
 
 
-import SdkEnvironment from '../managers/SdkEnvironment';
-import { WindowEnvironmentKind } from '../models/WindowEnvironmentKind';
-import Log from '../libraries/Log';
+import SdkEnvironment from "../managers/SdkEnvironment";
+import { WindowEnvironmentKind } from "../models/WindowEnvironmentKind";
+import Log from "../libraries/Log";
 
-export class SessionManager {
-  private static SESSION_STORAGE_KEY_NAME = 'onesignal-pageview-count';
+export class PageViewManager {
+  private static SESSION_STORAGE_KEY_NAME = "onesignal-pageview-count";
   private incrementedPageViewCount: boolean = false;
 
   getPageViewCount(): number {
@@ -15,7 +15,7 @@ export class SessionManager {
         as an API in incognito mode and in cases where the user disables
         third-party cookies on some browsers.
        */
-      const pageViewCountStr = sessionStorage.getItem(SessionManager.SESSION_STORAGE_KEY_NAME);
+      const pageViewCountStr = sessionStorage.getItem(PageViewManager.SESSION_STORAGE_KEY_NAME);
       const pageViewCount = pageViewCountStr ? parseInt(pageViewCountStr) : 0;
       if (isNaN(pageViewCount)) {
         return 0;
@@ -33,7 +33,7 @@ export class SessionManager {
 
   setPageViewCount(sessionCount: number) {
     try {
-      sessionStorage.setItem(SessionManager.SESSION_STORAGE_KEY_NAME, sessionCount.toString());
+      sessionStorage.setItem(PageViewManager.SESSION_STORAGE_KEY_NAME, sessionCount.toString());
 
       if (SdkEnvironment.getWindowEnv() === WindowEnvironmentKind.OneSignalSubscriptionPopup) {
         // If we're setting sessionStorage and we're in an Popup, we need to also set sessionStorage on the

--- a/src/managers/SessionManager.ts
+++ b/src/managers/SessionManager.ts
@@ -1,0 +1,61 @@
+import { ContextSWInterface } from "../models/ContextSW";
+import { PushDeviceRecord } from "../models/PushDeviceRecord";
+import { SessionPayload } from "../models/Session";
+import Log from "../libraries/Log";
+import { WorkerMessengerCommand } from "../libraries/WorkerMessenger";
+
+export class SessionManager {
+  private context: ContextSWInterface;
+
+  constructor(context: ContextSWInterface) {
+    this.context = context;
+  }
+
+  public async notifySWToUpsertSession(deviceId?: string, deviceRecord?: PushDeviceRecord): Promise<void> {
+    Log.debug("Notify SW to upsert session");
+    const payload: SessionPayload = {
+      deviceId,
+      deviceRecord: deviceRecord ? deviceRecord.serialize() : undefined,
+      sessionThreshold: OneSignal.config.sessionThreshold,
+      enableSessionDuration: OneSignal.config.enableSessionDuration,
+    };
+    await this.context.workerMessenger.unicast(WorkerMessengerCommand.SessionUpsert, payload);
+  }
+
+  public async notifySWToDeactivateSession(deviceId?: string, deviceRecord?: PushDeviceRecord): Promise<void> {
+    Log.debug("Notify SW to deactivate session");
+    const payload: SessionPayload = {
+      deviceId,
+      deviceRecord: deviceRecord ? deviceRecord.serialize() : undefined,
+      sessionThreshold: OneSignal.config.sessionThreshold,
+      enableSessionDuration: OneSignal.config.enableSessionDuration,
+    };
+    await this.context.workerMessenger.unicast(WorkerMessengerCommand.SessionDeactivate, payload);
+  }
+
+  public handleVisibilityChange(): void {
+    const visibilityState = document.visibilityState;
+    if (visibilityState === "visible") {
+      this.notifySWToUpsertSession();
+      return;
+    }
+
+    if (visibilityState === "hidden") {
+      this.notifySWToDeactivateSession();
+      return;
+    }
+
+    // it should never be anything else at this point
+  }
+
+  public async upsertSession(deviceId?: string, deviceRecord?: PushDeviceRecord): Promise<void> {
+    const sessionPromise = this.notifySWToUpsertSession(deviceId, deviceRecord);
+
+    // TODO: Possibly need to add handling for "pagehide" event. And review all the cases both fire in general
+    // https://github.com/w3c/page-visibility/issues/18
+    document.addEventListener("visibilitychange", () => { this.handleVisibilityChange() }, false);
+    // TODO: also may need to check for beforeunload though "pagehide" may help account for it
+
+    await sessionPromise;
+  }
+}

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -798,9 +798,9 @@ export class SubscriptionManager {
   public async registerFailedSubscription(
     subscriptionState: SubscriptionStateServiceWorkerNotIntalled,
     context: ContextSWInterface) {
-    if (context.sessionManager.isFirstPageView()) {
+    if (context.pageViewManager.isFirstPageView()) {
       context.subscriptionManager.registerSubscription(new RawPushSubscription(), subscriptionState);
-      context.sessionManager.incrementPageViewCount();
+      context.pageViewManager.incrementPageViewCount();
     }
   }
 }

--- a/src/managers/UpdateManager.ts
+++ b/src/managers/UpdateManager.ts
@@ -27,10 +27,7 @@ export class UpdateManager {
   }
 
   private async createDeviceRecord(): Promise<PushDeviceRecord> {
-    const deviceRecord = new PushDeviceRecord();
-    deviceRecord.appId = this.context.appConfig.appId;
-    deviceRecord.subscriptionState = await MainHelper.getCurrentNotificationType();
-    return deviceRecord;
+    return MainHelper.createDeviceRecord(this.context.appConfig.appId);
   }
 
   public async sendPlayerUpdate(deviceRecord?: PushDeviceRecord): Promise<void> {

--- a/src/managers/UpdateManager.ts
+++ b/src/managers/UpdateManager.ts
@@ -7,6 +7,7 @@ import Database from "../services/Database";
 import Log from "../libraries/Log";
 import { ContextSWInterface } from '../models/ContextSW';
 import Utils from "../utils/Utils";
+import { SessionOrigin } from '../models/Session';
 
 export class UpdateManager {
   private context: ContextSWInterface;
@@ -82,7 +83,7 @@ export class UpdateManager {
       // await OneSignalApiShared.updateUserSession(deviceId, deviceRecord);
       
       // Not awaiting here on purpose
-      this.context.sessionManager.upsertSession(deviceId, deviceRecord);
+      this.context.sessionManager.upsertSession(deviceId, deviceRecord, SessionOrigin.PlayerOnSession);
       this.onSessionSent = true;
     } catch(e) {
       Log.error(`Failed to update user session. Error "${e.message}" ${e.stack}`);
@@ -96,7 +97,7 @@ export class UpdateManager {
         Log.info("Subscribed to web push and registered with OneSignal", deviceRecord, deviceId);
         this.onSessionSent = true;
         // Not awaiting here on purpose
-        this.context.sessionManager.upsertSession(deviceId, deviceRecord);
+        this.context.sessionManager.upsertSession(deviceId, deviceRecord, SessionOrigin.PlayerCreate);
         return deviceId;
       }
       Log.error(`Failed to create user.`);

--- a/src/managers/UpdateManager.ts
+++ b/src/managers/UpdateManager.ts
@@ -15,7 +15,7 @@ export class UpdateManager {
 
   constructor(context: ContextSWInterface) {
     this.context = context;
-    this.onSessionSent = context.sessionManager.getPageViewCount() > 1;
+    this.onSessionSent = context.pageViewManager.getPageViewCount() > 1;
   }
 
   private async getDeviceId(): Promise<string> {
@@ -60,7 +60,7 @@ export class UpdateManager {
       return;
     }
 
-    if (!this.context.sessionManager.isFirstPageView()) {
+    if (!this.context.pageViewManager.isFirstPageView()) {
       return;
     }
 

--- a/src/managers/UpdateManager.ts
+++ b/src/managers/UpdateManager.ts
@@ -81,7 +81,11 @@ export class UpdateManager {
     }
 
     try {
-      await OneSignalApiShared.updateUserSession(deviceId, deviceRecord);
+      // Not sending on_session here but from SW instead.
+      // await OneSignalApiShared.updateUserSession(deviceId, deviceRecord);
+      
+      // Not awaiting here on purpose
+      this.context.sessionManager.upsertSession(deviceId, deviceRecord);
       this.onSessionSent = true;
     } catch(e) {
       Log.error(`Failed to update user session. Error "${e.message}" ${e.stack}`);
@@ -94,6 +98,8 @@ export class UpdateManager {
       if (deviceId) {
         Log.info("Subscribed to web push and registered with OneSignal", deviceRecord, deviceId);
         this.onSessionSent = true;
+        // Not awaiting here on purpose
+        this.context.sessionManager.upsertSession(deviceId, deviceRecord);
         return deviceId;
       }
       Log.error(`Failed to create user.`);

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -27,7 +27,7 @@ export interface AppConfig {
     mixpanelReportingToken: string | null;
   };
   enableOnSession?: boolean;
-
+  enableSessionDuration?: boolean;
   safariWebId?: string;
 
   /**
@@ -49,6 +49,7 @@ export interface AppConfig {
   userConfig: AppUserConfig;
   // TODO: Cleanup: pageUrl is also on AppUserConfig
   pageUrl?: string;
+  sessionThreshold?: number;
 }
 
 export enum ConfigIntegrationKind {
@@ -312,6 +313,7 @@ export interface ServerAppConfig {
       require_auth: boolean;
     };
     enable_on_session?: boolean;
+    enableSessionDuration: boolean;
   };
   config: {
     /**
@@ -321,6 +323,7 @@ export interface ServerAppConfig {
     origin: string;
     staticPrompts: ServerAppConfigPrompt;
     autoResubscribe: boolean;
+    sessionThreshold: number;
     siteInfo: {
       name: string;
       origin: string;

--- a/src/models/Context.ts
+++ b/src/models/Context.ts
@@ -11,6 +11,7 @@ import { ContextSWInterface } from "./ContextSW";
 import ContextHelper from "../helpers/ContextHelper";
 import { UpdateManager } from "../managers/UpdateManager";
 import { PromptsManager } from "../managers/PromptsManager";
+import { SessionManager } from "../managers/SessionManager";
 
 export interface ContextInterface extends ContextSWInterface {
   dynamicResourceLoader: DynamicResourceLoader;
@@ -30,6 +31,7 @@ export default class Context implements ContextInterface {
   public metricsManager: MetricsManager;
   public updateManager: UpdateManager;
   public promptsManager: PromptsManager;
+  public sessionManager: SessionManager;
 
   constructor(appConfig: AppConfig) {
     this.appConfig = appConfig;
@@ -39,6 +41,7 @@ export default class Context implements ContextInterface {
     this.permissionManager = new PermissionManager();
     this.workerMessenger = new WorkerMessenger(this);
     this.updateManager = new UpdateManager(this);
+    this.sessionManager = new SessionManager(this);
     
     this.promptsManager = new PromptsManager(this);
     this.cookieSyncer = new CookieSyncer(this, appConfig.cookieSyncEnabled);

--- a/src/models/Context.ts
+++ b/src/models/Context.ts
@@ -4,7 +4,7 @@ import { SubscriptionManager } from '../managers/SubscriptionManager';
 import { DynamicResourceLoader } from '../services/DynamicResourceLoader';
 import CookieSyncer from '../modules/CookieSyncer';
 import { AppConfig } from './AppConfig';
-import { SessionManager } from '../managers/SessionManager';
+import { PageViewManager } from '../managers/PageViewManager';
 import PermissionManager from '../managers/PermissionManager';
 import MetricsManager from '../managers/MetricsManager';
 import { ContextSWInterface } from "./ContextSW";
@@ -25,7 +25,7 @@ export default class Context implements ContextInterface {
   public serviceWorkerManager: ServiceWorkerManager;
   public workerMessenger: WorkerMessenger;
   public cookieSyncer: CookieSyncer;
-  public sessionManager: SessionManager;
+  public pageViewManager: PageViewManager;
   public permissionManager: PermissionManager;
   public metricsManager: MetricsManager;
   public updateManager: UpdateManager;
@@ -35,7 +35,7 @@ export default class Context implements ContextInterface {
     this.appConfig = appConfig;
     this.subscriptionManager = ContextHelper.getSubscriptionManager(this);
     this.serviceWorkerManager = ContextHelper.getServiceWorkerManager(this);
-    this.sessionManager = new SessionManager();
+    this.pageViewManager = new PageViewManager();
     this.permissionManager = new PermissionManager();
     this.workerMessenger = new WorkerMessenger(this);
     this.updateManager = new UpdateManager(this);

--- a/src/models/ContextSW.ts
+++ b/src/models/ContextSW.ts
@@ -2,7 +2,7 @@ import { WorkerMessenger } from '../libraries/WorkerMessenger';
 import { ServiceWorkerManager } from '../managers/ServiceWorkerManager';
 import { SubscriptionManager } from '../managers/SubscriptionManager';
 import { AppConfig } from './AppConfig';
-import { SessionManager } from '../managers/SessionManager';
+import { PageViewManager } from '../managers/PageViewManager';
 import PermissionManager from '../managers/PermissionManager';
 import ContextHelper from "../helpers/ContextHelper";
 import { UpdateManager } from "../managers/UpdateManager";
@@ -11,7 +11,7 @@ export interface ContextSWInterface {
   appConfig: AppConfig;
   subscriptionManager: SubscriptionManager;
   serviceWorkerManager: ServiceWorkerManager;
-  sessionManager: SessionManager;
+  pageViewManager: PageViewManager;
   permissionManager: PermissionManager;
   workerMessenger: WorkerMessenger;
   updateManager: UpdateManager;
@@ -21,7 +21,7 @@ export default class ContextSW implements ContextSWInterface {
   public appConfig: AppConfig;
   public subscriptionManager: SubscriptionManager;
   public serviceWorkerManager: ServiceWorkerManager;
-  public sessionManager: SessionManager;
+  public pageViewManager: PageViewManager;
   public permissionManager: PermissionManager;
   public workerMessenger: WorkerMessenger;
   public updateManager: UpdateManager;
@@ -30,7 +30,7 @@ export default class ContextSW implements ContextSWInterface {
     this.appConfig = appConfig;
     this.subscriptionManager = ContextHelper.getSubscriptionManager(this);
     this.serviceWorkerManager = ContextHelper.getServiceWorkerManager(this);
-    this.sessionManager = new SessionManager();
+    this.pageViewManager = new PageViewManager();
     this.permissionManager = new PermissionManager();
     this.workerMessenger = new WorkerMessenger(this);
     this.updateManager = new UpdateManager(this);

--- a/src/models/ContextSW.ts
+++ b/src/models/ContextSW.ts
@@ -6,12 +6,14 @@ import { PageViewManager } from '../managers/PageViewManager';
 import PermissionManager from '../managers/PermissionManager';
 import ContextHelper from "../helpers/ContextHelper";
 import { UpdateManager } from "../managers/UpdateManager";
+import { SessionManager } from '../managers/SessionManager';
 
 export interface ContextSWInterface {
   appConfig: AppConfig;
   subscriptionManager: SubscriptionManager;
   serviceWorkerManager: ServiceWorkerManager;
   pageViewManager: PageViewManager;
+  sessionManager: SessionManager;
   permissionManager: PermissionManager;
   workerMessenger: WorkerMessenger;
   updateManager: UpdateManager;
@@ -22,6 +24,7 @@ export default class ContextSW implements ContextSWInterface {
   public subscriptionManager: SubscriptionManager;
   public serviceWorkerManager: ServiceWorkerManager;
   public pageViewManager: PageViewManager;
+  public sessionManager: SessionManager;
   public permissionManager: PermissionManager;
   public workerMessenger: WorkerMessenger;
   public updateManager: UpdateManager;
@@ -31,6 +34,7 @@ export default class ContextSW implements ContextSWInterface {
     this.subscriptionManager = ContextHelper.getSubscriptionManager(this);
     this.serviceWorkerManager = ContextHelper.getServiceWorkerManager(this);
     this.pageViewManager = new PageViewManager();
+    this.sessionManager = new SessionManager(this);
     this.permissionManager = new PermissionManager();
     this.workerMessenger = new WorkerMessenger(this);
     this.updateManager = new UpdateManager(this);

--- a/src/models/PushDeviceRecord.ts
+++ b/src/models/PushDeviceRecord.ts
@@ -3,8 +3,13 @@ import bowser from 'bowser';
 import NotImplementedError from '../errors/NotImplementedError';
 import { RawPushSubscription } from './RawPushSubscription';
 import { SubscriptionStateKind } from './SubscriptionStateKind';
-import { DeviceRecord } from './DeviceRecord';
+import { DeviceRecord, FlattenedDeviceRecord } from './DeviceRecord';
 
+export interface SerializedPushDeviceRecord extends FlattenedDeviceRecord {
+  identifier?: string | null;
+  web_auth?: string;
+  web_p256?: string;
+}
 
 /**
  * Describes a push notification device record.
@@ -20,8 +25,8 @@ export class PushDeviceRecord extends DeviceRecord {
     this.subscription = subscription;
   }
 
-  serialize() {
-    const serializedBundle: any = super.serialize();
+  serialize(): SerializedPushDeviceRecord {
+    const serializedBundle: SerializedPushDeviceRecord = super.serialize();
 
     if (this.subscription) {
       serializedBundle.identifier = bowser.safari ?

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -1,3 +1,5 @@
+import { PushDeviceRecord } from "../models/PushDeviceRecord";
+
 export enum SessionStatus {
   Active = "active",
   Inactive = "inactive",
@@ -15,3 +17,26 @@ export interface Session {
 }
 
 export const ONESIGNAL_SESSION_KEY = "oneSignalSession";
+
+export function initializeNewSession(options?: Partial<Session>): Session {
+  const currentTimestamp = new Date().getTime();
+  const sessionKey = options && options.sessionKey || ONESIGNAL_SESSION_KEY;
+  const notificationId = options && options.notificationId || null;
+
+  return {
+    sessionKey,
+    startTimestamp: currentTimestamp,
+    accumulatedDuration: 0,
+    notificationId,
+    status: SessionStatus.Active,
+    lastDeactivatedTimestamp: null,
+    lastActivatedTimestamp: currentTimestamp,
+  }
+}
+
+export interface SessionPayload {
+  deviceId?: string;
+  deviceRecord?: PushDeviceRecord;
+  sessionThreshold: number;
+  enableSessionDuration: boolean;
+}

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -19,6 +19,9 @@ export enum SessionOrigin {
 
 export interface Session {
   sessionKey: string;
+  appId: string;
+  deviceId: string;
+  deviceType: number;
   startTimestamp: number;
   accumulatedDuration: number;
   notificationId: string | null; // for direct clicks
@@ -29,13 +32,18 @@ export interface Session {
 
 export const ONESIGNAL_SESSION_KEY = "oneSignalSession";
 
-export function initializeNewSession(options?: Partial<Session>): Session {
+export function initializeNewSession(options: 
+  Partial<Session> & {deviceId: string; appId: string, deviceType: number;}
+): Session {
   const currentTimestamp = new Date().getTime();
   const sessionKey = options && options.sessionKey || ONESIGNAL_SESSION_KEY;
   const notificationId = options && options.notificationId || null;
 
   return {
     sessionKey,
+    appId: options.appId,
+    deviceId: options.deviceId,
+    deviceType: options.deviceType,
     startTimestamp: currentTimestamp,
     accumulatedDuration: 0,
     notificationId,

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -8,7 +8,10 @@ export interface Session {
   sessionKey: string;
   startTimestamp: number;
   accumulatedDuration: number;
-  notificationId?: string; // for direct clicks
+  notificationId: string | null; // for direct clicks
   status: SessionStatus,
+  lastDeactivatedTimestamp: number | null;
   lastActivatedTimestamp: number;
 }
+
+export const ONESIGNAL_SESSION_KEY = "oneSignalSession";

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -11,6 +11,8 @@ export enum SessionOrigin {
   PlayerOnSession = 2,
   VisibilityVisible = 3,
   VisibilityHidden = 4,
+  BeforeUnload = 5,
+  PageRefresh = 6,
 }
 
 export interface Session {
@@ -41,10 +43,17 @@ export function initializeNewSession(options?: Partial<Session>): Session {
   }
 }
 
-export interface SessionPayload {
+interface BaseSessionPayload {
   deviceId?: string;
-  deviceRecord: SerializedPushDeviceRecord;
   sessionThreshold: number;
   enableSessionDuration: boolean;
   sessionOrigin: SessionOrigin;
+}
+
+export interface UpsertSessionPayload extends BaseSessionPayload {
+  deviceRecord: SerializedPushDeviceRecord;
+}
+
+export interface DeactivateSessionPayload extends BaseSessionPayload {
+  deviceRecord?: SerializedPushDeviceRecord;
 }

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -13,6 +13,8 @@ export enum SessionOrigin {
   VisibilityHidden = 4,
   BeforeUnload = 5,
   PageRefresh = 6,
+  Focus = 7,
+  Blur = 8,
 }
 
 export interface Session {

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -1,0 +1,14 @@
+export enum SessionStatus {
+  Active = "active",
+  Inactive = "inactive",
+  Expired = "expired"
+}
+
+export interface Session {
+  sessionKey: string;
+  startTimestamp: number;
+  accumulatedDuration: number;
+  notificationId?: string; // for direct clicks
+  status: SessionStatus,
+  lastActivatedTimestamp: number;
+}

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -1,9 +1,16 @@
-import { PushDeviceRecord } from "../models/PushDeviceRecord";
+import { SerializedPushDeviceRecord } from "../models/PushDeviceRecord";
 
 export enum SessionStatus {
   Active = "active",
   Inactive = "inactive",
   Expired = "expired"
+}
+
+export enum SessionOrigin {
+  PlayerCreate = 1,
+  PlayerOnSession = 2,
+  VisibilityVisible = 3,
+  VisibilityHidden = 4,
 }
 
 export interface Session {
@@ -36,7 +43,8 @@ export function initializeNewSession(options?: Partial<Session>): Session {
 
 export interface SessionPayload {
   deviceId?: string;
-  deviceRecord?: PushDeviceRecord;
+  deviceRecord: SerializedPushDeviceRecord;
   sessionThreshold: number;
   enableSessionDuration: boolean;
+  sessionOrigin: SessionOrigin;
 }

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -58,6 +58,8 @@ interface BaseSessionPayload {
   sessionThreshold: number;
   enableSessionDuration: boolean;
   sessionOrigin: SessionOrigin;
+  isHttps: boolean;
+  isSafari: boolean;
 }
 
 export interface UpsertSessionPayload extends BaseSessionPayload {

--- a/src/modules/frames/ProxyFrameHost.ts
+++ b/src/modules/frames/ProxyFrameHost.ts
@@ -190,10 +190,10 @@ export default class ProxyFrameHost implements Disposable {
     });
   }
 
-  async runCommand<T>(command: string): Promise<T> {
+  async runCommand<T>(command: string, payload: any = null): Promise<T> {
     const result = await new Promise<T>((resolve, reject) => {
-      this.message(command, null, reply => {
-        resolve(reply.data);
+      this.message(command, payload, reply => {
+        resolve(reply.data as T);
       });
     });
     return result;

--- a/src/modules/frames/ProxyFrameHost.ts
+++ b/src/modules/frames/ProxyFrameHost.ts
@@ -5,6 +5,7 @@ import Postmam from '../../Postmam';
 import { timeoutPromise, triggerNotificationPermissionChanged } from '../../utils';
 import { ServiceWorkerActiveState } from "../../helpers/ServiceWorkerHelper";
 import Log from '../../libraries/Log';
+import { PageVisibilityRequest } from '../../service-worker/types';
 
 /**
  * Manager for an instance of the OneSignal proxy frame, for use from the main
@@ -104,6 +105,8 @@ export default class ProxyFrameHost implements Disposable {
     this.messenger.on(OneSignal.POSTMAM_COMMANDS.REQUEST_HOST_URL, this.onRequestHostUrl.bind(this));
     this.messenger.on(OneSignal.POSTMAM_COMMANDS.SERVICEWORKER_COMMAND_REDIRECT, this.onServiceWorkerCommandRedirect.bind(this));
     this.messenger.on(OneSignal.POSTMAM_COMMANDS.GET_EVENT_LISTENER_COUNT, this.onGetEventListenerCount.bind(this));
+    this.messenger.on(OneSignal.POSTMAM_COMMANDS.ARE_YOU_VISIBLE_REQUEST, this.onAreYouVisibleRequest.bind(this));
+    this.messenger.on("os.page_focused_request", this.onAreYouVisibleRequest.bind(this));
     this.messenger.connect();
   }
 
@@ -188,6 +191,15 @@ export default class ProxyFrameHost implements Disposable {
         resolve(reply.data);
       });
     });
+  }
+
+  onAreYouVisibleRequest(event: {data: PageVisibilityRequest}) {
+    console.log("onAreYouVisibleRequest page")
+    const response = {
+      timestamp: event.data.timestamp,
+      focused: document.hasFocus(),
+    };
+    this.message(OneSignal.POSTMAM_COMMANDS.ARE_YOU_VISIBLE_RESPONSE, response);
   }
 
   async runCommand<T>(command: string, payload: any = null): Promise<T> {

--- a/src/modules/frames/SubscriptionPopupHost.ts
+++ b/src/modules/frames/SubscriptionPopupHost.ts
@@ -168,7 +168,7 @@ export default class SubscriptionPopupHost implements Disposable {
     Log.debug(SdkEnvironment.getWindowEnv().toString() + " Marking current session as a continuing browsing session.");
     const { sessionCount }: { sessionCount: number } = message.data;
     const context: Context = OneSignal.context;
-    context.sessionManager.setPageViewCount(sessionCount);
+    context.pageViewManager.setPageViewCount(sessionCount);
   }
 
   async onWindowTimeout(_: MessengerMessageEvent) {

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -13,7 +13,7 @@ import { RawPushSubscription } from "../models/RawPushSubscription";
 import { SubscriptionStateKind } from "../models/SubscriptionStateKind";
 import { SubscriptionStrategyKind } from "../models/SubscriptionStrategyKind";
 import { PushDeviceRecord } from "../models/PushDeviceRecord";
-import { SessionPayload } from "../models/Session";
+import { UpsertSessionPayload, DeactivateSessionPayload } from "../models/Session";
 import Log from "../libraries/Log";
 import { ConfigHelper } from "../helpers/ConfigHelper";
 import { OneSignalUtils } from "../utils/OneSignalUtils";
@@ -175,7 +175,7 @@ export class ServiceWorker {
       await context.subscriptionManager.unsubscribe(UnsubscriptionStrategy.MarkUnsubscribed);
       ServiceWorker.workerMessenger.broadcast(WorkerMessengerCommand.AmpUnsubscribe, null);
     });
-    ServiceWorker.workerMessenger.on(WorkerMessengerCommand.SessionUpsert, async (payload: SessionPayload) => {
+    ServiceWorker.workerMessenger.on(WorkerMessengerCommand.SessionUpsert, async (payload: UpsertSessionPayload) => {
       Log.debug("[Service Worker] Received SessionUpsert", payload);
       try {
         await ServiceWorkerHelper.upsertSession(
@@ -191,15 +191,18 @@ export class ServiceWorker {
       }
     });
 
-    ServiceWorker.workerMessenger.on(WorkerMessengerCommand.SessionDeactivate, async (payload: SessionPayload) => {
-      Log.debug("[Service Worker] Received SessionDeactivate");
-      try {
-        self.timerId = await ServiceWorkerHelper.deactivateSession(
-          payload.sessionThreshold, payload.enableSessionDuration);
-      } catch(e) {
-        Log.error("Error in SW.SessionDeactivate handler", e);
+    ServiceWorker.workerMessenger.on(
+      WorkerMessengerCommand.SessionDeactivate,
+      async (payload: DeactivateSessionPayload) => {
+        Log.debug("[Service Worker] Received SessionDeactivate");
+        try {
+          self.timerId = await ServiceWorkerHelper.deactivateSession(
+            payload.sessionThreshold, payload.enableSessionDuration);
+        } catch(e) {
+          Log.error("Error in SW.SessionDeactivate handler", e);
+        }
       }
-    });
+    );
   }
 
   /**

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -13,10 +13,12 @@ import { RawPushSubscription } from "../models/RawPushSubscription";
 import { SubscriptionStateKind } from "../models/SubscriptionStateKind";
 import { SubscriptionStrategyKind } from "../models/SubscriptionStrategyKind";
 import { PushDeviceRecord } from "../models/PushDeviceRecord";
+import { SessionPayload } from "../models/Session";
 import Log from "../libraries/Log";
 import { ConfigHelper } from "../helpers/ConfigHelper";
 import { OneSignalUtils } from "../utils/OneSignalUtils";
 import { Utils } from "../utils/Utils";
+import ServiceWorkerHelper from "../helpers/ServiceWorkerHelper";
 
 declare var self: ServiceWorkerGlobalScope;
 declare var Notification: Notification;
@@ -103,8 +105,8 @@ export class ServiceWorker {
 
       Also see: https://github.com/w3c/ServiceWorker/issues/1156
     */
-    Log.debug('Setting up message listeners.');
-    // self.addEventListener('message') is statically added inside the listen() method
+   Log.debug('Setting up message listeners.');
+   // self.addEventListener('message') is statically added inside the listen() method
     ServiceWorker.workerMessenger.listen();
     // Install messaging event handlers for page <-> service worker communication
     ServiceWorker.setupMessageListeners();
@@ -172,6 +174,24 @@ export class ServiceWorker {
       const context = new ContextSW(appConfig);
       await context.subscriptionManager.unsubscribe(UnsubscriptionStrategy.MarkUnsubscribed);
       ServiceWorker.workerMessenger.broadcast(WorkerMessengerCommand.AmpUnsubscribe, null);
+    });
+    ServiceWorker.workerMessenger.on(WorkerMessengerCommand.SessionUpsert, async (payload: SessionPayload) => {
+      Log.debug("[Service Worker] Received SessionUpsert", payload);
+      try {
+        await ServiceWorkerHelper.upsertSession(payload.sessionThreshold, payload.enableSessionDuration, self.timerId);
+      } catch(e) {
+        Log.error("Error in SW.SessionUpsert handler", e.message, e);
+      }
+    });
+
+    ServiceWorker.workerMessenger.on(WorkerMessengerCommand.SessionDeactivate, async (payload: SessionPayload) => {
+      Log.debug("[Service Worker] Received SessionDeactivate");
+      try {
+        self.timerId = await ServiceWorkerHelper.deactivateSession(
+          payload.sessionThreshold, payload.enableSessionDuration);
+      } catch(e) {
+        Log.error("Error in SW.SessionDeactivate handler", e);
+      }
     });
   }
 

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -20,7 +20,7 @@ import { OneSignalUtils } from "../utils/OneSignalUtils";
 import { Utils } from "../utils/Utils";
 import ServiceWorkerHelper from "../helpers/ServiceWorkerHelper";
 
-declare var self: ServiceWorkerGlobalScope;
+declare var self: ServiceWorkerGlobalScope & { timerId: number | undefined; };
 declare var Notification: Notification;
 
 /**
@@ -178,7 +178,14 @@ export class ServiceWorker {
     ServiceWorker.workerMessenger.on(WorkerMessengerCommand.SessionUpsert, async (payload: SessionPayload) => {
       Log.debug("[Service Worker] Received SessionUpsert", payload);
       try {
-        await ServiceWorkerHelper.upsertSession(payload.sessionThreshold, payload.enableSessionDuration, self.timerId);
+        await ServiceWorkerHelper.upsertSession(
+          payload.sessionThreshold,
+          payload.enableSessionDuration,
+          self.timerId,
+          payload.deviceRecord,
+          payload.deviceId,
+          payload.sessionOrigin
+        );
       } catch(e) {
         Log.error("Error in SW.SessionUpsert handler", e.message, e);
       }

--- a/src/service-worker/types.ts
+++ b/src/service-worker/types.ts
@@ -1,0 +1,23 @@
+export interface PageVisibilityRequest {
+  timestamp: number;
+}
+
+export interface PageVisibilityResponse extends PageVisibilityRequest {
+  focused: boolean;
+}
+
+export interface OSWindowClient extends WindowClient {
+  isSubdomainIframe: boolean;
+}
+
+export interface ClientStatus {
+  timestamp: number;
+  sentRequestsCount: number;
+  receivedResponsesCount: number;
+  hasAnyActiveSessions: boolean;
+}
+
+export interface OSServiceWorkerFields { 
+  timerId?: number;
+  clientsStatus?: ClientStatus;
+}

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -25,7 +25,7 @@ interface DatabaseResult {
   timestamp: any;
 }
 
-type OneSignalDbTable = "Options" | "Ids" | "NotificationOpened" | "Sessions";
+export type OneSignalDbTable = "Options" | "Ids" | "NotificationOpened" | "Sessions";
 
 export default class Database {
 

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -9,7 +9,7 @@ import { Subscription } from "../models/Subscription";
 import { TestEnvironmentKind } from "../models/TestEnvironmentKind";
 import { WindowEnvironmentKind } from "../models/WindowEnvironmentKind";
 import { EmailProfile } from "../models/EmailProfile";
-import { Session } from "../models/Session";
+import { Session, ONESIGNAL_SESSION_KEY } from "../models/Session";
 import SdkEnvironment from "../managers/SdkEnvironment";
 import OneSignalUtils from "../utils/OneSignalUtils";
 import Utils from "../utils/Utils";
@@ -26,8 +26,6 @@ interface DatabaseResult {
 }
 
 type OneSignalDbTable = "Options" | "Ids" | "NotificationOpened" | "Sessions";
-
-const ONESIGNAL_SESSION_KEY = "oneSignalSession";
 
 export default class Database {
 

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -9,6 +9,7 @@ import { Subscription } from "../models/Subscription";
 import { TestEnvironmentKind } from "../models/TestEnvironmentKind";
 import { WindowEnvironmentKind } from "../models/WindowEnvironmentKind";
 import { EmailProfile } from "../models/EmailProfile";
+import { Session } from "../models/Session";
 import SdkEnvironment from "../managers/SdkEnvironment";
 import OneSignalUtils from "../utils/OneSignalUtils";
 import Utils from "../utils/Utils";
@@ -24,7 +25,9 @@ interface DatabaseResult {
   timestamp: any;
 }
 
-type OneSignalDbTable = "Options" | "Ids" | "NotificationOpened";
+type OneSignalDbTable = "Options" | "Ids" | "NotificationOpened" | "Sessions";
+
+const ONESIGNAL_SESSION_KEY = "oneSignalSession";
 
 export default class Database {
 
@@ -337,6 +340,18 @@ export default class Database {
     return await this.get<boolean>("Options", "userConsent");
   }
 
+  private async getSession(sessionKey: string): Promise<Session | null> {
+    return await this.get<Session | null>("Sessions", sessionKey);
+  }
+
+  private async setSession(session: Session): Promise<void> {
+    await this.put("Sessions", session);
+  }
+
+  private async removeSession(sessionKey: string): Promise<void> {
+    await this.remove("Sessions", sessionKey);
+  }
+
   /**
    * Asynchronously removes the Ids, NotificationOpened, and Options tables from the database and recreates them with blank values.
    * @returns {Promise} Returns a promise that is fulfilled when rebuilding is completed, or rejects with an error.
@@ -352,6 +367,18 @@ export default class Database {
   // START: Static mappings to instance methods
   static async on(...args: any[]) {
     return Database.singletonInstance.emitter.on.apply(Database.singletonInstance.emitter, args);
+  }
+
+  public static async getCurrentSession(): Promise<Session | null> {
+    return await Database.singletonInstance.getSession(ONESIGNAL_SESSION_KEY);
+  }
+
+  public static async upsertSession(session: Session): Promise<void> {
+    await Database.singletonInstance.setSession(session);
+  }
+
+  public static async cleanupCurrentSession(): Promise<void> {
+    await Database.singletonInstance.removeSession(ONESIGNAL_SESSION_KEY);
   }
 
   static async setEmailProfile(emailProfile: EmailProfile) {

--- a/src/services/IndexedDb.ts
+++ b/src/services/IndexedDb.ts
@@ -100,15 +100,11 @@ export default class IndexedDb {
   private onDatabaseUpgradeNeeded(event: IDBVersionChangeEvent): void {
     Log.debug('IndexedDb: Database is being rebuilt or upgraded (upgradeneeded event).');
     const db = (event.target as IDBOpenDBRequest).result;
-    db.createObjectStore("Ids", {
-      keyPath: "type"
-    });
-    db.createObjectStore("NotificationOpened", {
-      keyPath: "url"
-    });
-    db.createObjectStore("Options", {
-      keyPath: "key"
-    });
+    db.createObjectStore("Ids", { keyPath: "type" });
+    db.createObjectStore("NotificationOpened", { keyPath: "url" });
+    db.createObjectStore("Options", { keyPath: "key" });
+    db.createObjectStore("Sessions", { keyPath: "sessionKey" });
+
     // Wrap in conditional for tests
     if (typeof OneSignal !== "undefined") {
       OneSignal._isNewVisitor = true;

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -387,10 +387,12 @@ export class TestEnvironment {
           metrics: {
             enable: true,
             mixpanel_reporting_token: "7c2582e45a6ecf1501aa3ca7887f3673"
-          }
+          },
+          enableSessionDuration: true,
         },
         config: {
           autoResubscribe: true,
+          sessionThreshold: 30,
           siteInfo: {
             name: "localhost https",
             origin: "https://localhost:3001",
@@ -544,13 +546,15 @@ export class TestEnvironment {
         },
         email: {
           require_auth: true,
-        }
+        },
+        enableSessionDuration: true
       },
       config: {
         origin: "https://example.com",
         subdomain: undefined,
         http_use_onesignal_com: false,
         autoResubscribe: false,
+        sessionThreshold: 30,
         staticPrompts: {
           native: {
             enabled: false,

--- a/test/unit/managers/SessionManager.ts
+++ b/test/unit/managers/SessionManager.ts
@@ -10,7 +10,7 @@ import { SubscriptionManager } from '../../../src/managers/SubscriptionManager';
 import { AppConfig } from '../../../src/models/AppConfig';
 
 import Context from '../../../src/models/Context';
-import { SessionManager } from '../../../src/managers/SessionManager';
+import { PageViewManager } from '../../../src/managers/PageViewManager';
 import Random from '../../support/tester/Random';
 
 test.beforeEach(async t => {
@@ -24,40 +24,40 @@ test.beforeEach(async t => {
 });
 
 test('page view count for first page view should be zero', async t => {
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 0);
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 0);
 });
 
 test('page view count should increment', async t => {
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 0);
-  OneSignal.context.sessionManager.incrementPageViewCount();
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 0);
+  OneSignal.context.pageViewManager.incrementPageViewCount();
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
 });
 
 test('page view count should only increment once for the current page view', async t => {
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 0);
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 0);
   for (let i = 0; i < 5; i++) {
     // Even though we're calling this 5 times
-    OneSignal.context.sessionManager.incrementPageViewCount();
+    OneSignal.context.pageViewManager.incrementPageViewCount();
   }
   // The final page count should only be incremented by one
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
 });
 
 test('page view count should increment per page-refresh', async t => {
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 0);
-  OneSignal.context.sessionManager.incrementPageViewCount();
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 0);
+  OneSignal.context.pageViewManager.incrementPageViewCount();
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
 
-  OneSignal.context.sessionManager.simulatePageNavigationOrRefresh();
+  OneSignal.context.pageViewManager.simulatePageNavigationOrRefresh();
 
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
-  OneSignal.context.sessionManager.incrementPageViewCount();
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 2);
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
+  OneSignal.context.pageViewManager.incrementPageViewCount();
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 2);
 
-  OneSignal.context.sessionManager.simulatePageNavigationOrRefresh();
+  OneSignal.context.pageViewManager.simulatePageNavigationOrRefresh();
 
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 2);
-  OneSignal.context.sessionManager.incrementPageViewCount();
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 3);
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 2);
+  OneSignal.context.pageViewManager.incrementPageViewCount();
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 3);
 });
 

--- a/test/unit/managers/SubscriptionManager.ts
+++ b/test/unit/managers/SubscriptionManager.ts
@@ -726,11 +726,11 @@ test(
     const context: Context = OneSignal.context;
     const serviceWorkerManager = context.serviceWorkerManager;
     const subscriptionManager = context.subscriptionManager; 
-    const sessionManager = context.sessionManager;
+    const pageViewManager = context.pageViewManager;
 
     TestEnvironment.mockInternalOneSignal();
 
-    sandbox.stub(sessionManager, "isFirstPageView").returns(true);
+    sandbox.stub(pageViewManager, "isFirstPageView").returns(true);
     const error403 = new ServiceWorkerRegistrationError(403, "403 Forbidden");
     sandbox.stub(serviceWorkerManager, "installWorker").rejects(error403);
     sandbox.stub(SdkEnvironment, "getWindowEnv").returns(WindowEnvironmentKind.Host);
@@ -751,11 +751,11 @@ test(
     const context: Context = OneSignal.context;
     const serviceWorkerManager = context.serviceWorkerManager;
     const subscriptionManager = context.subscriptionManager; 
-    const sessionManager = context.sessionManager;
+    const pageViewManager = context.pageViewManager;
 
     TestEnvironment.mockInternalOneSignal();
 
-    sandbox.stub(sessionManager, "isFirstPageView").returns(false);
+    sandbox.stub(pageViewManager, "isFirstPageView").returns(false);
     const error403 = new ServiceWorkerRegistrationError(403, "403 Forbidden");
     sandbox.stub(serviceWorkerManager, "installWorker").throws(error403);
     sandbox.stub(SdkEnvironment, "getWindowEnv").returns(WindowEnvironmentKind.Host);
@@ -776,11 +776,11 @@ test(
     const context: Context = OneSignal.context;
     const serviceWorkerManager = context.serviceWorkerManager;
     const subscriptionManager = context.subscriptionManager; 
-    const sessionManager = context.sessionManager;
+    const pageViewManager = context.pageViewManager;
 
     TestEnvironment.mockInternalOneSignal();
 
-    sandbox.stub(sessionManager, "isFirstPageView").returns(true);
+    sandbox.stub(pageViewManager, "isFirstPageView").returns(true);
     const error404 = new ServiceWorkerRegistrationError(404, "404 Not Found");
     sandbox.stub(serviceWorkerManager, "installWorker").rejects(error404);
     sandbox.stub(SdkEnvironment, "getWindowEnv").returns(WindowEnvironmentKind.Host);
@@ -801,11 +801,11 @@ test(
     const context: Context = OneSignal.context;
     const serviceWorkerManager = context.serviceWorkerManager;
     const subscriptionManager = context.subscriptionManager; 
-    const sessionManager = context.sessionManager;
+    const pageViewManager = context.pageViewManager;
 
     TestEnvironment.mockInternalOneSignal();
 
-    sandbox.stub(sessionManager, "isFirstPageView").returns(false);
+    sandbox.stub(pageViewManager, "isFirstPageView").returns(false);
     const error404 = new ServiceWorkerRegistrationError(404, "404 Not Found");
     sandbox.stub(serviceWorkerManager, "installWorker").throws(error404);
     sandbox.stub(SdkEnvironment, "getWindowEnv").returns(WindowEnvironmentKind.Host);

--- a/test/unit/managers/UpdateManager.ts
+++ b/test/unit/managers/UpdateManager.ts
@@ -50,7 +50,7 @@ test("sendPlayerUpdate sends on_session if on_session hasn't been sent before", 
 test("sendPlayerUpdate sends playerUpdate if on_session has already been sent", async t => {
   sandbox.stub(Database, "getSubscription").resolves({ deviceId: Random.getRandomUuid() });
   
-  OneSignal.context.sessionManager.setPageViewCount(2);
+  OneSignal.context.pageViewManager.setPageViewCount(2);
   OneSignal.context.updateManager = new UpdateManager(OneSignal.context);
 
   t.is(OneSignal.context.updateManager.onSessionAlreadyCalled(), true);
@@ -67,7 +67,7 @@ test("sendPlayerUpdate sends playerUpdate if on_session has already been sent", 
 test("sendOnSessionUpdate doesn't trigger on_session call if already did so", async t => {
   sandbox.stub(Database, "getSubscription").resolves({ deviceId: Random.getRandomUuid() });
   
-  OneSignal.context.sessionManager.setPageViewCount(2);
+  OneSignal.context.pageViewManager.setPageViewCount(2);
   OneSignal.context.updateManager = new UpdateManager(OneSignal.context);
   const onSessionSpy = sandbox.stub(OneSignalApiShared, "updateUserSession");
 
@@ -87,7 +87,7 @@ test("sendOnSessionUpdate doesn't trigger for a new user", async t => {
 
 test("sendOnSessionUpdate triggers on_session for existing subscribed user if hasn't done so already", async t => {
   sandbox.stub(Database, "getSubscription").resolves({ deviceId: Random.getRandomUuid() });
-  sandbox.stub(OneSignal.context.sessionManager, "isFirstPageView").returns(true);
+  sandbox.stub(OneSignal.context.pageViewManager, "isFirstPageView").returns(true);
   sandbox.stub(OneSignal.context.subscriptionManager, "isAlreadyRegisteredWithOneSignal").resolves(true);
   sandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.Subscribed);
   const onSessionSpy = sandbox.stub(OneSignalApiShared, "updateUserSession").resolves();
@@ -100,7 +100,7 @@ test("sendOnSessionUpdate triggers on_session for existing subscribed user if ha
 
 test("sendOnSessionUpdate triggers on_session for existing unsubscribed user if hasn't done so already and if enableOnSession flag is present", async t => {
   sandbox.stub(Database, "getSubscription").resolves({ deviceId: Random.getRandomUuid() });
-  sandbox.stub(OneSignal.context.sessionManager, "isFirstPageView").returns(true);
+  sandbox.stub(OneSignal.context.pageViewManager, "isFirstPageView").returns(true);
   sandbox.stub(OneSignal.context.subscriptionManager, "isAlreadyRegisteredWithOneSignal").resolves(true);
   sandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.MutedByApi);
   OneSignal.config.enableOnSession = true;
@@ -115,7 +115,7 @@ test("sendOnSessionUpdate triggers on_session for existing unsubscribed user if 
 
 test("sendOnSessionUpdate triggers on_session for existing unsubscribed user if hasn't done so already and if enableOnSession flag is not present", async t => {
   sandbox.stub(Database, "getSubscription").resolves({ deviceId: Random.getRandomUuid() });
-  sandbox.stub(OneSignal.context.sessionManager, "isFirstPageView").returns(true);
+  sandbox.stub(OneSignal.context.pageViewManager, "isFirstPageView").returns(true);
   sandbox.stub(OneSignal.context.subscriptionManager, "isAlreadyRegisteredWithOneSignal").resolves(true);
   sandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.MutedByApi);
   OneSignal.config.enableOnSession = false;
@@ -131,7 +131,7 @@ test("sendOnSessionUpdate includes appId at all times", async t => {
   const deviceId = Random.getRandomUuid();
   sandbox.stub(Database, "getSubscription").resolves({ deviceId });
   
-  OneSignal.context.sessionManager.setPageViewCount(1);
+  OneSignal.context.pageViewManager.setPageViewCount(1);
   OneSignal.context.updateManager = new UpdateManager(OneSignal.context);
   t.is(OneSignal.context.updateManager.onSessionAlreadyCalled(), false);
   sandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.Subscribed);

--- a/test/unit/modules/postmam.ts
+++ b/test/unit/modules/postmam.ts
@@ -10,7 +10,7 @@ import { SubscriptionManager } from '../../../src/managers/SubscriptionManager';
 import { AppConfig } from '../../../src/models/AppConfig';
 
 import Context from '../../../src/models/Context';
-import { SessionManager } from '../../../src/managers/SessionManager';
+import { PageViewManager } from '../../../src/managers/PageViewManager';
 import Postmam from '../../../src/Postmam';
 import { contains } from '../../../src/utils';
 

--- a/test/unit/modules/subscriptionHelper.ts
+++ b/test/unit/modules/subscriptionHelper.ts
@@ -5,7 +5,7 @@ import OneSignal from '../../../src/OneSignal';
 import sinon from 'sinon';
 import SubscriptionHelper from '../../../src/helpers/SubscriptionHelper';
 import { SubscriptionManager } from '../../../src/managers/SubscriptionManager';
-import { SessionManager } from '../../../src/managers/SessionManager';
+import { PageViewManager } from '../../../src/managers/PageViewManager';
 
 const sinonSandbox = sinon.sandbox.create();
 
@@ -22,7 +22,7 @@ test.afterEach(() => {
 
 test('should not resubscribe user on subsequent page views if the user is already subscribed', async t => {
   sinonSandbox.stub(OneSignal, 'privateIsPushNotificationsEnabled').resolves(true);
-  sinonSandbox.stub(SessionManager.prototype, 'getPageViewCount').returns(2);
+  sinonSandbox.stub(PageViewManager.prototype, 'getPageViewCount').returns(2);
   const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, 'subscribe');
 
   await SubscriptionHelper.registerForPush();
@@ -31,7 +31,7 @@ test('should not resubscribe user on subsequent page views if the user is alread
 
 test('should subscribe user on subsequent page views if the user is not subscribed', async t => {
   sinonSandbox.stub(OneSignal, 'isPushNotificationsEnabled').resolves(false);
-  sinonSandbox.stub(SessionManager.prototype, 'getPageViewCount').returns(2);
+  sinonSandbox.stub(PageViewManager.prototype, 'getPageViewCount').returns(2);
   sinonSandbox.stub(SubscriptionManager.prototype, 'registerSubscription').resolves();
   
   const subscribeStub = sinonSandbox.stub(SubscriptionManager.prototype, 'subscribe').resolves(null);
@@ -41,7 +41,7 @@ test('should subscribe user on subsequent page views if the user is not subscrib
 
 test('should resubscribe an already subscribed user on first page view', async t => {
   sinonSandbox.stub(OneSignal, 'isPushNotificationsEnabled').resolves(true);
-  sinonSandbox.stub(SessionManager.prototype, 'getPageViewCount').returns(1);
+  sinonSandbox.stub(PageViewManager.prototype, 'getPageViewCount').returns(1);
   sinonSandbox.stub(SubscriptionManager.prototype, 'registerSubscription').resolves();
 
   const subscribeStub = sinonSandbox.stub(SubscriptionManager.prototype, 'subscribe').resolves(null);

--- a/test/unit/public-sdk-apis/init.ts
+++ b/test/unit/public-sdk-apis/init.ts
@@ -80,8 +80,8 @@ test("email session should be updated on first page view", async t => {
   TestEnvironment.mockInternalOneSignal();
 
   // Ensure this is true, that way email on_session gets run
-  OneSignal.context.sessionManager.setPageViewCount(1);
-  t.true(OneSignal.context.sessionManager.isFirstPageView());
+  OneSignal.context.pageViewManager.setPageViewCount(1);
+  t.true(OneSignal.context.pageViewManager.isFirstPageView());
   
   await Database.setEmailProfile(testEmailProfile);
 

--- a/test/unit/public-sdk-apis/onSession.ts
+++ b/test/unit/public-sdk-apis/onSession.ts
@@ -19,7 +19,7 @@ import { ServiceWorkerManager } from "../../../src/managers/ServiceWorkerManager
 import { NotificationPermission } from "../../../src/models/NotificationPermission";
 import Database from "../../../src/services/Database";
 import { Subscription } from "../../../src/models/Subscription";
-import { SessionManager } from "../../../src/managers/SessionManager";
+import { PageViewManager } from "../../../src/managers/PageViewManager";
 import { SubscriptionManager } from "../../../src/managers/SubscriptionManager";
 import InitHelper from "../../../src/helpers/InitHelper";
 import { ServiceWorkerActiveState } from '../../../src/helpers/ServiceWorkerHelper';
@@ -105,7 +105,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
       autoResubscribe: false,
     });
     await initPromise;
-    t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+    t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
     await initializePromise;
     await subscriptionPromise;
 });
@@ -142,7 +142,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
     autoResubscribe: false,
   });
   await initPromise;
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
   await initializePromise;
   t.is(subscribeSpy.callCount, 0);
 });
@@ -186,7 +186,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
       autoResubscribe: true,
     });
     await initPromise;
-    t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+    t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
     await initializePromise;
     await registrationPromise;
     await subscriptionPromise;
@@ -218,7 +218,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
       autoResubscribe: true,
     });
     await initPromise;
-    t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+    t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
     await initializePromise;
     t.is(subscribeSpy.callCount, 0);
 });
@@ -248,7 +248,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
       autoResubscribe: false,
     });
     await initPromise;
-    t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+    t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
     await initializePromise;
     t.is(subscribeSpy.callCount, 0);
 });
@@ -286,7 +286,7 @@ test.serial(`HTTPS: User opted out => first page view => onSession flag is on =>
       }
     });
     await initPromise;
-    t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+    t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
     await initializePromise;
 });
 
@@ -323,7 +323,7 @@ test.serial(`HTTPS: User opted out => first page view => onSession flag is off =
     }
   });
   await initPromise;
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
   await initializePromise;
   t.is(subscribeSpy.callCount, 0);
 });
@@ -342,7 +342,7 @@ test.serial(`HTTPS: User opted out => second page view => onSession flag is on =
   const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
   await markUserAsOptedOut();
 
-  sinonSandbox.stub(SessionManager.prototype, "getPageViewCount").resolves(2);
+  sinonSandbox.stub(PageViewManager.prototype, "getPageViewCount").resolves(2);
 
   const initializePromise = new Promise((resolve) => {
     OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
@@ -406,7 +406,7 @@ test.serial(`HTTPS: User subscribed => first page view => expiring subscription 
     }
   });
   await initPromise;
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
   await initializePromise;
 });
 
@@ -442,7 +442,7 @@ test.serial(`HTTPS: User subscribed => first page view => sends on session`, asy
     }
   });
   await initPromise;
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
   await initializePromise;
 });
 
@@ -486,7 +486,7 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => s
       autoResubscribe: false,
     });
     await initPromise;
-    t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+    t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
     await initializePromise;
     await subscriptionPromise;
 });
@@ -523,7 +523,7 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => s
     autoResubscribe: false,
   });
   await initPromise;
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
   await initializePromise;
   t.is(subscribeSpy.callCount, 0);
 });
@@ -555,7 +555,7 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => a
       autoResubscribe: true,
     });
     await initPromise;
-    t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+    t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
     await initializePromise;
     t.is(subscribeSpy.callCount, 0);
 });
@@ -586,7 +586,7 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => a
       autoResubscribe: true,
     });
     await initPromise;
-    t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+    t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
     await initializePromise;
     t.is(subscribeSpy.callCount, 0);
 });
@@ -615,7 +615,7 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => n
       autoResubscribe: false,
     });
     await initPromise;
-    t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+    t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
     await initializePromise;
     t.is(subscribeSpy.callCount, 0);
 });
@@ -653,7 +653,7 @@ test.serial(`HTTP: User opted out => first page view => onSession flag is on => 
       }
     });
     await initPromise;
-    t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+    t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
     await initializePromise;
 });
 
@@ -690,7 +690,7 @@ test.serial(`HTTP: User opted out => first page view => onSession flag is off =>
     }
   });
   await initPromise;
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
   await initializePromise;
   t.is(subscribeSpy.callCount, 0);
 });
@@ -709,7 +709,7 @@ test.serial(`HTTP: User opted out => second page view => onSession flag is on =>
   const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
   await markUserAsOptedOut();
 
-  sinonSandbox.stub(SessionManager.prototype, "getPageViewCount").resolves(2);
+  sinonSandbox.stub(PageViewManager.prototype, "getPageViewCount").resolves(2);
 
   const initializePromise = new Promise((resolve) => {
     OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
@@ -768,7 +768,7 @@ test.serial(`HTTP: User subscribed => first page view => expiring subscription =
     }
   });
   await initPromise;
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
   await initializePromise;
 });
 
@@ -804,7 +804,7 @@ test.serial(`HTTP: User subscribed => first page view => sends on session`, asyn
     }
   });
   await initPromise;
-  t.is(OneSignal.context.sessionManager.getPageViewCount(), 1);
+  t.is(OneSignal.context.pageViewManager.getPageViewCount(), 1);
   await initializePromise;
 });
 


### PR DESCRIPTION
First iteration of code review:
- refactored session management to mirror what android does;
- tested Chrome https / Chrome http / Safari 13 https

For easier testing:
- use this branch from main OneSignal https://github.com/OneSignal/OneSignal/commits/sdk/outcomes_events
- added a new param to sandbox to test with staging
https://localhost:3001/sdks/web-sdk/sandbox?appId=afcacc95-05d1-44b6-bba7-d0502cd06894&staging=1

on_session is accepted as usual, on_focus is accepted (deployed this PR to staging turbine https://github.com/OneSignal/turbine/pull/209 for CORS support) but I don't see the playtime to be reflected correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/567)
<!-- Reviewable:end -->
