### PR TITLE
Save new player_id if returned from on_session

### DIFF
--- a/src/managers/UpdateManager.ts
+++ b/src/managers/UpdateManager.ts
@@ -81,8 +81,15 @@ export class UpdateManager {
     }
 
     try {
-      await OneSignalApiShared.updateUserSession(deviceId, deviceRecord);
+      const newPlayerId = await OneSignalApiShared.updateUserSession(deviceId, deviceRecord);
       this.onSessionSent = true;
+
+      // If the returned player id is different, save the new id.
+      if (newPlayerId !== deviceId) {
+        const subscription = await Database.getSubscription();
+        subscription.deviceId = newPlayerId;
+        await Database.setSubscription(subscription);
+      }
     } catch(e) {
       Log.error(`Failed to update user session. Error "${e.message}" ${e.stack}`);
     }


### PR DESCRIPTION
This happens when the player id deleted via the OneSignal dashboard
and the user return to the site

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/593)
<!-- Reviewable:end -->
