### PR TITLE
WebSDK Sandbox HTTP Support

### DIFF
--- a/build/config/page-sdk-es6.config.js
+++ b/build/config/page-sdk-es6.config.js
@@ -22,7 +22,7 @@ async function getWebpackPlugins() {
         __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
         __API_TYPE__: JSON.stringify(apiEnv),
         __API_ORIGIN__: JSON.stringify(apiOrigin),
-        __IS_HTTPS__: process.env.HTTPS == 1,
+        __IS_HTTPS__: process.env.HTTPS == true,
         __TEST__: !!process.env.TESTS,
         __VERSION__: process.env.npm_package_config_sdkVersion,
         __LOGGING__: env === "development",

--- a/build/config/page-sdk-es6.config.js
+++ b/build/config/page-sdk-es6.config.js
@@ -11,6 +11,7 @@ const apiEnv = process.env.API || "production";
 const apiOrigin = process.env.API_ORIGIN || "onesignal.com"
 const isProdBuild = process.env.ENV === "production";
 const nodeEnv = isProdBuild ? "production" : "development";
+const isHttps = !!process.env.HTTPS || true;
 
 async function getWebpackPlugins() {
   const plugins = [
@@ -22,6 +23,7 @@ async function getWebpackPlugins() {
         __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
         __API_TYPE__: JSON.stringify(apiEnv),
         __API_ORIGIN__: JSON.stringify(apiOrigin),
+        __IS_HTTPS__: JSON.stringify(isHttps),
         __TEST__: !!process.env.TESTS,
         __VERSION__: process.env.npm_package_config_sdkVersion,
         __LOGGING__: env === "development",

--- a/build/config/page-sdk-es6.config.js
+++ b/build/config/page-sdk-es6.config.js
@@ -11,6 +11,9 @@ const apiEnv = process.env.API || "production";
 const apiOrigin = process.env.API_ORIGIN || "onesignal.com"
 const isProdBuild = process.env.ENV === "production";
 const nodeEnv = isProdBuild ? "production" : "development";
+const isHttps = process.env.HTTPS;
+const tests = process.env.TESTS;
+const sdkVersion = process.env.npm_package_config_sdkVersion;
 
 async function getWebpackPlugins() {
   const plugins = [
@@ -22,9 +25,9 @@ async function getWebpackPlugins() {
         __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
         __API_TYPE__: JSON.stringify(apiEnv),
         __API_ORIGIN__: JSON.stringify(apiOrigin),
-        __IS_HTTPS__: process.env.HTTPS == true,
-        __TEST__: !!process.env.TESTS,
-        __VERSION__: process.env.npm_package_config_sdkVersion,
+        __IS_HTTPS__: isHttps == true,
+        __TEST__: !!tests,
+        __VERSION__: sdkVersion,
         __LOGGING__: env === "development",
         "process.env.NODE_ENV": JSON.stringify(nodeEnv),
       })

--- a/build/config/page-sdk-es6.config.js
+++ b/build/config/page-sdk-es6.config.js
@@ -11,7 +11,6 @@ const apiEnv = process.env.API || "production";
 const apiOrigin = process.env.API_ORIGIN || "onesignal.com"
 const isProdBuild = process.env.ENV === "production";
 const nodeEnv = isProdBuild ? "production" : "development";
-const isHttps = !!process.env.HTTPS || true;
 
 async function getWebpackPlugins() {
   const plugins = [
@@ -23,7 +22,7 @@ async function getWebpackPlugins() {
         __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
         __API_TYPE__: JSON.stringify(apiEnv),
         __API_ORIGIN__: JSON.stringify(apiOrigin),
-        __IS_HTTPS__: JSON.stringify(isHttps),
+        __IS_HTTPS__: process.env.HTTPS == 1,
         __TEST__: !!process.env.TESTS,
         __VERSION__: process.env.npm_package_config_sdkVersion,
         __LOGGING__: env === "development",

--- a/build/config/sdk.config.js
+++ b/build/config/sdk.config.js
@@ -14,6 +14,9 @@ const apiEnv = process.env.API;
 const apiOrigin = process.env.API_ORIGIN || "localhost";
 const isProdBuild = process.env.ENV === "production";
 const nodeEnv = isProdBuild ? "production" : "development";
+const isHttps = process.env.HTTPS;
+const tests = process.env.TESTS;
+const sdkVersion = process.env.npm_package_config_sdkVersion;
 
 async function getStylesheetsHash() {
   const styleSheetsPath = "src/stylesheets";
@@ -59,9 +62,9 @@ async function getWebpackPlugins() {
         __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
         __API_TYPE__: JSON.stringify(apiEnv),
         __API_ORIGIN__: JSON.stringify(apiOrigin),
-        __IS_HTTPS__: process.env.HTTPS == true,
-        __TEST__: !!process.env.TESTS,
-        __VERSION__: process.env.npm_package_config_sdkVersion,
+        __IS_HTTPS__: isHttps == true,
+        __TEST__: !!tests,
+        __VERSION__: sdkVersion,
         __LOGGING__: env === "development",
         __SRC_STYLESHEETS_MD5_HASH__: JSON.stringify(await getStylesheetsHash()),
         "process.env.NODE_ENV": JSON.stringify(nodeEnv),

--- a/build/config/sdk.config.js
+++ b/build/config/sdk.config.js
@@ -14,6 +14,7 @@ const apiEnv = process.env.API;
 const apiOrigin = process.env.API_ORIGIN || "localhost";
 const isProdBuild = process.env.ENV === "production";
 const nodeEnv = isProdBuild ? "production" : "development";
+const isHttps = !!process.env.HTTPS || true;
 
 async function getStylesheetsHash() {
   const styleSheetsPath = "src/stylesheets";
@@ -59,6 +60,7 @@ async function getWebpackPlugins() {
         __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
         __API_TYPE__: JSON.stringify(apiEnv),
         __API_ORIGIN__: JSON.stringify(apiOrigin),
+        __IS_HTTPS__: JSON.stringify(isHttps),
         __TEST__: !!process.env.TESTS,
         __VERSION__: process.env.npm_package_config_sdkVersion,
         __LOGGING__: env === "development",

--- a/build/config/sdk.config.js
+++ b/build/config/sdk.config.js
@@ -59,7 +59,7 @@ async function getWebpackPlugins() {
         __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
         __API_TYPE__: JSON.stringify(apiEnv),
         __API_ORIGIN__: JSON.stringify(apiOrigin),
-        __IS_HTTPS__: process.env.HTTPS == 1,
+        __IS_HTTPS__: process.env.HTTPS == true,
         __TEST__: !!process.env.TESTS,
         __VERSION__: process.env.npm_package_config_sdkVersion,
         __LOGGING__: env === "development",

--- a/build/config/sdk.config.js
+++ b/build/config/sdk.config.js
@@ -14,7 +14,6 @@ const apiEnv = process.env.API;
 const apiOrigin = process.env.API_ORIGIN || "localhost";
 const isProdBuild = process.env.ENV === "production";
 const nodeEnv = isProdBuild ? "production" : "development";
-const isHttps = !!process.env.HTTPS || true;
 
 async function getStylesheetsHash() {
   const styleSheetsPath = "src/stylesheets";
@@ -60,7 +59,7 @@ async function getWebpackPlugins() {
         __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
         __API_TYPE__: JSON.stringify(apiEnv),
         __API_ORIGIN__: JSON.stringify(apiOrigin),
-        __IS_HTTPS__: JSON.stringify(isHttps),
+        __IS_HTTPS__: process.env.HTTPS == 1,
         __TEST__: !!process.env.TESTS,
         __VERSION__: process.env.npm_package_config_sdkVersion,
         __LOGGING__: env === "development",

--- a/build/config/serviceworker.config.js
+++ b/build/config/serviceworker.config.js
@@ -20,7 +20,7 @@ async function getWebpackPlugins() {
       __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
       __API_TYPE__: JSON.stringify(apiEnv),
       __API_ORIGIN__: JSON.stringify(apiOrigin),
-      __IS_HTTPS__: process.env.HTTPS == 1,
+      __IS_HTTPS__: process.env.HTTPS == true,
       __TEST__: !!process.env.TESTS,
       __VERSION__: process.env.npm_package_config_sdkVersion,
       __LOGGING__: env === "development",

--- a/build/config/serviceworker.config.js
+++ b/build/config/serviceworker.config.js
@@ -10,6 +10,7 @@ const apiEnv = process.env.API;
 const apiOrigin = process.env.API_ORIGIN || "localhost";
 const isProdBuild = process.env.ENV === "production";
 const nodeEnv = isProdBuild ? "production" : "development";
+const isHttps = !!process.env.HTTPS || true;
 
 async function getWebpackPlugins() {
   const plugins = [
@@ -20,6 +21,7 @@ async function getWebpackPlugins() {
       __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
       __API_TYPE__: JSON.stringify(apiEnv),
       __API_ORIGIN__: JSON.stringify(apiOrigin),
+      __IS_HTTPS__: JSON.stringify(isHttps),
       __TEST__: !!process.env.TESTS,
       __VERSION__: process.env.npm_package_config_sdkVersion,
       __LOGGING__: env === "development",

--- a/build/config/serviceworker.config.js
+++ b/build/config/serviceworker.config.js
@@ -10,7 +10,6 @@ const apiEnv = process.env.API;
 const apiOrigin = process.env.API_ORIGIN || "localhost";
 const isProdBuild = process.env.ENV === "production";
 const nodeEnv = isProdBuild ? "production" : "development";
-const isHttps = !!process.env.HTTPS || true;
 
 async function getWebpackPlugins() {
   const plugins = [
@@ -21,7 +20,7 @@ async function getWebpackPlugins() {
       __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
       __API_TYPE__: JSON.stringify(apiEnv),
       __API_ORIGIN__: JSON.stringify(apiOrigin),
-      __IS_HTTPS__: JSON.stringify(isHttps),
+      __IS_HTTPS__: process.env.HTTPS == 1,
       __TEST__: !!process.env.TESTS,
       __VERSION__: process.env.npm_package_config_sdkVersion,
       __LOGGING__: env === "development",

--- a/build/config/serviceworker.config.js
+++ b/build/config/serviceworker.config.js
@@ -10,6 +10,9 @@ const apiEnv = process.env.API;
 const apiOrigin = process.env.API_ORIGIN || "localhost";
 const isProdBuild = process.env.ENV === "production";
 const nodeEnv = isProdBuild ? "production" : "development";
+const isHttps = process.env.HTTPS;
+const tests = process.env.TESTS;
+const sdkVersion = process.env.npm_package_config_sdkVersion;
 
 async function getWebpackPlugins() {
   const plugins = [
@@ -20,9 +23,9 @@ async function getWebpackPlugins() {
       __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
       __API_TYPE__: JSON.stringify(apiEnv),
       __API_ORIGIN__: JSON.stringify(apiOrigin),
-      __IS_HTTPS__: process.env.HTTPS == true,
-      __TEST__: !!process.env.TESTS,
-      __VERSION__: process.env.npm_package_config_sdkVersion,
+      __IS_HTTPS__: isHttps == true,
+      __TEST__: !!tests,
+      __VERSION__: sdkVersion,
       __LOGGING__: env === "development",
       "process.env.NODE_ENV": JSON.stringify(nodeEnv),
     })

--- a/build/config/webpack.config.js
+++ b/build/config/webpack.config.js
@@ -193,7 +193,7 @@ async function getStylesheetsHash() {
       resolve(combinedHash);
     });
   });
-} 
+}
 
 async function getBuildDefines() {
   var buildDefines = {

--- a/build/config/webpack.config.js
+++ b/build/config/webpack.config.js
@@ -193,15 +193,15 @@ async function getStylesheetsHash() {
       resolve(combinedHash);
     });
   });
-}
+} 
 
 async function getBuildDefines() {
   var buildDefines = {
-    __BUILD_TYPE__: env,
-    __BUILD_ORIGIN__: buildOrigin,
-    __API_TYPE__: apiEnv,
-    __API_ORIGIN__: apiOrigin,
-    __IS_HTTPS__: isHttps,
+    __BUILD_TYPE__: process.env.ENV,
+    __BUILD_ORIGIN__: process.env.BUILD_ORIGIN,
+    __API_TYPE__: process.env.API,
+    __API_ORIGIN__: process.env.API_ORIGIN,
+    __IS_HTTPS__: process.env.HTTPS,
     __TEST__: !!process.env.TESTS,
     __VERSION__: process.env.npm_package_config_sdkVersion,
     __LOGGING__: process.env.ENV === "development",

--- a/build/config/webpack.config.js
+++ b/build/config/webpack.config.js
@@ -201,6 +201,7 @@ async function getBuildDefines() {
     __BUILD_ORIGIN__: buildOrigin,
     __API_TYPE__: apiEnv,
     __API_ORIGIN__: apiOrigin,
+    __IS_HTTPS__: isHttps,
     __TEST__: !!process.env.TESTS,
     __VERSION__: process.env.npm_package_config_sdkVersion,
     __LOGGING__: process.env.ENV === "development",

--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -2,14 +2,15 @@
 # codepath for all commands of the form `yarn build:<env>-<env>`
 ENV=$1
 API=$2
-HTTPS=1
+HTTPS=true
 
 if [ -z "$3" ]; then
-  # no origin provided
-  echo "No build origin provided";
+  BUILD_ORIGIN_PROVIDED=false
 else
+  BUILD_ORIGIN_PROVIDED=true
   if [ $3 == "--http" ]; then
-    HTTPS=0
+    HTTPS=false
+    BUILD_ORIGIN_PROVIDED=false
   # custom origin provided. api env must be dev
   elif [ $ENV == "development" ]; then
     BUILD_ORIGIN=$3
@@ -20,11 +21,12 @@ else
 fi
 
 if [ -z "$4" ]; then
-  # no origin provided
-  echo "No API origin provided";
+  API_ORIGIN_PROVIDED=false
 else
+  API_ORIGIN_PROVIDED=true
   if [ $4 == "--http" ]; then
-    HTTPS=0
+    HTTPS=false
+    API_ORIGIN_PROVIDED=false
   # custom origin provided. api env must be dev
   elif [ $API == "development" ]; then
     API_ORIGIN=$4
@@ -34,8 +36,28 @@ else
   fi
 fi
 
+# both origins provided + http flag
 if [[ $5 == "--http" ]]; then 
-  HTTPS=0
+  HTTPS=false
+fi
+
+# verbose
+if [ $BUILD_ORIGIN_PROVIDED = true ]; then
+  echo "BUILD_ORIGIN: ${BUILD_ORIGIN}"
+else
+  echo "BUILD_ORIGIN: not provided"
+fi
+
+if [ $API_ORIGIN_PROVIDED = true ]; then
+  echo "API_ORIGIN: ${API_ORIGIN}"
+else
+  echo "API_ORIGIN: not provided"
+fi
+
+if [ $HTTPS = true ]; then
+  echo "PROTOCOL: https"
+else
+  echo "PROTOCOL: http"
 fi
 
 ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN HTTPS=$HTTPS yarn transpile:sources 

--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -2,13 +2,16 @@
 # codepath for all commands of the form `yarn build:<env>-<env>`
 ENV=$1
 API=$2
+HTTPS=1
 
 if [ -z "$3" ]; then
   # no origin provided
   echo "No build origin provided";
 else
+  if [ $3 == "--http" ]; then
+    HTTPS=0
   # custom origin provided. api env must be dev
-  if [ $ENV == "development" ]; then
+  elif [ $ENV == "development" ]; then
     BUILD_ORIGIN=$3
   else
     # empty, default to production
@@ -20,8 +23,10 @@ if [ -z "$4" ]; then
   # no origin provided
   echo "No API origin provided";
 else
+  if [ $4 == "--http" ]; then
+    HTTPS=0
   # custom origin provided. api env must be dev
-  if [ $API == "development" ]; then
+  elif [ $API == "development" ]; then
     API_ORIGIN=$4
   else
     # empty, default to production
@@ -29,8 +34,12 @@ else
   fi
 fi
 
-ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN yarn transpile:sources 
-ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN yarn bundle-sw 
-ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN yarn bundle-sdk 
-ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN yarn bundle-page-sdk-es6
-ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN ./build/scripts/publish.sh
+if [[ $5 == "--http" ]]; then 
+  HTTPS=0
+fi
+
+ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN HTTPS=$HTTPS yarn transpile:sources 
+ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN HTTPS=$HTTPS yarn bundle-sw 
+ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN HTTPS=$HTTPS yarn bundle-sdk 
+ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN HTTPS=$HTTPS yarn bundle-page-sdk-es6
+ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN HTTPS=$HTTPS ./build/scripts/publish.sh

--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -1,64 +1,57 @@
 #!/bin/bash
 # codepath for all commands of the form `yarn build:<env>-<env>`
-ENV=$1
-API=$2
-HTTPS=true
+# defaults
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+key="$1"
 
-if [ -z "$3" ]; then
-  BUILD_ORIGIN_PROVIDED=false
-else
-  BUILD_ORIGIN_PROVIDED=true
-  if [ $3 == "--http" ]; then
+case $key in
+    -b|--build)
+    BUILD_ORIGIN="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -a|--api)
+    API_ORIGIN="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -f|--from)
+    ENV="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    -t|--target)
+    API="$2"
+    shift # past argument
+    shift # past value
+    ;;
+    --http)
     HTTPS=false
-    BUILD_ORIGIN_PROVIDED=false
-  # custom origin provided. api env must be dev
-  elif [ $ENV == "development" ]; then
-    BUILD_ORIGIN=$3
-  else
-    # empty, default to production
-    BUILD_ORIGIN=""
-  fi
-fi
+    shift # past argument
+    ;;
+    *)    # unknown option
+    POSITIONAL+=("$1") # save it in an array for later
+    shift # past argument
+    ;;
+esac
+done
 
-if [ -z "$4" ]; then
-  API_ORIGIN_PROVIDED=false
-else
-  API_ORIGIN_PROVIDED=true
-  if [ $4 == "--http" ]; then
-    HTTPS=false
-    API_ORIGIN_PROVIDED=false
-  # custom origin provided. api env must be dev
-  elif [ $API == "development" ]; then
-    API_ORIGIN=$4
-  else
-    # empty, default to production
-    API_ORIGIN=""
-  fi
-fi
+BUILD_ORIGIN=${BUILD_ORIGIN:-"localhost"}
+API_ORIGIN=${API_ORIGIN:-"onesignal.com"}
+ENV=${ENV:-"development"}
+API=${API:-"production"}
+HTTPS=${HTTPS:-true}
 
-# both origins provided + http flag
-if [[ $5 == "--http" ]]; then 
-  HTTPS=false
-fi
+echo "BUILD_ORIGIN = ${BUILD_ORIGIN}"
+echo "API_ORIGIN = ${API_ORIGIN}"
+echo "HTTPS = ${HTTPS}"
+echo "ENV = ${ENV}"
+echo "API = ${API}"
+echo "Unknown options -> ${POSITIONAL}"
+set -- "${POSITIONAL[@]}" # restore positional parameters
 
-# verbose
-if [ $BUILD_ORIGIN_PROVIDED = true ]; then
-  echo "BUILD_ORIGIN: ${BUILD_ORIGIN}"
-else
-  echo "BUILD_ORIGIN: not provided"
-fi
-
-if [ $API_ORIGIN_PROVIDED = true ]; then
-  echo "API_ORIGIN: ${API_ORIGIN}"
-else
-  echo "API_ORIGIN: not provided"
-fi
-
-if [ $HTTPS = true ]; then
-  echo "PROTOCOL: https"
-else
-  echo "PROTOCOL: http"
-fi
 
 ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN HTTPS=$HTTPS yarn transpile:sources 
 ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN HTTPS=$HTTPS yarn bundle-sw 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       ports:
           - published: 4001
             target: 4001
+          - published: 4000
+            target: 4000
 
 # Named volumes that are persisted between docker-compose rebuilds.
 # If you need to remove these volumes for some reason, run `docker-compose down -v`

--- a/express_webpack/README.md
+++ b/express_webpack/README.md
@@ -39,6 +39,10 @@ yarn build:<type>-<type>
 ```
 **Example**: `yarn build:dev-prod` builds the SDK with the BUILD environment as "development" and the API environment as "production"
 
+### HTTP
+All builds default to `https` unless `--http` is passed into the build command...
+**Example**: `yarn build:dev-prod --http` or `yarn build:dev-prod localhost --http`
+
 #### CUSTOM ORIGIN PARAMS: 
 You can pass two additional parameters to the above command, the first being the origin of the build environment and the second being that of the api environment. 
 

--- a/express_webpack/README.md
+++ b/express_webpack/README.md
@@ -41,21 +41,33 @@ yarn build:<type>-<type>
 
 ### HTTP
 All builds default to `https` unless `--http` is passed to the end of the build command...
-**Example**: `yarn build:dev-prod --http` or `yarn build:dev-prod localhost --http`
+**Example**: `yarn build:dev-prod --http` or `yarn build:dev-prod -b localhost --http`
 
 #### CUSTOM ORIGIN PARAMS: 
-You can pass two additional parameters to the above command, the first being the origin of the build environment and the second being that of the api environment. 
+You can pass two additional parameters to the above command, the first being the origin of the build environment and the second being that of the api environment. These parameters use option flags. 
 
-If no custom origins are set, defaults will be used: `localhost` for build and `onesignal.com` for api
+   - Option flags are:
+      - `-b` or `--build`
+      - `-a` or `--api`
+
+If no custom origins are set, defaults will be used: `localhost` for build and `onesignal.com` for api. 
+
+**Note:**: make sure custom origins make sense with respect to the build and api environments set (e.g: you cannot use a `prod` api environment and expect a custom api origin to be used).
 
 **Examples**:
 ```
-yarn build:dev-prod texas
+yarn build:dev-prod -b texas
 ```
 This sets the dev environment origin to `texas` which will result in SDK files being fetched from `https://texas:4001/sdks/`
 
 ```
-yarn build:dev-dev texas <ip>
+yarn build:dev-dev -b texas -a <ip>
 ```
 This sets the dev environment origin to `texas` which will result in SDK files being fetched from `https://texas:4001/sdks/` and the API environment origin to `<ip>` which will make all onesignal api calls to that origin such as `https://<ip>:3001/api/v1/apps/<app>`
 
+#### NOTE ON PORTS:
+**SDK**: SDK files will automatically be fetched from the 4000s ports depending on the HTTP/S setting
+   - HTTP: `4000`
+   - HTTPS: `4001`
+
+**API**: dev-environment API calls will be made to the `3001` port (e.g: `<custom-origin>:3001`)

--- a/express_webpack/README.md
+++ b/express_webpack/README.md
@@ -40,7 +40,7 @@ yarn build:<type>-<type>
 **Example**: `yarn build:dev-prod` builds the SDK with the BUILD environment as "development" and the API environment as "production"
 
 ### HTTP
-All builds default to `https` unless `--http` is passed into the build command...
+All builds default to `https` unless `--http` is passed to the end of the build command...
 **Example**: `yarn build:dev-prod --http` or `yarn build:dev-prod localhost --http`
 
 #### CUSTOM ORIGIN PARAMS: 

--- a/express_webpack/server.js
+++ b/express_webpack/server.js
@@ -24,6 +24,7 @@ app.get('/:file', (req, res) => {
     res.sendFile(SDK_FILES+req.params.file);
 });
 
-https.createServer(options, app).listen(4001);
-console.log("express_webpack: listening on port 4001");
+https.createServer(options, app).listen(4001, () => console.log("express_webpack: listening on port 4001 (https)"));
 
+// http
+app.listen(4000, () => console.log('express_webpack: listening on port 4000 (http)'));

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "test": "ENV=development yarn transpile:tests && yarn run ava --verbose --color --watch",
     "test:noWatch": "ENV=development yarn transpile:tests && ava --verbose --color --watch=false",
     "publish": "yarn clean && yarn build:prod && yarn",
-    "build:dev-dev":"./build/scripts/build.sh development development",
-    "build:dev-prod":"./build/scripts/build.sh development production",
-    "build:dev-stag":"./build/scripts/build.sh development staging"
+    "build:dev-dev":"./build/scripts/build.sh -f development -t development",
+    "build:dev-prod":"./build/scripts/build.sh -f development -t production",
+    "build:dev-stag":"./build/scripts/build.sh -f development -t staging"
   },
   "config": {
     "sdkVersion": "150711"

--- a/src/managers/SdkEnvironment.ts
+++ b/src/managers/SdkEnvironment.ts
@@ -273,10 +273,10 @@ export default class SdkEnvironment {
         origin = `${protocol}://${buildOrigin}:${port}`;
         break;
       case EnvironmentKind.Staging:
-        origin = `${protocol}://${window.location.host}`;
+        origin = `https://${window.location.host}`;
         break;
       case EnvironmentKind.Production:
-        origin = `${protocol}://onesignal.com`;
+        origin = `https://onesignal.com`;
         break;
       default:
         throw new InvalidArgumentError('buildEnv', InvalidArgumentReason.EnumOutOfRange);

--- a/src/managers/SdkEnvironment.ts
+++ b/src/managers/SdkEnvironment.ts
@@ -7,6 +7,10 @@ import ServiceWorkerHelper from "../helpers/ServiceWorkerHelper";
 import Environment from "../Environment";
 import OneSignalUtils from "../utils/OneSignalUtils";
 
+const RESOURCE_HTTP_PORT = 4000;
+const RESOURCE_HTTPS_PORT = 4001;
+const API_URL_PORT = 3001;
+
 export default class SdkEnvironment {
   /**
    * Returns development, staging, or production.
@@ -251,7 +255,7 @@ export default class SdkEnvironment {
 
     switch (buildEnv) {
       case EnvironmentKind.Development:
-        return new URL(`https://${apiOrigin}:3001/api/v1`);
+        return new URL(`https://${apiOrigin}:${API_URL_PORT}/api/v1`);
       case EnvironmentKind.Staging:
         return new URL(`https://${window.location.host}/api/v1`);
       case EnvironmentKind.Production:
@@ -266,7 +270,7 @@ export default class SdkEnvironment {
     const isHttps = (typeof __IS_HTTPS__ !== "undefined") ? __IS_HTTPS__ : true;
     let origin: string;
     const protocol = isHttps ? "https" : "http";
-    const port = isHttps ? 4001 : 4000;
+    const port = isHttps ? RESOURCE_HTTPS_PORT : RESOURCE_HTTP_PORT;
 
     switch (buildEnv) {
       case EnvironmentKind.Development:
@@ -276,7 +280,7 @@ export default class SdkEnvironment {
         origin = `https://${window.location.host}`;
         break;
       case EnvironmentKind.Production:
-        origin = `https://onesignal.com`;
+        origin = "https://onesignal.com";
         break;
       default:
         throw new InvalidArgumentError('buildEnv', InvalidArgumentReason.EnumOutOfRange);

--- a/src/managers/SdkEnvironment.ts
+++ b/src/managers/SdkEnvironment.ts
@@ -265,9 +265,11 @@ export default class SdkEnvironment {
     const buildOrigin = (typeof __BUILD_ORIGIN__ !== "undefined") ? __BUILD_ORIGIN__ || "localhost" : "localhost";
     let origin: string;
     const protocol = __IS_HTTPS__ ? "https" : "http";
+    const port = __IS_HTTPS__ ? 4001 : 4000;
+
     switch (buildEnv) {
       case EnvironmentKind.Development:
-        origin = `${protocol}://${buildOrigin}:4001`;
+        origin = `${protocol}://${buildOrigin}:${port}`;
         break;
       case EnvironmentKind.Staging:
         origin = `${protocol}://${window.location.host}`;

--- a/src/managers/SdkEnvironment.ts
+++ b/src/managers/SdkEnvironment.ts
@@ -263,9 +263,10 @@ export default class SdkEnvironment {
 
   public static getOneSignalResourceUrlPath(buildEnv: EnvironmentKind = SdkEnvironment.getBuildEnv()): URL {
     const buildOrigin = (typeof __BUILD_ORIGIN__ !== "undefined") ? __BUILD_ORIGIN__ || "localhost" : "localhost";
+    const isHttps = (typeof __IS_HTTPS__ !== "undefined") ? __IS_HTTPS__ : true;
     let origin: string;
-    const protocol = __IS_HTTPS__ ? "https" : "http";
-    const port = __IS_HTTPS__ ? 4001 : 4000;
+    const protocol = isHttps ? "https" : "http";
+    const port = isHttps ? 4001 : 4000;
 
     switch (buildEnv) {
       case EnvironmentKind.Development:

--- a/src/managers/SdkEnvironment.ts
+++ b/src/managers/SdkEnvironment.ts
@@ -264,16 +264,16 @@ export default class SdkEnvironment {
   public static getOneSignalResourceUrlPath(buildEnv: EnvironmentKind = SdkEnvironment.getBuildEnv()): URL {
     const buildOrigin = (typeof __BUILD_ORIGIN__ !== "undefined") ? __BUILD_ORIGIN__ || "localhost" : "localhost";
     let origin: string;
-
+    const protocol = __IS_HTTPS__ ? "https" : "http";
     switch (buildEnv) {
       case EnvironmentKind.Development:
-        origin = `https://${buildOrigin}:4001`;
+        origin = `${protocol}://${buildOrigin}:4001`;
         break;
       case EnvironmentKind.Staging:
-        origin = `https://${window.location.host}`;
+        origin = `${protocol}://${window.location.host}`;
         break;
       case EnvironmentKind.Production:
-        origin = 'https://onesignal.com';
+        origin = `${protocol}://onesignal.com`;
         break;
       default:
         throw new InvalidArgumentError('buildEnv', InvalidArgumentReason.EnumOutOfRange);

--- a/src/utils/OneSignalShimLoader.ts
+++ b/src/utils/OneSignalShimLoader.ts
@@ -27,14 +27,15 @@ export class OneSignalShimLoader {
       return productionOrigin;
     }
 
-    const protocol = __IS_HTTPS__ ? "https" : "http";
-    const port = __IS_HTTPS__ ? 4001 : 4000;
+    const isHttps = (typeof __IS_HTTPS__ !== "undefined") ? __IS_HTTPS__ : true;
+    const protocol = isHttps ? "https" : "http";
+    const port = isHttps ? 4001 : 4000;
 
     switch(__BUILD_TYPE__){
       case "development":
         return `${protocol}://${buildOrigin}:${port}/sdks/Dev-`;
       case "staging":
-        return `${protocol}://${window.location.host}/sdks/Staging-`;
+        return `https://${window.location.host}/sdks/Staging-`;
       default:
         return productionOrigin;
     }

--- a/src/utils/OneSignalShimLoader.ts
+++ b/src/utils/OneSignalShimLoader.ts
@@ -18,7 +18,7 @@ export class OneSignalShimLoader {
     document.head.appendChild(scriptElement);
   }
 
-  // Some logic from SdkEnvironment
+  // Same logic from SdkEnvironment
   private static getPathAndPrefix(): string {
     const buildOrigin = (typeof __BUILD_ORIGIN__ !== "undefined") ? __BUILD_ORIGIN__ || "localhost" : "localhost";
     const productionOrigin = "https://cdn.onesignal.com/sdks/";
@@ -27,11 +27,14 @@ export class OneSignalShimLoader {
       return productionOrigin;
     }
 
+    const protocol = __IS_HTTPS__ ? "https" : "http";
+    const port = __IS_HTTPS__ ? 4001 : 4000;
+
     switch(__BUILD_TYPE__){
       case "development":
-        return `https://${buildOrigin}:4001/sdks/Dev-`;
+        return `${protocol}://${buildOrigin}:${port}/sdks/Dev-`;
       case "staging":
-        return `https://${window.location.host}/sdks/Staging-`;
+        return `${protocol}://${window.location.host}/sdks/Staging-`;
       default:
         return productionOrigin;
     }

--- a/typings/globals/missing.d.ts
+++ b/typings/globals/missing.d.ts
@@ -90,6 +90,7 @@ declare var __BUILD_TYPE__: string;
 declare var __BUILD_ORIGIN__: string;
 declare var __API_TYPE__: string;
 declare var __API_ORIGIN__: string;
+declare var __IS_HTTPS__: string;
 declare var __DEV__: string;
 declare var __TEST__: string;
 declare var __STAGING__: string;

--- a/typings/globals/missing.d.ts
+++ b/typings/globals/missing.d.ts
@@ -90,7 +90,7 @@ declare var __BUILD_TYPE__: string;
 declare var __BUILD_ORIGIN__: string;
 declare var __API_TYPE__: string;
 declare var __API_ORIGIN__: string;
-declare var __IS_HTTPS__: string;
+declare var __IS_HTTPS__: boolean;
 declare var __DEV__: string;
 declare var __TEST__: string;
 declare var __STAGING__: string;


### PR DESCRIPTION
## Motivation
The new Express Webpack sandbox environment does not currently support HTTP testing.

## Implementation

### Config Files
- Added `isHttps` environment variable which is passed in through the build script
- Exposed port `4000` in Webpack config (for HTTP)

### Build Script
- Added `HTTPS` to build script which is configurable through a opt flag 
- Switched from hard-coded command parsing to use bash getOpt implementation (from stack overflow: https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash)

### Express.js server
- Also serve files from port `4000` (in addition to HTTPS `4001` port)

### Readme Updates
- Outline new build instructions with opt flags
- HTTP info
- Port details

### SDK Environment & Shimloader Files
These files contain methods returning the appropriate origin depending on the environment for both:
   - BUILD: sdk files & other resources
   - API: what API origin will the SDK query (e.g: onesignal.com/api/v1...)

Changes include making the protocol and ports used dynamic based off of the build script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/582)
<!-- Reviewable:end -->
