### PR TITLE
Removed global OneSignal any define, added imports

### DIFF
--- a/src/CustomLink.ts
+++ b/src/CustomLink.ts
@@ -3,6 +3,7 @@ import { AppUserConfigCustomLinkOptions } from "./models/AppConfig";
 import { ResourceLoadState } from "./services/DynamicResourceLoader";
 import Log from "./libraries/Log";
 import { RegisterOptions } from './helpers/InitHelper';
+import OneSignal from "./OneSignal";
 
 export class CustomLink {
   public static readonly initializedAttribute = "data-cl-initialized";

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -3,7 +3,7 @@ import SdkEnvironment from './managers/SdkEnvironment';
 import { WindowEnvironmentKind } from './models/WindowEnvironmentKind';
 import Log from './libraries/Log';
 import Utils from "./utils/Utils";
-
+import OneSignal from "./OneSignal";
 
 const SILENT_EVENTS = [
   'notifyButtonHovering',

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -15,7 +15,7 @@ import LimitStore from './LimitStore';
 import AltOriginManager from './managers/AltOriginManager';
 import LegacyManager from './managers/LegacyManager';
 import SdkEnvironment from './managers/SdkEnvironment';
-import { AppConfig, AppUserConfig, AppUserConfigNotifyButton } from './models/AppConfig';
+import { AppConfig, AppUserConfig } from './models/AppConfig';
 import Context from './models/Context';
 import { Notification } from './models/Notification';
 import { NotificationActionButton } from './models/NotificationActionButton';
@@ -53,6 +53,7 @@ import { ProcessOneSignalPushCalls } from "./utils/ProcessOneSignalPushCalls";
 import { AutoPromptOptions } from "./managers/PromptsManager";
 import { EnvironmentInfoHelper } from './context/browser/helpers/EnvironmentInfoHelper';
 import { EnvironmentInfo } from './context/browser/models/EnvironmentInfo';
+import Bell from './bell/Bell';
 
 export default class OneSignal {
   /**
@@ -745,7 +746,7 @@ export default class OneSignal {
    *  OneSignal.push(["functionName", param1, param2]);
    *  OneSignal.push(function() { OneSignal.functionName(param1, param2); });
    */
-  static push(item: Function | object[]) {
+  static push(item: Function | object[] | object) {
     ProcessOneSignalPushCalls.processItem(OneSignal, item);
   }
 
@@ -800,7 +801,7 @@ export default class OneSignal {
   static _channel = null;
   static timedLocalStorage = TimedLocalStorage;
   static initialized = false;
-  static notifyButton: AppUserConfigNotifyButton | null = null;
+  static notifyButton: Bell | null = null;
   static store = LimitStore;
   static environment = Environment;
   static database = Database;
@@ -850,6 +851,7 @@ export default class OneSignal {
   static _usingNativePermissionHook = false;
   static _initCalled = false;
   static __initAlreadyCalled = false;
+  static _isRegisteringForPush: boolean;
   static context: Context;
   static checkAndWipeUserSubscription = function () { }
   static DeviceRecord = DeviceRecord;

--- a/src/Postmam.ts
+++ b/src/Postmam.ts
@@ -6,6 +6,7 @@ import Emitter from './libraries/Emitter';
 import Log from './libraries/Log';
 import { Utils } from "./utils/Utils";
 import { OneSignalUtils } from "./utils/OneSignalUtils";
+import OneSignal from "./OneSignal";
 
 /**
  * Establishes a cross-domain MessageChannel between the current browsing context (this page) and another (an iFrame, popup, or parent page).

--- a/src/bell/Badge.ts
+++ b/src/bell/Badge.ts
@@ -1,5 +1,6 @@
 import ActiveAnimatedElement from './ActiveAnimatedElement';
 import AnimatedElement from './AnimatedElement';
+import OneSignal from "../OneSignal"
 
 
 export default class Badge extends ActiveAnimatedElement {

--- a/src/bell/Dialog.ts
+++ b/src/bell/Dialog.ts
@@ -5,6 +5,7 @@ import SdkEnvironment from '../managers/SdkEnvironment';
 import {addDomElement, clearDomElementChildren, getPlatformNotificationIcon} from '../utils';
 import AnimatedElement from './AnimatedElement';
 import Bell from './Bell';
+import OneSignal from "../OneSignal"
 
 export default class Dialog extends AnimatedElement {
 

--- a/src/errors/DeprecatedApiError.ts
+++ b/src/errors/DeprecatedApiError.ts
@@ -1,5 +1,6 @@
 import OneSignalError from './OneSignalError';
 import { ApiUsageMetricEvent, ApiUsageMetricKind } from '../managers/MetricsManager';
+import OneSignal from "../OneSignal"
 
 export enum DeprecatedApiReason {
   HttpPermissionRequest,

--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -7,6 +7,7 @@ import SdkEnvironment from "../managers/SdkEnvironment";
 import OneSignalUtils from "../utils/OneSignalUtils";
 import Utils from "../utils/Utils";
 import MainHelper from './MainHelper';
+import OneSignal from "../OneSignal"
 
 export enum IntegrationConfigurationKind {
   /**

--- a/src/helpers/EventHelper.ts
+++ b/src/helpers/EventHelper.ts
@@ -7,6 +7,7 @@ import Log from '../libraries/Log';
 import { CustomLink } from "../CustomLink";
 import { OneSignalUtils } from "../utils/OneSignalUtils";
 import { BrowserUtils } from "../utils/BrowserUtils";
+import OneSignal from "../OneSignal"
 
 export default class EventHelper {
   static onNotificationPermissionChange() {

--- a/src/helpers/HttpHelper.ts
+++ b/src/helpers/HttpHelper.ts
@@ -9,9 +9,7 @@ import SubscriptionModal from '../modules/frames/SubscriptionModal';
 import SubscriptionPopup from '../modules/frames/SubscriptionPopup';
 import { getConsoleStyle } from '../utils';
 import Log from '../libraries/Log';
-
-declare var OneSignal: any;
-
+import OneSignal from '../OneSignal';
 
 export default class HttpHelper {
 

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -29,8 +29,8 @@ import SubscriptionPopupHost from "../modules/frames/SubscriptionPopupHost";
 import { OneSignalUtils } from "../utils/OneSignalUtils";
 import { DeprecatedApiError, DeprecatedApiReason } from "../errors/DeprecatedApiError";
 import LocalStorage from '../utils/LocalStorage';
-
-declare var OneSignal: any;
+import OneSignal from '../OneSignal';
+import { EnvironmentInfo } from '../context/browser/models/EnvironmentInfo';
 
 export interface RegisterOptions extends SubscriptionPopupHostOptions {
   modalPrompt?: boolean;
@@ -113,8 +113,8 @@ export default class InitHelper {
       * It simply wouldn't work to try to show native prompt from script.
       */
 
-     const { environmentInfo } = OneSignal;
-     const { browserType, browserVersion, requiresUserInteraction } = environmentInfo;
+     const { environmentInfo } = OneSignal
+     const { browserType, browserVersion, requiresUserInteraction } : EnvironmentInfo = environmentInfo;
 
       const showSlidedownForceEnable =
         (
@@ -360,7 +360,7 @@ export default class InitHelper {
         };
       }
 
-      const displayPredicate: () => boolean = OneSignal.config.userConfig.notifyButton.displayPredicate;
+      const displayPredicate = OneSignal.config.userConfig.notifyButton.displayPredicate;
       if (displayPredicate && typeof displayPredicate === 'function') {
         OneSignal.emitter.once(OneSignal.EVENTS.SDK_INITIALIZED, async () => {
           const predicateValue = await Promise.resolve(OneSignal.config.userConfig.notifyButton.displayPredicate());

--- a/src/helpers/MainHelper.ts
+++ b/src/helpers/MainHelper.ts
@@ -10,6 +10,7 @@ import { NotificationPermission } from "../models/NotificationPermission";
 import { OneSignalUtils } from "../utils/OneSignalUtils";
 import { PermissionUtils } from "../utils/PermissionUtils";
 import { Utils } from "../utils/Utils";
+import OneSignal from "../OneSignal";
 
 export default class MainHelper {
 

--- a/src/helpers/SubscriptionHelper.ts
+++ b/src/helpers/SubscriptionHelper.ts
@@ -12,6 +12,7 @@ import { ContextSWInterface } from '../models/ContextSW';
 import SdkEnvironment from '../managers/SdkEnvironment';
 import { PermissionUtils } from "../utils/PermissionUtils";
 import LocalStorage from '../utils/LocalStorage';
+import OneSignal from "../OneSignal";
 
 export default class SubscriptionHelper {
   public static async registerForPush(): Promise<Subscription | null> {

--- a/src/helpers/TestHelper.ts
+++ b/src/helpers/TestHelper.ts
@@ -5,8 +5,7 @@ import Database from '../services/Database';
 import TimedLocalStorage from '../modules/TimedLocalStorage';
 import Log from '../libraries/Log';
 import { isUsingSubscriptionWorkaround } from '../utils';
-
-declare var OneSignal: any;
+import OneSignal from '../OneSignal';
 
 export default class TestHelper {
   /**

--- a/src/managers/PermissionManager.ts
+++ b/src/managers/PermissionManager.ts
@@ -5,6 +5,7 @@ import Database from '../services/Database';
 import { NotificationPermission } from '../models/NotificationPermission';
 import SdkEnvironment from '../managers/SdkEnvironment';
 import LocalStorage from '../utils/LocalStorage';
+import OneSignal from "../OneSignal"
 
 /**
  * A permission manager to consolidate the different quirks of obtaining and evaluating permissions

--- a/src/managers/PromptsManager.ts
+++ b/src/managers/PromptsManager.ts
@@ -15,6 +15,7 @@ import Popover, { manageNotifyButtonStateWhilePopoverShows } from '../popover/Po
 import { SlidedownPermissionMessageOptions } from '../models/AppConfig';
 import TestHelper from '../helpers/TestHelper';
 import InitHelper, { RegisterOptions } from '../helpers/InitHelper';
+import OneSignal from "../OneSignal"
 
 export interface AutoPromptOptions {
   force: boolean;

--- a/src/managers/SdkEnvironment.ts
+++ b/src/managers/SdkEnvironment.ts
@@ -6,6 +6,7 @@ import { IntegrationKind } from "../models/IntegrationKind";
 import ServiceWorkerHelper from "../helpers/ServiceWorkerHelper";
 import Environment from "../Environment";
 import OneSignalUtils from "../utils/OneSignalUtils";
+import OneSignal from "../OneSignal";
 
 const RESOURCE_HTTP_PORT = 4000;
 const RESOURCE_HTTPS_PORT = 4001;

--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -18,6 +18,7 @@ import ServiceWorkerHelper, { ServiceWorkerActiveState, ServiceWorkerManagerConf
   from "../helpers/ServiceWorkerHelper";
 import { ContextSWInterface } from '../models/ContextSW';
 import { Utils } from "../utils/Utils";
+import OneSignal from '../OneSignal';
 
 export class ServiceWorkerManager {
   private context: ContextSWInterface;

--- a/src/managers/SessionManager.ts
+++ b/src/managers/SessionManager.ts
@@ -1,8 +1,7 @@
-
-
 import SdkEnvironment from '../managers/SdkEnvironment';
 import { WindowEnvironmentKind } from '../models/WindowEnvironmentKind';
 import Log from '../libraries/Log';
+import OneSignal from "../OneSignal"
 
 export class SessionManager {
   private static SESSION_STORAGE_KEY_NAME = 'onesignal-pageview-count';

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -31,6 +31,7 @@ import NotImplementedError from "../errors/NotImplementedError";
 import { PermissionUtils } from "../utils/PermissionUtils";
 import { base64ToUint8Array } from "../utils/Encoding";
 import { ContextSWInterface } from '../models/ContextSW';
+import OneSignal from "../OneSignal";
 
 export interface SubscriptionManagerConfig {
   safariWebId?: string;

--- a/src/managers/UpdateManager.ts
+++ b/src/managers/UpdateManager.ts
@@ -7,6 +7,7 @@ import Database from "../services/Database";
 import Log from "../libraries/Log";
 import { ContextSWInterface } from '../models/ContextSW';
 import Utils from "../utils/Utils";
+import OneSignal from "../OneSignal"
 
 export class UpdateManager {
   private context: ContextSWInterface;
@@ -18,7 +19,7 @@ export class UpdateManager {
     this.onSessionSent = context.sessionManager.getPageViewCount() > 1;
   }
 
-  private async getDeviceId(): Promise<string> {
+  async getDeviceId(): Promise<string> {
     const { deviceId } = await Database.getSubscription();
     if (!deviceId) {
       throw new NotSubscribedError(NotSubscribedReason.NoDeviceId);

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -49,6 +49,7 @@ export interface AppConfig {
   userConfig: AppUserConfig;
   // TODO: Cleanup: pageUrl is also on AppUserConfig
   pageUrl?: string;
+  pageTitle?: string;
 }
 
 export enum ConfigIntegrationKind {
@@ -103,9 +104,9 @@ interface BasePromptOptions {
 }
 
 export interface SlidedownPermissionMessageOptions extends BasePromptOptions {
-  actionMessage: string;
-  acceptButtonText: string;
-  cancelButtonText: string;
+  actionMessage?: string;
+  acceptButtonText?: string;
+  cancelButtonText?: string;
 }
 
 export interface FullscreenPermissionMessageOptions extends BasePromptOptions {

--- a/src/modules/frames/ProxyFrame.ts
+++ b/src/modules/frames/ProxyFrame.ts
@@ -15,6 +15,7 @@ import { unsubscribeFromPush } from '../../utils';
 import RemoteFrame from './RemoteFrame';
 import Context from '../../models/Context';
 import Log from '../../libraries/Log';
+import OneSignal from "../../OneSignal"
 
 /**
  * The actual OneSignal proxy frame contents / implementation, that is loaded

--- a/src/modules/frames/ProxyFrameHost.ts
+++ b/src/modules/frames/ProxyFrameHost.ts
@@ -5,6 +5,7 @@ import Postmam from '../../Postmam';
 import { timeoutPromise, triggerNotificationPermissionChanged } from '../../utils';
 import { ServiceWorkerActiveState } from "../../helpers/ServiceWorkerHelper";
 import Log from '../../libraries/Log';
+import OneSignal from "../../OneSignal";
 
 /**
  * Manager for an instance of the OneSignal proxy frame, for use from the main

--- a/src/modules/frames/RemoteFrame.ts
+++ b/src/modules/frames/RemoteFrame.ts
@@ -7,6 +7,7 @@ import Postmam from '../../Postmam';
 import Context from '../../models/Context';
 import ConfigManager from '../../managers/ConfigManager';
 import LocalStorage from '../../utils/LocalStorage';
+import OneSignal from "../../OneSignal";
 
 export default class RemoteFrame implements Disposable {
   protected messenger: Postmam;
@@ -75,7 +76,7 @@ export default class RemoteFrame implements Disposable {
     /* This is necessary, otherwise the subdomain is lost after ConfigManager.getAppConfig */
     (rasterizedOptions as any).subdomainName = rasterizedOptions.subdomain;
     rasterizedOptions.origin = rasterizedOptions.origin;
-    OneSignal.config = rasterizedOptions || {};
+    OneSignal.config = rasterizedOptions;
 
     const appConfig = await new ConfigManager().getAppConfig(rasterizedOptions);
     OneSignal.context = new Context(appConfig);

--- a/src/modules/frames/SubscriptionPopup.ts
+++ b/src/modules/frames/SubscriptionPopup.ts
@@ -5,6 +5,7 @@ import { MessengerMessageEvent } from '../../models/MessengerMessageEvent';
 import Postmam from '../../Postmam';
 import RemoteFrame from './RemoteFrame';
 import Log from '../../libraries/Log';
+import OneSignal from "../../OneSignal"
 
 /**
  * The actual OneSignal proxy frame contents / implementation, that is loaded
@@ -42,4 +43,7 @@ export default class SubscriptionPopup extends RemoteFrame {
     Log.debug(`(${SdkEnvironment.getWindowEnv().toString()}) The host page is now ready to receive commands from the HTTP popup.`);
     this.finishInitialization();
   }
+
+  // Assigned by assignPostmamLegacyFunctions
+  message?: Function
 }

--- a/src/modules/frames/SubscriptionPopupHost.ts
+++ b/src/modules/frames/SubscriptionPopupHost.ts
@@ -8,6 +8,7 @@ import { RawPushSubscription } from '../../models/RawPushSubscription';
 import { SubscriptionManager } from '../../managers/SubscriptionManager';
 import Context from '../../models/Context';
 import Log from '../../libraries/Log';
+import OneSignal from "../../OneSignal"
 
 /**
  * Manager for an instance of the OneSignal proxy frame, for use from the main

--- a/src/popover/Popover.ts
+++ b/src/popover/Popover.ts
@@ -4,6 +4,7 @@ import Event from '../Event';
 import MainHelper from '../helpers/MainHelper';
 import {addCssClass, addDomElement, getPlatformNotificationIcon, once, removeDomElement} from '../utils';
 import { SlidedownPermissionMessageOptions } from '../models/AppConfig';
+import OneSignal from "../OneSignal"
 
 export default class Popover {
   public options: SlidedownPermissionMessageOptions;

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -12,6 +12,7 @@ import { EmailProfile } from "../models/EmailProfile";
 import SdkEnvironment from "../managers/SdkEnvironment";
 import OneSignalUtils from "../utils/OneSignalUtils";
 import Utils from "../utils/Utils";
+import OneSignal from "../OneSignal";
 
 enum DatabaseEventName {
   SET

--- a/src/services/IndexedDb.ts
+++ b/src/services/IndexedDb.ts
@@ -3,6 +3,8 @@ import Emitter from '../libraries/Emitter';
 import Log from '../libraries/Log';
 import Utils from "../utils/Utils";
 
+import OneSignal from "../OneSignal"
+
 export default class IndexedDb {
 
   public emitter: Emitter;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import { PermissionUtils } from './utils/PermissionUtils';
 import { BrowserUtils } from './utils/BrowserUtils';
 import { Utils } from "./utils/Utils";
 import bowser from 'bowser';
+import OneSignal from "./OneSignal";
 
 export function isArray(variable: any) {
   return Object.prototype.toString.call(variable) === '[object Array]';

--- a/src/utils/OneSignalShimLoader.ts
+++ b/src/utils/OneSignalShimLoader.ts
@@ -3,6 +3,7 @@ import { OneSignalStubES6 } from "./OneSignalStubES6";
 import { OneSignalStubES5 } from "./OneSignalStubES5";
 import { PossiblePredefinedOneSignal } from "./OneSignalStub";
 // NOTE: Careful if adding imports, ES5 targets can't clean up functions never called.
+declare var OneSignal : any;
 
 // See sdk.ts for what entry points this handles
 

--- a/src/utils/OneSignalUtils.ts
+++ b/src/utils/OneSignalUtils.ts
@@ -3,6 +3,7 @@ import SdkEnvironment from "../managers/SdkEnvironment";
 import { WindowEnvironmentKind } from "../models/WindowEnvironmentKind";
 import Log from "../libraries/Log";
 import { Utils } from "./Utils";
+import OneSignal from '../OneSignal';
 
 export class OneSignalUtils {
   public static getBaseUrl() {

--- a/src/utils/PermissionUtils.ts
+++ b/src/utils/PermissionUtils.ts
@@ -1,5 +1,6 @@
 import Database from "../services/Database";
 import Event from '../Event';
+import OneSignal from '../OneSignal';
 
 export class PermissionUtils {
   public static async triggerNotificationPermissionChanged(updateIfIdentical = false) {

--- a/src/utils/ProcessOneSignalPushCalls.ts
+++ b/src/utils/ProcessOneSignalPushCalls.ts
@@ -1,7 +1,7 @@
 import OneSignalError from "../errors/OneSignalError";
 
 export class ProcessOneSignalPushCalls {
-  public static processItem(oneSignalInstance: IOneSignal, item: Function | object[]) {
+  public static processItem(oneSignalInstance: IOneSignal, item: Function | object[] | object) {
     if (typeof(item) === "function")
       item();
     else if (Array.isArray(item)) {

--- a/src/utils/ReplayCallsOnOneSignal.ts
+++ b/src/utils/ReplayCallsOnOneSignal.ts
@@ -1,5 +1,6 @@
 import { OneSignalStubES6 } from "./OneSignalStubES6";
 import Log from "../libraries/Log";
+import OneSignal from '../OneSignal';
 
 
 export class ReplayCallsOnOneSignal {

--- a/test/support/tester/utils.ts
+++ b/test/support/tester/utils.ts
@@ -7,6 +7,7 @@ import OneSignalApi from "../../../src/OneSignalApi";
 import OneSignalApiBase from "../../../src/OneSignalApiBase";
 import { TestEnvironment, TestEnvironmentConfig, HttpHttpsEnvironment } from '../../support/sdk/TestEnvironment';
 import { ServerAppConfig } from '../../../src/models/AppConfig';
+import OneSignal from "../../../src/OneSignal"
 
 export function isNullOrUndefined<T>(value: T | null | undefined): boolean {
   return typeof value === 'undefined' || value === null;

--- a/test/unit/helpers1/InitHelper.ts
+++ b/test/unit/helpers1/InitHelper.ts
@@ -7,6 +7,7 @@ import { TestEnvironment, BrowserUserAgent } from '../../support/sdk/TestEnviron
 import { setBrowser } from '../../support/tester/browser';
 import { stubMessageChannel } from '../../support/tester/utils';
 import SubscriptionHelper from "../../../src/helpers/SubscriptionHelper";
+import OneSignal from "../../../src/OneSignal"
 
 let sandbox: SinonSandbox = sinon.sandbox.create();
 

--- a/test/unit/managers/UpdateManager.ts
+++ b/test/unit/managers/UpdateManager.ts
@@ -8,6 +8,7 @@ import OneSignalApiShared from "../../../src/OneSignalApiShared";
 import MainHelper from "../../../src/helpers/MainHelper";
 import { SubscriptionStateKind } from "../../../src/models/SubscriptionStateKind";
 import { PushDeviceRecord } from "../../../src/models/PushDeviceRecord";
+import OneSignal from "../../../src/OneSignal"
 
 // manually create and restore the sandbox
 const sandbox: SinonSandbox = sinon.sandbox.create();

--- a/test/unit/onesignal/registerForPushNotifications.ts
+++ b/test/unit/onesignal/registerForPushNotifications.ts
@@ -4,6 +4,7 @@ import sinon, { SinonSandbox } from 'sinon';
 import { TestEnvironment, HttpHttpsEnvironment } from '../../support/sdk/TestEnvironment';
 import InitHelper from "../../../src/helpers/InitHelper";
 import Event from '../../../src/Event';
+import OneSignal from "../../../src/OneSignal"
 
 let sandbox: SinonSandbox;
 

--- a/test/unit/prompts/CustomLink.ts
+++ b/test/unit/prompts/CustomLink.ts
@@ -7,6 +7,7 @@ import OneSignalUtils from '../../../src/utils/OneSignalUtils';
 import { ResourceLoadState } from '../../../src/services/DynamicResourceLoader';
 import { hasCssClass } from '../../../src/utils';
 import MainHelper from "../../../src/helpers/MainHelper";
+import OneSignal from "../../../src/OneSignal"
 
 let sandbox: SinonSandbox = sinon.sandbox.create();;
 let config: AppUserConfigCustomLinkOptions;

--- a/test/unit/public-sdk-apis/init.ts
+++ b/test/unit/public-sdk-apis/init.ts
@@ -16,7 +16,7 @@ import { EmailDeviceRecord } from "../../../src/models/EmailDeviceRecord";
 import {
   mockWebPushAnalytics, InitTestHelper, AssertInitSDK
 } from '../../support/tester/utils';
-
+import OneSignal from "../../../src/OneSignal"
 
 let sinonSandbox: SinonSandbox = sinon.sandbox.create();
 let initTestHelper = new InitTestHelper(sinonSandbox);

--- a/test/unit/public-sdk-apis/onSession.ts
+++ b/test/unit/public-sdk-apis/onSession.ts
@@ -26,7 +26,8 @@ import { ServiceWorkerActiveState } from '../../../src/helpers/ServiceWorkerHelp
 import { WorkerMessenger } from '../../../src/libraries/WorkerMessenger';
 import { UpdateManager } from '../../../src/managers/UpdateManager';
 import PermissionManager from '../../../src/managers/PermissionManager';
-import {MockServiceWorkerRegistration} from "../../support/mocks/service-workers/models/MockServiceWorkerRegistration";
+import { MockServiceWorkerRegistration } from "../../support/mocks/service-workers/models/MockServiceWorkerRegistration";
+import OneSignal from "../../../src/OneSignal"
 
 const sinonSandbox: SinonSandbox = sinon.sandbox.create();
 const initTestHelper = new InitTestHelper(sinonSandbox);

--- a/typings/globals/missing.d.ts
+++ b/typings/globals/missing.d.ts
@@ -80,10 +80,6 @@ interface Window {
  * END: window.safari definition
  */
 
-
-declare var OneSignal: any;
-
-
 // These __*__ variables are defined from Webpack to change resulting JS
 declare var __VERSION__: string;
 declare var __BUILD_TYPE__: string;


### PR DESCRIPTION
* Correct all OneSignal typing so IDE hints and compile time checks work on the OneSignal object.
* TODOs
  * Fix test runtime errors
  * Fix `OneSignalSDKWork.js` bloated size
    * Attempt to use TS 2.9's [import() method to import types only](https://davidea.st/articles/typescript-2-9-import-types)
    * `declare var OneSignal: import('OneSignal');`

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/589)
<!-- Reviewable:end -->

