### PR TITLE
Updated SDK readme to match the main web site

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,13 @@
 <p align="center">
   <img src="https://media.onesignal.com/cms/Website%20Layout/logo-red.svg"/>
   <br/>
-    <br/>
-  <img src="https://www.filepicker.io/api/file/FKy7xatlQeGqUuE9C3p8"/>
+  <br/>
   <span style="color: grey !important">Showing web push notifications from Chrome, Safari, and Firefox</span>
 </p>
 
 # OneSignal Web Push SDK
 
-[OneSignal](https://onesignal.com) is a free push notification service for web and mobile apps.
+[OneSignal](https://onesignal.com) is the market leader in customer engagement, powering mobile push, web push, email, and in-app messages.
 
 This SDK allows your site's visitors to receive push notifications from you. Send visitors custom notification content, target specific users, and send automatically based on triggers.
 


### PR DESCRIPTION
- Deleted image was not rendered.
- Updated OneSignal description to match the main web site

Before:
<img width="791" alt="Screen Shot 2019-11-13 at 2 49 57 PM" src="https://user-images.githubusercontent.com/39500603/68811186-e5126a00-0624-11ea-8d53-518acb332122.png">

After:
https://github.com/OneSignal/OneSignal-Website-SDK/blob/0ae3d2fde387201c316d9b7ef6374a050e8f69e7/README.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/572)
<!-- Reviewable:end -->
