### PR TITLE
Fixes Require Interaction Bug

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -305,21 +305,6 @@ export default class OneSignal {
   }
 
   /**
-   * Saves `isPushNotificationsEnabled` and `isOptedOut` to local storage
-   *    - values are used to bypass codepath resulting in errors such as:
-   *        "The Notification permission may only be requested 
-   *         from inside a short running user-generated event handler."
-   *  @private
-   */
-  public static async storeBrowserPushSettings(){
-    const isPushNotificationsEnabled = await OneSignal.privateIsPushNotificationsEnabled();
-    localStorage.setItem('isPushNotificationsEnabled', String(isPushNotificationsEnabled));
-  
-    const isOptedOut = await OneSignal.internalIsOptedOut();
-    localStorage.setItem('isOptedOut', String(isOptedOut));
-  }
-
-  /**
    * Call after use accepts your user consent agreement
    * @PublicApi
    */

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -240,6 +240,9 @@ export default class OneSignal {
     }
 
     await OneSignal.delayedInit();
+
+    // stores `isOptedOut` and `isPushNotificationsEnabled` on init
+    OneSignal.storeBrowserPushSettings();
   }
 
   private static async delayedInit(): Promise<void> {
@@ -302,6 +305,21 @@ export default class OneSignal {
           __init();
       };
     }
+  }
+
+  /**
+   * Saves `isPushNotificationsEnabled` and `isOptedOut` to local storage
+   *    - values are used to bypass codepath resulting in errors such as:
+   *        "The Notification permission may only be requested 
+   *         from inside a short running user-generated event handler."
+   *  @private
+   */
+  private static async storeBrowserPushSettings(){
+    const isPushNotificationsEnabled = await OneSignal.privateIsPushNotificationsEnabled();
+    localStorage.setItem('isPushNotificationsEnabled', String(isPushNotificationsEnabled));
+  
+    const isOptedOut = await OneSignal.internalIsOptedOut();
+    localStorage.setItem('isOptedOut', String(isOptedOut));
   }
 
   /**

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -311,7 +311,7 @@ export default class OneSignal {
    *         from inside a short running user-generated event handler."
    *  @private
    */
