### PR TITLE
Dont install sw on host page when subdomain is set

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "ava": "^0.21.0",
     "awesome-typescript-loader": "^4.0.1",
     "css-loader": "^0.26.2",
+    "deepmerge": "^4.2.2",
     "dom-storage": "^2.0.2",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "fake-indexeddb": "github:OneSignal/fakeIndexedDB#onesignal",

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -43,7 +43,7 @@ export default class InitHelper {
     Log.debug('Called %cinternalInit()', getConsoleStyle('code'));
 
     // Always check for an updated service worker
-    await OneSignal.context.serviceWorkerManager.updateWorker();
+    await OneSignal.context.serviceWorkerManager.installWorker();
 
     OneSignal.context.sessionManager.incrementPageViewCount();
 

--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -194,6 +194,13 @@ export class ServiceWorkerManager {
   }
 
   async shouldInstallWorker(): Promise<boolean> {
+    if (!Environment.supportsServiceWorkers())
+      return false;
+
+    // No, if configured to use our subdomain (AKA HTTP setup) AND this is on their page (HTTP or HTTPS).
+    if (OneSignal.config.subdomain && SdkEnvironment.getWindowEnv() == WindowEnvironmentKind.Host)
+      return false;
+
     const workerState = await this.getActiveState();
 
     if (workerState !== ServiceWorkerActiveState.WorkerA && workerState !== ServiceWorkerActiveState.WorkerB) {
@@ -297,7 +304,7 @@ export class ServiceWorkerManager {
    * considered subscribed.
    */
   public async installWorker() {
-    if (!Environment.supportsServiceWorkers()) {
+    if (!await OneSignal.context.serviceWorkerManager.shouldInstallWorker()) {
       return;
     }
 

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -355,23 +355,21 @@ export class SubscriptionManager {
     }
 
     /* Now that permissions have been granted, install the service worker */
-    if (await this.context.serviceWorkerManager.shouldInstallWorker()) {
-        try {
-          await this.context.serviceWorkerManager.installWorker();
-        } catch(err) {
-          if (err instanceof ServiceWorkerRegistrationError) {
-            if (err.status === 403) {
-              await this.context.subscriptionManager.registerFailedSubscription(
-                SubscriptionStateKind.ServiceWorkerStatus403, 
-                this.context);
-            } else if (err.status === 404) {
-              await this.context.subscriptionManager.registerFailedSubscription(
-                SubscriptionStateKind.ServiceWorkerStatus404,
-                this.context);
-            } 
-          } 
-          throw err;
-        }
+    try {
+      await this.context.serviceWorkerManager.installWorker();
+    } catch(err) {
+      if (err instanceof ServiceWorkerRegistrationError) {
+        if (err.status === 403) {
+          await this.context.subscriptionManager.registerFailedSubscription(
+            SubscriptionStateKind.ServiceWorkerStatus403, 
+            this.context);
+        } else if (err.status === 404) {
+          await this.context.subscriptionManager.registerFailedSubscription(
+            SubscriptionStateKind.ServiceWorkerStatus404,
+            this.context);
+        } 
+      } 
+      throw err;
     }
       
 

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -317,6 +317,7 @@ export interface ServerAppConfig {
     /**
      * The allowed origin this web push config is allowed to run on.
      */
+    // TODO: origin and siteInfo.proxyOrigin are the same, clean up mixed usage in code
     origin: string;
     staticPrompts: ServerAppConfigPrompt;
     autoResubscribe: boolean;

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -4,6 +4,10 @@ interface IndexOfAble {
   indexOf(match:string): number;
 }
 
+export type RecursivePartial<T> = {
+  [P in keyof T]?: RecursivePartial<T[P]>;
+};
+
 export class Utils {
   /**
    * Returns true if match is in string; otherwise, returns false.

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -24,6 +24,7 @@ import { MockPushManager } from "../mocks/service-workers/models/MockPushManager
 import { MockServiceWorkerContainer } from "../mocks/service-workers/models/MockServiceWorkerContainer";
 import { addServiceWorkerGlobalScopeToGlobal } from "../polyfills/polyfills";
 import deepmerge = require("deepmerge");
+import { RecursivePartial } from '../../../src/utils/Utils';
 
 // NodeJS.Global
 declare var global: any;

--- a/test/unit/managers/ServiceWorkerManager.ts
+++ b/test/unit/managers/ServiceWorkerManager.ts
@@ -509,6 +509,18 @@ test("Service worker failed to install in popup. No handling.", async t => {
   t.is(error.message, workerRegistrationError.message);
 });
 
+
+test('installWorker() should not install when on an HTTPS site with a subdomain set', async t => {
+  await TestEnvironment.initialize({
+    httpOrHttps: HttpHttpsEnvironment.Https,
+    initOptions: { subdomain: "abc" }
+  });
+
+  const manager = LocalHelpers.getServiceWorkerManager();
+  await manager.installWorker();
+  t.is(await manager.getActiveState(), ServiceWorkerActiveState.None);
+});
+
 test('ServiceWorkerManager.getRegistration() handles throws by returning null', async t => {
   getRegistrationStub.restore();
   getRegistrationStub = sandbox.stub(navigator.serviceWorker, 'getRegistration');

--- a/test/unit/modules/mergedLegacyConfig.ts
+++ b/test/unit/modules/mergedLegacyConfig.ts
@@ -7,7 +7,7 @@ import OneSignal from '../../../src/OneSignal';
 import ConfigManager from '../../../src/managers/ConfigManager';
 
 test.beforeEach(t => {
-  t.context.serverConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom);
+  t.context.overrideServerConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom);
 });
 
 test('should assign the default service worker file path if not provided', async t => {

--- a/typings/globals/missing.d.ts
+++ b/typings/globals/missing.d.ts
@@ -97,7 +97,3 @@ declare var __IS_ES6__: string;
 declare var __SRC_STYLESHEETS_MD5_HASH__: string;
 
 declare var __LOGGING__: boolean;
-
-type RecursivePartial<T> = {
-  [P in keyof T]?: RecursivePartial<T[P]>;
-};

--- a/typings/globals/missing.d.ts
+++ b/typings/globals/missing.d.ts
@@ -97,3 +97,7 @@ declare var __IS_ES6__: string;
 declare var __SRC_STYLESHEETS_MD5_HASH__: string;
 
 declare var __LOGGING__: boolean;
+
+type RecursivePartial<T> = {
+  [P in keyof T]?: RecursivePartial<T[P]>;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2442,6 +2442,11 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 default-require-extensions@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"


### PR DESCRIPTION
* Don't install ServiceWorker on host page IF subdomain is set.
* This was only happening in a case where the os.tc service worker was out of date and the SDK
    would attempt to install a ServiceWorker to os.tc AND the host page due to this missing check.
* Added test to confirm this new logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/571)
<!-- Reviewable:end -->
