### PR TITLE
Test cleanup around onPushReceived

### DIFF
--- a/build/config/tsconfig.base.json
+++ b/build/config/tsconfig.base.json
@@ -38,6 +38,6 @@
       "dom.iterable",
       "scripthost"
     ],
-    "target": "ESNext"
+    "target": "ES2017"
   }
 }

--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -73,9 +73,9 @@ export class ConfigHelper {
     switch (integration) {
       case ConfigIntegrationKind.Custom:
       case ConfigIntegrationKind.WordPress:
-        return {configuration: IntegrationConfigurationKind.JavaScript};
+        return { configuration: IntegrationConfigurationKind.JavaScript };
       default:
-        return {configuration: IntegrationConfigurationKind.Dashboard};
+        return { configuration: IntegrationConfigurationKind.Dashboard };
     }
   }
 
@@ -113,6 +113,8 @@ export class ConfigHelper {
       emailAuthRequired: serverConfig.features.email && serverConfig.features.email.require_auth,
       userConfig: mergedUserConfig,
       enableOnSession: serverConfig.features.enable_on_session || false,
+      // default confirmed deliveries feature to off
+      receiveReceiptsEnable: serverConfig.features.receive_receipts_enable || false
     };
   }
 

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -49,6 +49,11 @@ export interface AppConfig {
   userConfig: AppUserConfig;
   // TODO: Cleanup: pageUrl is also on AppUserConfig
   pageUrl?: string;
+
+  /**
+   * Describes whether Confirmed Delivery should be active
+   */
+  receiveReceiptsEnable?: boolean;
 }
 
 export enum ConfigIntegrationKind {
@@ -312,6 +317,7 @@ export interface ServerAppConfig {
       require_auth: boolean;
     };
     enable_on_session?: boolean;
+    receive_receipts_enable?: boolean;
   };
   config: {
     /**

--- a/src/models/ContextSW.ts
+++ b/src/models/ContextSW.ts
@@ -7,6 +7,11 @@ import PermissionManager from '../managers/PermissionManager';
 import ContextHelper from "../helpers/ContextHelper";
 import { UpdateManager } from "../managers/UpdateManager";
 
+
+// TODO: Ideally this file should only import classes used by ServiceWorker.ts.
+//       Example, ServiceWorkerManager should be remove as it is used by the page / browser,
+//         not the ServiceWorker itself internally.
+
 export interface ContextSWInterface {
   appConfig: AppConfig;
   subscriptionManager: SubscriptionManager;

--- a/src/models/ServiceWorkerState.ts
+++ b/src/models/ServiceWorkerState.ts
@@ -1,10 +1,6 @@
-import { Notification } from "./Notification";
-
-
 class ServiceWorkerState {
   workerVersion: number;
   updaterWorkerVersion: number;
-  backupNotification: Notification;
 }
 
 export { ServiceWorkerState };

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -196,7 +196,6 @@ export class ServiceWorker {
                 // Never nest the following line in a callback from the point of entering from retrieveNotifications
                 notificationEventPromiseFns.push((notif => {
                   return ServiceWorker.displayNotification(notif)
-                      .then(() => ServiceWorker.updateBackupNotification(notif).catch(e => Log.error(e)))
                       .then(() => {
                         return ServiceWorker.workerMessenger.broadcast(WorkerMessengerCommand.NotificationDisplayed, notif).catch(e => Log.error(e))
                       })
@@ -503,22 +502,6 @@ export class ServiceWorker {
     }
 
     return clone;
-  }
-
-  /**
-   * Stores the most recent notification into IndexedDB so that it can be shown as a backup if a notification fails
-   * to be displayed. This is to avoid Chrome's forced "This site has been updated in the background" message. See
-   * this post for more details: http://stackoverflow.com/a/35045513/555547.
-   * This is called every time is a push message is received so that the most recent message can be used as the
-   * backup notification.
-   * @param notification The most recent notification as a structured notification object.
-   */
-  static async updateBackupNotification(notification): Promise<void> {
-    let isWelcomeNotification = notification.data && notification.data.__isOneSignalWelcomeNotification;
-    // Don't save the welcome notification, that just looks broken
-    if (isWelcomeNotification)
-      return;
-    await Database.put('Ids', {type: 'backupNotification', id: notification});
   }
 
   /**

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -180,18 +180,12 @@ export class ServiceWorker {
    * This method handles the receipt of a push signal on all web browsers except Safari, which uses the OS to handle
    * notifications.
    */
-  static onPushReceived(event: PushEvent) {
+  static onPushReceived(event: PushEvent): void {
     Log.debug(`Called %conPushReceived(${JSON.stringify(event, null, 4)}):`, Utils.getConsoleStyle('code'), event);
 
     event.waitUntil(
         ServiceWorker.parseOrFetchNotifications(event)
             .then((notifications: any) => {
-              if (!notifications || notifications.length == 0) {
-                Log.debug("Because no notifications were retrieved, we'll display the last known notification, so" +
-                          " long as it isn't the welcome notification.");
-                return ServiceWorker.displayBackupNotification();
-              }
-
               //Display push notifications in the order we received them
               let notificationEventPromiseFns = [];
 
@@ -219,10 +213,6 @@ export class ServiceWorker {
               if (ServiceWorker.UNSUBSCRIBED_FROM_NOTIFICATIONS) {
                 Log.debug('Because we have just unsubscribed from notifications, we will not show anything.');
                 return undefined;
-              } else {
-                Log.debug(
-                    "Because a notification failed to display, we'll display the last known notification, so long as it isn't the welcome notification.");
-                return ServiceWorker.displayBackupNotification();
               }
             })
     )
@@ -529,29 +519,6 @@ export class ServiceWorker {
     if (isWelcomeNotification)
       return;
     await Database.put('Ids', {type: 'backupNotification', id: notification});
-  }
-
-  /**
-   * Displays a fail-safe notification during a push event in case notification contents could not be retrieved.
-   * This is to avoid Chrome's forced "This site has been updated in the background" message. See this post for
-   * more details: http://stackoverflow.com/a/35045513/555547.
-   */
-  static displayBackupNotification() {
-    return Database.get('Ids', 'backupNotification')
-        .then(backupNotification => {
-          let overrides = {
-            // Don't persist our backup notification; users should ideally not see them
-            persistNotification: false,
-            data: {__isOneSignalBackupNotification: true}
-          };
-          if (backupNotification) {
-            return ServiceWorker.displayNotification(backupNotification, overrides);
-          } else {
-            return ServiceWorker.displayNotification({
-              content: 'You have new updates.'
-            }, overrides);
-          }
-        });
   }
 
   /**

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -258,9 +258,9 @@ export default class Database {
 
    async setServiceWorkerState(state: ServiceWorkerState) {
     if (state.workerVersion)
-      await this.put("Ids", {type: "WORKER1_ONE_SIGNAL_SW_VERSION", id: state.workerVersion});
+      await this.put("Ids", { type: "WORKER1_ONE_SIGNAL_SW_VERSION", id: state.workerVersion });
     if (state.updaterWorkerVersion)
-      await this.put("Ids", {type: "WORKER2_ONE_SIGNAL_SW_VERSION", id: state.updaterWorkerVersion});
+      await this.put("Ids", { type: "WORKER2_ONE_SIGNAL_SW_VERSION", id: state.updaterWorkerVersion });
   }
 
   async getSubscription(): Promise<Subscription> {

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -253,7 +253,6 @@ export default class Database {
     const state = new ServiceWorkerState();
     state.workerVersion = await this.get<number>("Ids", "WORKER1_ONE_SIGNAL_SW_VERSION");
     state.updaterWorkerVersion = await this.get<number>("Ids", "WORKER2_ONE_SIGNAL_SW_VERSION");
-    state.backupNotification = await this.get<Notification>("Ids", "backupNotification");
     return state;
   }
 
@@ -262,8 +261,6 @@ export default class Database {
       await this.put("Ids", {type: "WORKER1_ONE_SIGNAL_SW_VERSION", id: state.workerVersion});
     if (state.updaterWorkerVersion)
       await this.put("Ids", {type: "WORKER2_ONE_SIGNAL_SW_VERSION", id: state.updaterWorkerVersion});
-    if (state.backupNotification)
-      await this.put("Ids", {type: "backupNotification", id: state.backupNotification});
   }
 
   async getSubscription(): Promise<Subscription> {

--- a/test/support/mocks/MockExtendableEvent.ts
+++ b/test/support/mocks/MockExtendableEvent.ts
@@ -1,5 +1,14 @@
 import { MockEvent } from "./MockEvent";
 
-export class MockExtendableEvent extends MockEvent {
+export class MockExtendableEvent extends MockEvent implements ExtendableEvent  {
 
+    private _lastWaitUntilPromise?: Promise<any>;
+
+    get lastWaitUntilPromise(): Promise<any> | undefined {
+        return this._lastWaitUntilPromise;
+    }
+
+    waitUntil(f: Promise<any>): void {
+        this._lastWaitUntilPromise = f;
+    }
 }

--- a/test/support/mocks/service-workers/models/MockPushEvent.ts
+++ b/test/support/mocks/service-workers/models/MockPushEvent.ts
@@ -1,0 +1,16 @@
+import { MockExtendableEvent } from "../../MockExtendableEvent";
+
+export class MockPushEvent extends MockExtendableEvent implements PushEvent {
+
+  data: PushMessageData | null;
+
+  private static EVENT_TYPE_PUSH_EVENT = "onpush";
+
+  public constructor(data: PushMessageData) {
+    super(MockPushEvent.EVENT_TYPE_PUSH_EVENT);
+    this.data = data;
+  }
+    
+  waitUntil(f: Promise<any>): void {
+  }
+}

--- a/test/support/mocks/service-workers/models/MockPushEvent.ts
+++ b/test/support/mocks/service-workers/models/MockPushEvent.ts
@@ -2,15 +2,12 @@ import { MockExtendableEvent } from "../../MockExtendableEvent";
 
 export class MockPushEvent extends MockExtendableEvent implements PushEvent {
 
-  data: PushMessageData | null;
+  public data: PushMessageData | null;
 
   private static EVENT_TYPE_PUSH_EVENT = "onpush";
 
   public constructor(data: PushMessageData) {
     super(MockPushEvent.EVENT_TYPE_PUSH_EVENT);
     this.data = data;
-  }
-    
-  waitUntil(f: Promise<any>): void {
   }
 }

--- a/test/support/mocks/service-workers/models/MockPushMessageData.ts
+++ b/test/support/mocks/service-workers/models/MockPushMessageData.ts
@@ -1,0 +1,21 @@
+export class MockPushMessageData implements PushMessageData {
+
+    private data?: object;
+
+    public constructor(data?: object) {
+        this.data = data;
+    }
+
+    arrayBuffer(): ArrayBuffer {
+        throw new Error("Method not implemented.");
+    }
+    blob(): Blob {
+        throw new Error("Method not implemented.");
+    }
+    json(): any {
+        return this.data;
+    }
+    text(): string {
+        throw new Error("Method not implemented.");
+    }
+}

--- a/test/unit/context/sw/ServiceWorker.ts
+++ b/test/unit/context/sw/ServiceWorker.ts
@@ -1,0 +1,254 @@
+import test from 'ava';
+import sinon, { SinonSandbox, SinonStub } from 'sinon';
+import nock from 'nock';
+
+import OneSignal from '../../../../src/OneSignal';
+import Database from '../../../../src/services/Database';
+import Context from '../../../../src/models/Context';
+import { ServiceWorker as ServiceWorkerReal } from "../../../../src/service-worker/ServiceWorker";
+
+import { TestEnvironment, BrowserUserAgent, HttpHttpsEnvironment } from "../../../support/sdk/TestEnvironment";
+import { setUserAgent } from '../../../support/tester/browser';
+import Random from '../../../support/tester/Random';
+import { MockServiceWorkerGlobalScope } from '../../../support/mocks/service-workers/models/MockServiceWorkerGlobalScope';
+import MockNotification from '../../../support/mocks/MockNotification';
+import { Subscription } from '../../../../src/models/Subscription';
+
+declare var self: MockServiceWorkerGlobalScope;
+
+let sandbox: SinonSandbox;
+let getRegistrationStub: SinonStub;
+
+test.beforeEach(async function() {
+  sandbox = sinon.sandbox.create();
+
+  await TestEnvironment.stubDomEnvironment();
+  getRegistrationStub = sandbox.stub(navigator.serviceWorker, 'getRegistration').callThrough();
+
+  const appConfig = TestEnvironment.getFakeAppConfig();
+  appConfig.appId = Random.getRandomUuid();
+  OneSignal.context = new Context(appConfig);
+});
+
+test.afterEach(function () {
+  if (getRegistrationStub.callCount > 0)
+    sandbox.assert.alwaysCalledWithExactly(getRegistrationStub, location.href);
+  sandbox.restore();
+});
+
+/***************************************************
+ * displayNotification()
+ ****************************************************/
+async function displayNotificationEnvSetup() {
+    await TestEnvironment.initialize({ httpOrHttps: HttpHttpsEnvironment.Https });
+    await TestEnvironment.stubServiceWorkerEnvironment();
+    setUserAgent(BrowserUserAgent.ChromeWindowsSupported);
+  }
+  
+  // Start - displayNotification - persistNotification
+  test('displayNotification - persistNotification - true', async t => {
+    await displayNotificationEnvSetup();
+  
+    await Database.put('Options', { key: 'persistNotification', value: true });
+  
+    const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
+    await ServiceWorkerReal.displayNotification({});
+    t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
+  });
+  
+  test('displayNotification - persistNotification - undefined', async t => {
+    await displayNotificationEnvSetup();
+  
+    const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
+    await ServiceWorkerReal.displayNotification({});
+    t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
+  });
+  
+  test('displayNotification - persistNotification - force', async t => {
+    await displayNotificationEnvSetup();
+  
+    // "force isn't set any more but for legacy users it still results in true
+    await Database.put('Options', { key: 'persistNotification', value: "force" });
+  
+    const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
+    await ServiceWorkerReal.displayNotification({});
+    t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
+  });
+  
+  test('displayNotification - persistNotification - true - Chrome macOS 10.15', async t => {
+    await displayNotificationEnvSetup();
+    setUserAgent(BrowserUserAgent.ChromeMac10_15);
+  
+    await Database.put('Options', { key: 'persistNotification', value: true });
+  
+    const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
+    await ServiceWorkerReal.displayNotification({});
+    t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, false);
+  });
+  
+  test('displayNotification - persistNotification - true - Chrome macOS pre-10.15', async t => {
+    await displayNotificationEnvSetup();
+    setUserAgent(BrowserUserAgent.ChromeMacSupported);
+  
+    await Database.put('Options', { key: 'persistNotification', value: true });
+  
+    const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
+    await ServiceWorkerReal.displayNotification({});
+    t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
+  });
+  
+  test('displayNotification - persistNotification - true - Opera macOS 10.14', async t => {
+    await displayNotificationEnvSetup();
+    setUserAgent(BrowserUserAgent.OperaMac10_14);
+  
+    await Database.put('Options', { key: 'persistNotification', value: true });
+  
+    const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
+    await ServiceWorkerReal.displayNotification({});
+    t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, false);
+  });
+  
+  test('displayNotification - persistNotification - false', async t => {
+    await displayNotificationEnvSetup();
+  
+    await Database.put('Options', { key: 'persistNotification', value: false });
+  
+    const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
+    await ServiceWorkerReal.displayNotification({});
+    t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, false);
+  });
+  // End - displayNotification - persistNotification
+
+
+  /***************************************************
+ * onNotificationClicked()
+ ****************************************************/
+async function onNotificationClickedEnvSetup() {
+  await TestEnvironment.initialize({ httpOrHttps: HttpHttpsEnvironment.Https });
+  await TestEnvironment.stubServiceWorkerEnvironment();
+}
+
+async function setupFakeAppId(): Promise<string> {
+  const appConfig = TestEnvironment.getFakeAppConfig();
+  await Database.setAppConfig(appConfig);
+  return appConfig.appId;
+}
+
+async function setupFakePlayerId(): Promise<string> {
+  const subscription: Subscription = new Subscription();
+  subscription.deviceId = Random.getRandomUuid();
+  await OneSignal.database.setSubscription(subscription);
+  return subscription.deviceId;
+}
+
+function mockNotificationNotificationEventInit(id: string): NotificationEventInit {
+  const notificationOptions: NotificationOptions = { data: { id: id } };
+  const notification = new MockNotification("Title", notificationOptions);
+  return { notification: notification };
+}
+
+test('onNotificationClicked - notification click sends PUT api/v1/notification', async t => {
+  await onNotificationClickedEnvSetup();
+
+  const appId = await setupFakeAppId();
+  const playerId = await setupFakePlayerId();
+  const notificationId = Random.getRandomUuid();
+
+  const notificationPutCall = nock("https://onesignal.com")
+    .put(`/api/v1/notifications/${notificationId}`)
+    .reply(200, (_uri: string, requestBody: string) => {
+      t.deepEqual(JSON.parse(requestBody), {
+        app_id: appId,
+        opened: true,
+        player_id: playerId
+      });
+      return { success: true };
+    });
+
+  const notificationEvent = mockNotificationNotificationEventInit(notificationId);
+  await ServiceWorkerReal.onNotificationClicked(notificationEvent);
+
+  t.true(notificationPutCall.isDone());
+});
+
+test('onNotificationClicked - notification click count omitted when appId is null', async t => {
+  await onNotificationClickedEnvSetup();
+
+  const notificationId = Random.getRandomUuid();
+
+  const notificationPutCall = nock("https://onesignal.com")
+    .put(`/api/v1/notifications/${notificationId}`)
+    .reply(200);
+
+  const notificationEvent = mockNotificationNotificationEventInit(notificationId);
+  await ServiceWorkerReal.onNotificationClicked(notificationEvent);
+
+  t.false(notificationPutCall.isDone());
+});
+
+function addNotificationPutNock(notificationId: string) {
+  nock("https://onesignal.com")
+    .put(`/api/v1/notifications/${notificationId}`)
+    .reply(200);
+}
+
+test('onNotificationClicked - sends webhook', async t => {
+  await onNotificationClickedEnvSetup();
+
+  const notificationId = Random.getRandomUuid();
+  addNotificationPutNock(notificationId);
+
+  const executeWebhooksSpy = sandbox.stub(ServiceWorkerReal, "executeWebhooks");
+
+  const notificationEvent = mockNotificationNotificationEventInit(notificationId);
+  await ServiceWorkerReal.onNotificationClicked(notificationEvent);
+  t.true(executeWebhooksSpy.calledWithExactly(
+    'notification.clicked',
+    notificationEvent.notification.data
+  ));
+});
+
+test('onNotificationClicked - openWindow', async t => {
+  await onNotificationClickedEnvSetup();
+
+  const notificationId = Random.getRandomUuid();
+  addNotificationPutNock(notificationId);
+
+  const openWindowMock = sandbox.stub(self.clients, "openWindow");
+
+  const notificationEvent = mockNotificationNotificationEventInit(notificationId);
+  await ServiceWorkerReal.onNotificationClicked(notificationEvent);
+
+  t.true(openWindowMock.calledWithExactly('https://site.com'));
+});
+
+/*
+ Order is important on Chrome for Android when the site is added to the HomeScreen as a PWA app.
+   - A correctly configured manifest.json file is required for it to become a PWA.
+ We must make sure the network call is kicked off before opening a page as the ServiceWorker
+   stops executing as soon as openWindow is called,
+   before the onNotificationClicked function finishes.
+*/
+test('onNotificationClicked - notification PUT Before openWindow', async t => {
+  await onNotificationClickedEnvSetup();
+  await setupFakeAppId();
+
+  const notificationId = Random.getRandomUuid();
+
+  const callOrder: string[] = [];
+  sandbox.stub(self.clients, "openWindow", function() {
+    callOrder.push("openWindow");
+  });
+
+  nock("https://onesignal.com")
+    .put(`/api/v1/notifications/${notificationId}`)
+    .reply(200, (_uri: string, _requestBody: string) => {
+      callOrder.push("notificationPut");
+      return { success: true };
+    });
+
+  const notificationEvent = mockNotificationNotificationEventInit(notificationId);
+  await ServiceWorkerReal.onNotificationClicked(notificationEvent);
+
+  t.deepEqual(callOrder, ["notificationPut", "openWindow"]);
+});

--- a/test/unit/context/sw/ServiceWorker.ts
+++ b/test/unit/context/sw/ServiceWorker.ts
@@ -17,13 +17,11 @@ import { Subscription } from '../../../../src/models/Subscription';
 declare var self: MockServiceWorkerGlobalScope;
 
 let sandbox: SinonSandbox;
-let getRegistrationStub: SinonStub;
 
 test.beforeEach(async function() {
   sandbox = sinon.sandbox.create();
 
-  await TestEnvironment.stubDomEnvironment();
-  getRegistrationStub = sandbox.stub(navigator.serviceWorker, 'getRegistration').callThrough();
+  await TestEnvironment.stubServiceWorkerEnvironment();
 
   const appConfig = TestEnvironment.getFakeAppConfig();
   appConfig.appId = Random.getRandomUuid();
@@ -31,8 +29,6 @@ test.beforeEach(async function() {
 });
 
 test.afterEach(function () {
-  if (getRegistrationStub.callCount > 0)
-    sandbox.assert.alwaysCalledWithExactly(getRegistrationStub, location.href);
   sandbox.restore();
 });
 

--- a/test/unit/context/sw/ServiceWorker.ts
+++ b/test/unit/context/sw/ServiceWorker.ts
@@ -5,7 +5,7 @@ import nock from 'nock';
 import OneSignal from '../../../../src/OneSignal';
 import Database from '../../../../src/services/Database';
 import Context from '../../../../src/models/Context';
-import { ServiceWorker as ServiceWorkerReal } from "../../../../src/service-worker/ServiceWorker";
+import { ServiceWorker as OSServiceWorker } from "../../../../src/service-worker/ServiceWorker";
 
 import { TestEnvironment, BrowserUserAgent, HttpHttpsEnvironment } from "../../../support/sdk/TestEnvironment";
 import { setUserAgent } from '../../../support/tester/browser';
@@ -76,7 +76,7 @@ test('onPushReceived - Ensure undefined payload does not show', async t => {
   const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
 
   const mockPushEvent = new MockPushEvent(new MockPushMessageData());
-  ServiceWorkerReal.onPushReceived(mockPushEvent);
+  OSServiceWorker.onPushReceived(mockPushEvent);
   await mockPushEvent.lastWaitUntilPromise;
 
   t.true(showNotificationSpy.notCalled);
@@ -86,7 +86,7 @@ test('onPushReceived - Ensure empty payload does not show', async t => {
   const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
 
   const mockPushEvent = new MockPushEvent(new MockPushMessageData({}));
-  ServiceWorkerReal.onPushReceived(mockPushEvent);
+  OSServiceWorker.onPushReceived(mockPushEvent);
   await mockPushEvent.lastWaitUntilPromise;
 
   t.true(showNotificationSpy.notCalled);
@@ -96,7 +96,7 @@ test('onPushReceived - Ensure non-OneSignal payload does not show', async t => {
   const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
 
   const mockPushEvent = new MockPushEvent(new MockPushMessageData({ title: "Test Title" }));
-  ServiceWorkerReal.onPushReceived(mockPushEvent);
+  OSServiceWorker.onPushReceived(mockPushEvent);
   await mockPushEvent.lastWaitUntilPromise;
 
   t.true(showNotificationSpy.notCalled);
@@ -106,7 +106,7 @@ test('onPushReceived - Ensure display when only required values', async t => {
   const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
 
   const mockPushEvent = mockOneSignalPushEvent({ title: "Test Title" });
-  ServiceWorkerReal.onPushReceived(mockPushEvent);
+  OSServiceWorker.onPushReceived(mockPushEvent);
   await mockPushEvent.lastWaitUntilPromise;
 
   assertValidNotificationShown(t, showNotificationSpy);
@@ -125,7 +125,7 @@ test('displayNotification - persistNotification - true', async t => {
   await Database.put('Options', { key: 'persistNotification', value: true });
 
   const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-  await ServiceWorkerReal.displayNotification({});
+  await OSServiceWorker.displayNotification({});
   t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
 });
 
@@ -133,7 +133,7 @@ test('displayNotification - persistNotification - undefined', async t => {
   setUserAgent(BrowserUserAgent.ChromeWindowsSupported);
 
   const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-  await ServiceWorkerReal.displayNotification({});
+  await OSServiceWorker.displayNotification({});
   t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
 });
 
@@ -144,7 +144,7 @@ test('displayNotification - persistNotification - force', async t => {
   await Database.put('Options', { key: 'persistNotification', value: "force" });
 
   const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-  await ServiceWorkerReal.displayNotification({});
+  await OSServiceWorker.displayNotification({});
   t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
 });
 
@@ -154,7 +154,7 @@ test('displayNotification - persistNotification - true - Chrome macOS 10.15', as
   await Database.put('Options', { key: 'persistNotification', value: true });
 
   const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-  await ServiceWorkerReal.displayNotification({});
+  await OSServiceWorker.displayNotification({});
   t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, false);
 });
 
@@ -164,7 +164,7 @@ test('displayNotification - persistNotification - true - Chrome macOS pre-10.15'
   await Database.put('Options', { key: 'persistNotification', value: true });
 
   const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-  await ServiceWorkerReal.displayNotification({});
+  await OSServiceWorker.displayNotification({});
   t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
 });
 
@@ -174,7 +174,7 @@ test('displayNotification - persistNotification - true - Opera macOS 10.14', asy
   await Database.put('Options', { key: 'persistNotification', value: true });
 
   const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-  await ServiceWorkerReal.displayNotification({});
+  await OSServiceWorker.displayNotification({});
   t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, false);
 });
 
@@ -184,7 +184,7 @@ test('displayNotification - persistNotification - false', async t => {
   await Database.put('Options', { key: 'persistNotification', value: false });
 
   const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-  await ServiceWorkerReal.displayNotification({});
+  await OSServiceWorker.displayNotification({});
   t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, false);
 });
 // End - displayNotification - persistNotification
@@ -230,7 +230,7 @@ test('onNotificationClicked - notification click sends PUT api/v1/notification',
     });
 
   const notificationEvent = mockNotificationNotificationEventInit(notificationId);
-  await ServiceWorkerReal.onNotificationClicked(notificationEvent);
+  await OSServiceWorker.onNotificationClicked(notificationEvent);
 
   t.true(notificationPutCall.isDone());
 });
@@ -243,7 +243,7 @@ test('onNotificationClicked - notification click count omitted when appId is nul
     .reply(200);
 
   const notificationEvent = mockNotificationNotificationEventInit(notificationId);
-  await ServiceWorkerReal.onNotificationClicked(notificationEvent);
+  await OSServiceWorker.onNotificationClicked(notificationEvent);
 
   t.false(notificationPutCall.isDone());
 });
@@ -258,10 +258,10 @@ test('onNotificationClicked - sends webhook', async t => {
   const notificationId = Random.getRandomUuid();
   addNotificationPutNock(notificationId);
 
-  const executeWebhooksSpy = sandbox.stub(ServiceWorkerReal, "executeWebhooks");
+  const executeWebhooksSpy = sandbox.stub(OSServiceWorker, "executeWebhooks");
 
   const notificationEvent = mockNotificationNotificationEventInit(notificationId);
-  await ServiceWorkerReal.onNotificationClicked(notificationEvent);
+  await OSServiceWorker.onNotificationClicked(notificationEvent);
   t.true(executeWebhooksSpy.calledWithExactly(
     'notification.clicked',
     notificationEvent.notification.data
@@ -275,7 +275,7 @@ test('onNotificationClicked - openWindow', async t => {
   const openWindowMock = sandbox.stub(self.clients, "openWindow");
 
   const notificationEvent = mockNotificationNotificationEventInit(notificationId);
-  await ServiceWorkerReal.onNotificationClicked(notificationEvent);
+  await OSServiceWorker.onNotificationClicked(notificationEvent);
 
   t.true(openWindowMock.calledWithExactly('https://site.com'));
 });
@@ -305,7 +305,7 @@ test('onNotificationClicked - notification PUT Before openWindow', async t => {
     });
 
   const notificationEvent = mockNotificationNotificationEventInit(notificationId);
-  await ServiceWorkerReal.onNotificationClicked(notificationEvent);
+  await OSServiceWorker.onNotificationClicked(notificationEvent);
 
   t.deepEqual(callOrder, ["notificationPut", "openWindow"]);
 });

--- a/test/unit/context/sw/ServiceWorker.ts
+++ b/test/unit/context/sw/ServiceWorker.ts
@@ -24,6 +24,7 @@ let sandbox: SinonSandbox;
 test.beforeEach(async function() {
   sandbox = sinon.sandbox.create();
 
+  await TestEnvironment.initialize({ httpOrHttps: HttpHttpsEnvironment.Https });
   await TestEnvironment.stubServiceWorkerEnvironment();
 
   const appConfig = TestEnvironment.getFakeAppConfig();
@@ -115,15 +116,11 @@ test('onPushReceived - Ensure display when only required values', async t => {
 /***************************************************
  * displayNotification()
  ****************************************************/
-async function displayNotificationEnvSetup() {
-  await TestEnvironment.initialize({ httpOrHttps: HttpHttpsEnvironment.Https });
-  await TestEnvironment.stubServiceWorkerEnvironment();
-  setUserAgent(BrowserUserAgent.ChromeWindowsSupported);
-}
+
   
 // Start - displayNotification - persistNotification
 test('displayNotification - persistNotification - true', async t => {
-  await displayNotificationEnvSetup();
+  setUserAgent(BrowserUserAgent.ChromeWindowsSupported);
 
   await Database.put('Options', { key: 'persistNotification', value: true });
 
@@ -133,7 +130,7 @@ test('displayNotification - persistNotification - true', async t => {
 });
 
 test('displayNotification - persistNotification - undefined', async t => {
-  await displayNotificationEnvSetup();
+  setUserAgent(BrowserUserAgent.ChromeWindowsSupported);
 
   const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
   await ServiceWorkerReal.displayNotification({});
@@ -141,7 +138,7 @@ test('displayNotification - persistNotification - undefined', async t => {
 });
 
 test('displayNotification - persistNotification - force', async t => {
-  await displayNotificationEnvSetup();
+  setUserAgent(BrowserUserAgent.ChromeWindowsSupported);
 
   // "force isn't set any more but for legacy users it still results in true
   await Database.put('Options', { key: 'persistNotification', value: "force" });
@@ -152,7 +149,6 @@ test('displayNotification - persistNotification - force', async t => {
 });
 
 test('displayNotification - persistNotification - true - Chrome macOS 10.15', async t => {
-  await displayNotificationEnvSetup();
   setUserAgent(BrowserUserAgent.ChromeMac10_15);
 
   await Database.put('Options', { key: 'persistNotification', value: true });
@@ -163,7 +159,6 @@ test('displayNotification - persistNotification - true - Chrome macOS 10.15', as
 });
 
 test('displayNotification - persistNotification - true - Chrome macOS pre-10.15', async t => {
-  await displayNotificationEnvSetup();
   setUserAgent(BrowserUserAgent.ChromeMacSupported);
 
   await Database.put('Options', { key: 'persistNotification', value: true });
@@ -174,7 +169,6 @@ test('displayNotification - persistNotification - true - Chrome macOS pre-10.15'
 });
 
 test('displayNotification - persistNotification - true - Opera macOS 10.14', async t => {
-  await displayNotificationEnvSetup();
   setUserAgent(BrowserUserAgent.OperaMac10_14);
 
   await Database.put('Options', { key: 'persistNotification', value: true });
@@ -185,7 +179,7 @@ test('displayNotification - persistNotification - true - Opera macOS 10.14', asy
 });
 
 test('displayNotification - persistNotification - false', async t => {
-  await displayNotificationEnvSetup();
+  setUserAgent(BrowserUserAgent.ChromeWindowsSupported);
 
   await Database.put('Options', { key: 'persistNotification', value: false });
 
@@ -199,10 +193,6 @@ test('displayNotification - persistNotification - false', async t => {
   /***************************************************
  * onNotificationClicked()
  ****************************************************/
-async function onNotificationClickedEnvSetup() {
-  await TestEnvironment.initialize({ httpOrHttps: HttpHttpsEnvironment.Https });
-  await TestEnvironment.stubServiceWorkerEnvironment();
-}
 
 async function setupFakeAppId(): Promise<string> {
   const appConfig = TestEnvironment.getFakeAppConfig();
@@ -224,8 +214,6 @@ function mockNotificationNotificationEventInit(id: string): NotificationEventIni
 }
 
 test('onNotificationClicked - notification click sends PUT api/v1/notification', async t => {
-  await onNotificationClickedEnvSetup();
-
   const appId = await setupFakeAppId();
   const playerId = await setupFakePlayerId();
   const notificationId = Random.getRandomUuid();
@@ -248,8 +236,6 @@ test('onNotificationClicked - notification click sends PUT api/v1/notification',
 });
 
 test('onNotificationClicked - notification click count omitted when appId is null', async t => {
-  await onNotificationClickedEnvSetup();
-
   const notificationId = Random.getRandomUuid();
 
   const notificationPutCall = nock("https://onesignal.com")
@@ -269,8 +255,6 @@ function addNotificationPutNock(notificationId: string) {
 }
 
 test('onNotificationClicked - sends webhook', async t => {
-  await onNotificationClickedEnvSetup();
-
   const notificationId = Random.getRandomUuid();
   addNotificationPutNock(notificationId);
 
@@ -285,8 +269,6 @@ test('onNotificationClicked - sends webhook', async t => {
 });
 
 test('onNotificationClicked - openWindow', async t => {
-  await onNotificationClickedEnvSetup();
-
   const notificationId = Random.getRandomUuid();
   addNotificationPutNock(notificationId);
 
@@ -306,7 +288,6 @@ test('onNotificationClicked - openWindow', async t => {
    before the onNotificationClicked function finishes.
 */
 test('onNotificationClicked - notification PUT Before openWindow', async t => {
-  await onNotificationClickedEnvSetup();
   await setupFakeAppId();
 
   const notificationId = Random.getRandomUuid();

--- a/test/unit/context/sw/ServiceWorker.ts
+++ b/test/unit/context/sw/ServiceWorker.ts
@@ -13,6 +13,8 @@ import Random from '../../../support/tester/Random';
 import { MockServiceWorkerGlobalScope } from '../../../support/mocks/service-workers/models/MockServiceWorkerGlobalScope';
 import MockNotification from '../../../support/mocks/MockNotification';
 import { Subscription } from '../../../../src/models/Subscription';
+import { MockPushEvent } from '../../../support/mocks/service-workers/models/MockPushEvent';
+import { MockPushMessageData } from '../../../support/mocks/service-workers/models/MockPushMessageData';
 
 declare var self: MockServiceWorkerGlobalScope;
 
@@ -32,88 +34,101 @@ test.afterEach(function () {
   sandbox.restore();
 });
 
+
+/***************************************************
+ * onPushReceived() 
+ ****************************************************/
+
+test('onPushReceived - Ensure undefined payload does not throw', async t => {
+  const mockPushEvent = new MockPushEvent(new MockPushMessageData());
+  await ServiceWorkerReal.onPushReceived(mockPushEvent);
+  t.pass();
+});
+
+/* MockPushSubscriptionChangeEvent */
+
 /***************************************************
  * displayNotification()
  ****************************************************/
 async function displayNotificationEnvSetup() {
-    await TestEnvironment.initialize({ httpOrHttps: HttpHttpsEnvironment.Https });
-    await TestEnvironment.stubServiceWorkerEnvironment();
-    setUserAgent(BrowserUserAgent.ChromeWindowsSupported);
-  }
+  await TestEnvironment.initialize({ httpOrHttps: HttpHttpsEnvironment.Https });
+  await TestEnvironment.stubServiceWorkerEnvironment();
+  setUserAgent(BrowserUserAgent.ChromeWindowsSupported);
+}
   
-  // Start - displayNotification - persistNotification
-  test('displayNotification - persistNotification - true', async t => {
-    await displayNotificationEnvSetup();
-  
-    await Database.put('Options', { key: 'persistNotification', value: true });
-  
-    const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-    await ServiceWorkerReal.displayNotification({});
-    t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
-  });
-  
-  test('displayNotification - persistNotification - undefined', async t => {
-    await displayNotificationEnvSetup();
-  
-    const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-    await ServiceWorkerReal.displayNotification({});
-    t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
-  });
-  
-  test('displayNotification - persistNotification - force', async t => {
-    await displayNotificationEnvSetup();
-  
-    // "force isn't set any more but for legacy users it still results in true
-    await Database.put('Options', { key: 'persistNotification', value: "force" });
-  
-    const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-    await ServiceWorkerReal.displayNotification({});
-    t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
-  });
-  
-  test('displayNotification - persistNotification - true - Chrome macOS 10.15', async t => {
-    await displayNotificationEnvSetup();
-    setUserAgent(BrowserUserAgent.ChromeMac10_15);
-  
-    await Database.put('Options', { key: 'persistNotification', value: true });
-  
-    const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-    await ServiceWorkerReal.displayNotification({});
-    t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, false);
-  });
-  
-  test('displayNotification - persistNotification - true - Chrome macOS pre-10.15', async t => {
-    await displayNotificationEnvSetup();
-    setUserAgent(BrowserUserAgent.ChromeMacSupported);
-  
-    await Database.put('Options', { key: 'persistNotification', value: true });
-  
-    const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-    await ServiceWorkerReal.displayNotification({});
-    t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
-  });
-  
-  test('displayNotification - persistNotification - true - Opera macOS 10.14', async t => {
-    await displayNotificationEnvSetup();
-    setUserAgent(BrowserUserAgent.OperaMac10_14);
-  
-    await Database.put('Options', { key: 'persistNotification', value: true });
-  
-    const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-    await ServiceWorkerReal.displayNotification({});
-    t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, false);
-  });
-  
-  test('displayNotification - persistNotification - false', async t => {
-    await displayNotificationEnvSetup();
-  
-    await Database.put('Options', { key: 'persistNotification', value: false });
-  
-    const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-    await ServiceWorkerReal.displayNotification({});
-    t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, false);
-  });
-  // End - displayNotification - persistNotification
+// Start - displayNotification - persistNotification
+test('displayNotification - persistNotification - true', async t => {
+  await displayNotificationEnvSetup();
+
+  await Database.put('Options', { key: 'persistNotification', value: true });
+
+  const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
+  await ServiceWorkerReal.displayNotification({});
+  t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
+});
+
+test('displayNotification - persistNotification - undefined', async t => {
+  await displayNotificationEnvSetup();
+
+  const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
+  await ServiceWorkerReal.displayNotification({});
+  t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
+});
+
+test('displayNotification - persistNotification - force', async t => {
+  await displayNotificationEnvSetup();
+
+  // "force isn't set any more but for legacy users it still results in true
+  await Database.put('Options', { key: 'persistNotification', value: "force" });
+
+  const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
+  await ServiceWorkerReal.displayNotification({});
+  t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
+});
+
+test('displayNotification - persistNotification - true - Chrome macOS 10.15', async t => {
+  await displayNotificationEnvSetup();
+  setUserAgent(BrowserUserAgent.ChromeMac10_15);
+
+  await Database.put('Options', { key: 'persistNotification', value: true });
+
+  const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
+  await ServiceWorkerReal.displayNotification({});
+  t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, false);
+});
+
+test('displayNotification - persistNotification - true - Chrome macOS pre-10.15', async t => {
+  await displayNotificationEnvSetup();
+  setUserAgent(BrowserUserAgent.ChromeMacSupported);
+
+  await Database.put('Options', { key: 'persistNotification', value: true });
+
+  const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
+  await ServiceWorkerReal.displayNotification({});
+  t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
+});
+
+test('displayNotification - persistNotification - true - Opera macOS 10.14', async t => {
+  await displayNotificationEnvSetup();
+  setUserAgent(BrowserUserAgent.OperaMac10_14);
+
+  await Database.put('Options', { key: 'persistNotification', value: true });
+
+  const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
+  await ServiceWorkerReal.displayNotification({});
+  t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, false);
+});
+
+test('displayNotification - persistNotification - false', async t => {
+  await displayNotificationEnvSetup();
+
+  await Database.put('Options', { key: 'persistNotification', value: false });
+
+  const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
+  await ServiceWorkerReal.displayNotification({});
+  t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, false);
+});
+// End - displayNotification - persistNotification
 
 
   /***************************************************


### PR DESCRIPTION
* Tests for ServiceWorkerManager.ts should test only the usage from a page.
* The new context/sw tests should be for the ServiceWorker itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/599)
<!-- Reviewable:end -->