-  private static async storeBrowserPushSettings(){
+  public static async storeBrowserPushSettings(){
     const isPushNotificationsEnabled = await OneSignal.privateIsPushNotificationsEnabled();
     localStorage.setItem('isPushNotificationsEnabled', String(isPushNotificationsEnabled));
   

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -240,9 +240,6 @@ export default class OneSignal {
     }
 
     await OneSignal.delayedInit();
-
-    // stores `isOptedOut` and `isPushNotificationsEnabled` on init
-    OneSignal.storeBrowserPushSettings();
   }
 
   private static async delayedInit(): Promise<void> {

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -28,7 +28,7 @@ import { ServiceWorkerManager } from "../managers/ServiceWorkerManager";
 import SubscriptionPopupHost from "../modules/frames/SubscriptionPopupHost";
 import { OneSignalUtils } from "../utils/OneSignalUtils";
 import { DeprecatedApiError, DeprecatedApiReason } from "../errors/DeprecatedApiError";
-import LocalStorage from 'src/utils/LocalStorage';
+import LocalStorage from '../utils/LocalStorage';
 
 declare var OneSignal: any;
 

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -100,7 +100,7 @@ export default class InitHelper {
       await InitHelper.handleAutoResubscribe(isOptedOut);
     }
 
-    const isSubscribed = LocalStorage.getIsPushNotificationsEnabled();
+    const isSubscribed = LocalStorage.getIsPushNotificationsEnabled() === "true";
     if (OneSignal.config.userConfig.promptOptions.autoPrompt && !isOptedOut && !isSubscribed) {
       /*
       * Chrome 63 on Android permission prompts are permanent without a dismiss option. To avoid

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -150,21 +150,11 @@ export default class InitHelper {
       return;
     }
 
-    /**
-     * Safari 12.1+ is very sensitive about indexeddb queries. any queries performed before prompting for
-     * notifications are considered as violation of "Prompting requires a user gesture rule".
-     * TODO: May want to store isOptedOut flag somewhere during initialization. For now hardcoding it to false.
-     */
-    if (bowser.safari && Number(bowser.version) >= 12.1) {
-      await SubscriptionHelper.internalRegisterForPush(false);
-      return;
-    }
-
     /*
      * We don't want to resubscribe if the user is opted out, and we can't check on HTTP, because the promise will
      * prevent the popup from opening.
      */
-    const isOptedOut = await OneSignal.internalIsOptedOut();
+    const isOptedOut = localStorage.getItem('isOptedOut') === "true";
     if (!isOptedOut) {
       await SubscriptionHelper.registerForPush();
     }

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -84,13 +84,13 @@ export default class InitHelper {
       throw err;
     }
 
-    await OneSignal.storeBrowserPushSettings();
-
     /**
      * We don't want to resubscribe if the user is opted out, and we can't check on HTTP, because the promise will
      * prevent the popup from opening.
      */
-    const isOptedOut = LocalStorage.getIsOptedOut() === "true";
+    const isOptedOut = await OneSignal.internalIsOptedOut();
+    // saves isOptedOut to localStorage. used for require user interaction functionality
+    LocalStorage.setIsOptedOut(!!isOptedOut);
 
     /**
      * Auto-resubscribe is working only on HTTPS (and in safari)
@@ -100,7 +100,10 @@ export default class InitHelper {
       await InitHelper.handleAutoResubscribe(isOptedOut);
     }
 
-    const isSubscribed = LocalStorage.getIsPushNotificationsEnabled() === "true";
+    const isSubscribed = await OneSignal.privateIsPushNotificationsEnabled();
+    // saves isSubscribed to localStorage. used for require user interaction functionality
+    LocalStorage.setIsPushNotificationsEnabled(!!isSubscribed);
+
     if (OneSignal.config.userConfig.promptOptions.autoPrompt && !isOptedOut && !isSubscribed) {
       /*
       * Chrome 63 on Android permission prompts are permanent without a dismiss option. To avoid
@@ -158,7 +161,7 @@ export default class InitHelper {
      * We don't want to resubscribe if the user is opted out, and we can't check on HTTP, because the promise will
      * prevent the popup from opening.
      */
-    const isOptedOut = LocalStorage.getIsOptedOut() === "true";
+    const isOptedOut = LocalStorage.getIsOptedOut();
     if (!isOptedOut) {
       await SubscriptionHelper.registerForPush();
     }

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -154,7 +154,7 @@ export default class InitHelper {
      * We don't want to resubscribe if the user is opted out, and we can't check on HTTP, because the promise will
      * prevent the popup from opening.
      */
-    const isOptedOut = localStorage.getItem('isOptedOut') === "true";
+    const isOptedOut = SubscriptionHelper.getBrowserPushSetting('isOptedOut') === "true";
     if (!isOptedOut) {
       await SubscriptionHelper.registerForPush();
     }

--- a/src/helpers/SubscriptionHelper.ts
+++ b/src/helpers/SubscriptionHelper.ts
@@ -14,8 +14,12 @@ import { PermissionUtils } from "../utils/PermissionUtils";
 
 export default class SubscriptionHelper {
   public static async registerForPush(): Promise<Subscription | null> {
-    const isPushEnabled = localStorage.getItem('isPushNotificationsEnabled') === "true";
+    const isPushEnabled = SubscriptionHelper.getBrowserPushSetting('isPushNotificationsEnabled') === "true";
     return await SubscriptionHelper.internalRegisterForPush(isPushEnabled);
+  }
+
+  public static getBrowserPushSetting(key: string) {
+    return localStorage.getItem(key);
   }
 
   public static async internalRegisterForPush(isPushEnabled: boolean): Promise<Subscription | null> {

--- a/src/helpers/SubscriptionHelper.ts
+++ b/src/helpers/SubscriptionHelper.ts
@@ -11,15 +11,12 @@ import Log from '../libraries/Log';
 import { ContextSWInterface } from '../models/ContextSW';
 import SdkEnvironment from '../managers/SdkEnvironment';
 import { PermissionUtils } from "../utils/PermissionUtils";
+import LocalStorage from 'src/utils/LocalStorage';
 
 export default class SubscriptionHelper {
   public static async registerForPush(): Promise<Subscription | null> {
-    const isPushEnabled = SubscriptionHelper.getBrowserPushSetting('isPushNotificationsEnabled') === "true";
+    const isPushEnabled = LocalStorage.getIsPushNotificationsEnabled() === "true";
     return await SubscriptionHelper.internalRegisterForPush(isPushEnabled);
-  }
-
-  public static getBrowserPushSetting(key: string) {
-    return localStorage.getItem(key);
   }
 
   public static async internalRegisterForPush(isPushEnabled: boolean): Promise<Subscription | null> {

--- a/src/helpers/SubscriptionHelper.ts
+++ b/src/helpers/SubscriptionHelper.ts
@@ -14,7 +14,7 @@ import { PermissionUtils } from "../utils/PermissionUtils";
 
 export default class SubscriptionHelper {
   public static async registerForPush(): Promise<Subscription | null> {
-    const isPushEnabled = await OneSignal.privateIsPushNotificationsEnabled();
+    const isPushEnabled = localStorage.getItem('isPushNotificationsEnabled') === "true";
     return await SubscriptionHelper.internalRegisterForPush(isPushEnabled);
   }
 

--- a/src/helpers/SubscriptionHelper.ts
+++ b/src/helpers/SubscriptionHelper.ts
@@ -15,7 +15,7 @@ import LocalStorage from '../utils/LocalStorage';
 
 export default class SubscriptionHelper {
   public static async registerForPush(): Promise<Subscription | null> {
-    const isPushEnabled = LocalStorage.getIsPushNotificationsEnabled() === "true";
+    const isPushEnabled = LocalStorage.getIsPushNotificationsEnabled();
     return await SubscriptionHelper.internalRegisterForPush(isPushEnabled);
   }
 

--- a/src/helpers/SubscriptionHelper.ts
+++ b/src/helpers/SubscriptionHelper.ts
@@ -11,7 +11,7 @@ import Log from '../libraries/Log';
 import { ContextSWInterface } from '../models/ContextSW';
 import SdkEnvironment from '../managers/SdkEnvironment';
 import { PermissionUtils } from "../utils/PermissionUtils";
-import LocalStorage from 'src/utils/LocalStorage';
+import LocalStorage from '../utils/LocalStorage';
 
 export default class SubscriptionHelper {
   public static async registerForPush(): Promise<Subscription | null> {

--- a/src/utils/LocalStorage.ts
+++ b/src/utils/LocalStorage.ts
@@ -2,19 +2,19 @@ const IS_OPTED_OUT = "isOptedOut";
 const IS_PUSH_NOTIFICATIONS_ENABLED = "isPushNotificationsEnabled";
 
 export default class LocalStorage {
-    public static getIsOptedOut() : boolean {
+    public static getIsOptedOut(): boolean {
         return localStorage.getItem(IS_OPTED_OUT) === "true";
     }
 
-    public static getIsPushNotificationsEnabled() : boolean {
+    public static getIsPushNotificationsEnabled(): boolean {
         return localStorage.getItem(IS_PUSH_NOTIFICATIONS_ENABLED) === "true";
     }
 
-    public static setIsOptedOut(value: boolean) :void {
+    public static setIsOptedOut(value: boolean): void {
         localStorage.setItem(IS_OPTED_OUT, value.toString());
     }
 
-    public static setIsPushNotificationsEnabled(value: boolean) :void {
+    public static setIsPushNotificationsEnabled(value: boolean): void {
         localStorage.setItem(IS_PUSH_NOTIFICATIONS_ENABLED, value.toString());
     }
 }

--- a/src/utils/LocalStorage.ts
+++ b/src/utils/LocalStorage.ts
@@ -1,0 +1,9 @@
+export default class LocalStorage {
+    public static getIsOptedOut() {
+        return localStorage.getItem('isOptedOut');
+    }
+
+    public static getIsPushNotificationsEnabled() {
+        return localStorage.getItem('isPushNotificationsEnabled');
+    }
+}

--- a/src/utils/LocalStorage.ts
+++ b/src/utils/LocalStorage.ts
@@ -1,9 +1,20 @@
+const IS_OPTED_OUT = "isOptedOut";
+const IS_PUSH_NOTIFICATIONS_ENABLED = "isPushNotificationsEnabled";
+
 export default class LocalStorage {
-    public static getIsOptedOut() {
-        return localStorage.getItem('isOptedOut');
+    public static getIsOptedOut() : boolean {
+        return localStorage.getItem(IS_OPTED_OUT) === "true";
     }
 
-    public static getIsPushNotificationsEnabled() {
-        return localStorage.getItem('isPushNotificationsEnabled');
+    public static getIsPushNotificationsEnabled() : boolean {
+        return localStorage.getItem(IS_PUSH_NOTIFICATIONS_ENABLED) === "true";
+    }
+
+    public static setIsOptedOut(value: boolean) :void {
+        localStorage.setItem(IS_OPTED_OUT, value.toString());
+    }
+
+    public static setIsPushNotificationsEnabled(value: boolean) :void {
+        localStorage.setItem(IS_PUSH_NOTIFICATIONS_ENABLED, value.toString());
     }
 }

--- a/test/unit/helpers1/InitHelper.ts
+++ b/test/unit/helpers1/InitHelper.ts
@@ -38,38 +38,6 @@ test('registerForPushNotifications: load fullscreen popup when using subscriptio
   t.is(loadStub.calledOnce, true);
 });
 
-test('registerForPushNotifications: not using subscription workaround and safari < 12.1 and never subscribed',
-  async (t) => {
-    setBrowser(BrowserUserAgent.ChromeMacSupported);
-
-    sandbox.stub(OneSignal, 'internalIsOptedOut').resolves(false);
-    const registerSpy = sandbox.stub(SubscriptionHelper, 'registerForPush').resolves();
-    await InitHelper.registerForPushNotifications();
-    t.is(registerSpy.calledOnce, true);
-});
-
-test('registerForPushNotifications: not using subscription workaround and safari < 12.1 and opted out',
-  async (t) => {
-    setBrowser(BrowserUserAgent.ChromeMacSupported);
-
-    sandbox.stub(OneSignal, 'internalIsOptedOut').resolves(true);
-    const registerSpy = sandbox.stub(SubscriptionHelper, 'registerForPush').resolves();
-    await InitHelper.registerForPushNotifications();
-    t.is(registerSpy.notCalled, true);
-});
-
-test('registerForPushNotifications: after OneSignal.initialized and not using subscription workaround and safari 12.1',
-  async (t) => {
-    setBrowser(BrowserUserAgent.SafariSupportedMac121);
-
-    const registerStub = sandbox.stub(SubscriptionHelper, 'internalRegisterForPush').resolves();
-    await InitHelper.registerForPushNotifications();
-    t.is(registerStub.calledOnce, true);
-});
-
-/** sessionInit */
-
-
 /** onSdkInitialized */
 test("onSdkInitialized: ensure public sdk initialized triggered", async (t) => {
   OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => { t.pass(); });

--- a/test/unit/modules/subscriptionHelper.ts
+++ b/test/unit/modules/subscriptionHelper.ts
@@ -21,7 +21,7 @@ test.afterEach(() => {
 })
 
 test('should not resubscribe user on subsequent page views if the user is already subscribed', async t => {
-  sinonSandbox.stub(OneSignal, 'privateIsPushNotificationsEnabled').resolves(true);
+  sinonSandbox.stub(SubscriptionHelper, 'getBrowserPushSetting').returns("true");
   sinonSandbox.stub(SessionManager.prototype, 'getPageViewCount').returns(2);
   const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, 'subscribe');
 

--- a/test/unit/modules/subscriptionHelper.ts
+++ b/test/unit/modules/subscriptionHelper.ts
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import SubscriptionHelper from '../../../src/helpers/SubscriptionHelper';
 import { SubscriptionManager } from '../../../src/managers/SubscriptionManager';
 import { SessionManager } from '../../../src/managers/SessionManager';
-import LocalStorage from 'src/utils/LocalStorage';
+import LocalStorage from '../../../src/utils/LocalStorage';
 
 const sinonSandbox = sinon.sandbox.create();
 

--- a/test/unit/modules/subscriptionHelper.ts
+++ b/test/unit/modules/subscriptionHelper.ts
@@ -6,6 +6,7 @@ import sinon from 'sinon';
 import SubscriptionHelper from '../../../src/helpers/SubscriptionHelper';
 import { SubscriptionManager } from '../../../src/managers/SubscriptionManager';
 import { SessionManager } from '../../../src/managers/SessionManager';
+import LocalStorage from 'src/utils/LocalStorage';
 
 const sinonSandbox = sinon.sandbox.create();
 
@@ -21,7 +22,7 @@ test.afterEach(() => {
 })
 
 test('should not resubscribe user on subsequent page views if the user is already subscribed', async t => {
-  sinonSandbox.stub(SubscriptionHelper, 'getBrowserPushSetting').returns("true");
+  sinonSandbox.stub(LocalStorage, 'getIsPushNotificationsEnabled').returns("true");
   sinonSandbox.stub(SessionManager.prototype, 'getPageViewCount').returns(2);
   const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, 'subscribe');
 


### PR DESCRIPTION
### Context
- Firefox 72 requires user interaction to prompt for notification permissions. However even after clicking on our slide down prompt Firefox still thinks our native prompting did not come from a user interaction. 
- A similar requirement was implemented in Safari 12.1 which was resolved by [this workaround](https://github.com/OneSignal/OneSignal-Website-SDK/pull/418) which is no longer needed with the following PR.
- The reason this happens is due to the fact that IndexDB reads are asynchronous and are handled by the Message Queue. Thus, the browser doesn’t think this is part of the same click handler since it executes anything waiting on the [Message Queue](https://flaviocopes.com/javascript-event-loop/#the-message-queue) after the current call stack completes.
- Example error message: `The Notification permission may only be requested from inside a short running user-generated event handler.`

## Fix
Upon SDK initialization (after page load), save the necessary values to `localStorage` (synchronous unlike `IndexDB` which is asynchronous) and then use the values by reading them out of `localStorage` when the subscription is attempted.

### OneSignal.storeBrowserPushSettings
Saves `isPushNotificationsEnabled` and `isOptedOut` to local storage. Called after OneSignal initialization.

### SubscriptionHelper. getBrowserPushSetting
Getter for previously-stored local storage values. Takes the key to the value.

### InitHelper.ts  ,  test/unit/helpers1/InitHelper.ts
We no longer need the workaround that checks for the browser being Safari v 12.1+

Closes #540

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/577)
<!-- Reviewable:end -->
