### PR TITLE
Confirmed Deliveries

### DIFF
--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -96,9 +96,6 @@ export class ConfigHelper {
     const mergedUserConfig = this.getUserConfigForConfigIntegrationKind(
       configIntegrationKind, userConfig, serverConfig, isUsingSubscriptionWorkaround);
 
-    const receiveReceiptsEnable = typeof serverConfig.features.receive_receipts_enable !== "undefined" ?
-                                    serverConfig.features.receive_receipts_enable : true;
-
     return {
       appId: serverConfig.app_id,
       subdomain,
@@ -116,7 +113,8 @@ export class ConfigHelper {
       emailAuthRequired: serverConfig.features.email && serverConfig.features.email.require_auth,
       userConfig: mergedUserConfig,
       enableOnSession: serverConfig.features.enable_on_session || false,
-      receiveReceiptsEnable
+      // default confirmed deliveries feature to off
+      receiveReceiptsEnable: serverConfig.features.receive_receipts_enable || false
     };
   }
 

--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -73,9 +73,9 @@ export class ConfigHelper {
     switch (integration) {
       case ConfigIntegrationKind.Custom:
       case ConfigIntegrationKind.WordPress:
-        return {configuration: IntegrationConfigurationKind.JavaScript};
+        return { configuration: IntegrationConfigurationKind.JavaScript };
       default:
-        return {configuration: IntegrationConfigurationKind.Dashboard};
+        return { configuration: IntegrationConfigurationKind.Dashboard };
     }
   }
 
@@ -96,6 +96,9 @@ export class ConfigHelper {
     const mergedUserConfig = this.getUserConfigForConfigIntegrationKind(
       configIntegrationKind, userConfig, serverConfig, isUsingSubscriptionWorkaround);
 
+    const receiveReceiptsEnable = typeof serverConfig.features.receive_receipts_enable !== "undefined" ?
+                                    serverConfig.features.receive_receipts_enable : true;
+
     return {
       appId: serverConfig.app_id,
       subdomain,
@@ -113,6 +116,7 @@ export class ConfigHelper {
       emailAuthRequired: serverConfig.features.email && serverConfig.features.email.require_auth,
       userConfig: mergedUserConfig,
       enableOnSession: serverConfig.features.enable_on_session || false,
+      receiveReceiptsEnable
     };
   }
 

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -49,6 +49,11 @@ export interface AppConfig {
   userConfig: AppUserConfig;
   // TODO: Cleanup: pageUrl is also on AppUserConfig
   pageUrl?: string;
+
+  /**
+   * Describes whether Confirmed Delivery should be active
+   */
+  receiveReceiptsEnable?: boolean;
 }
 
 export enum ConfigIntegrationKind {
@@ -312,6 +317,7 @@ export interface ServerAppConfig {
       require_auth: boolean;
     };
     enable_on_session?: boolean;
+    receive_receipts_enable?: boolean;
   };
   config: {
     /**

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -287,10 +287,13 @@ export class ServiceWorker {
     const appId = await ServiceWorker.getAppId();
     const appConfig = await ConfigHelper.getAppConfig({ appId }, OneSignalApiSW.downloadServerAppConfig);
     const { deviceId } = await Database.getSubscription();
-    const hasRequiredParams = notification && notification.id && deviceId && appId;
+
+    // Decided to exclude deviceId from required params
+    // In rare case we don't have it we can still report as confirmed to backend to increment count
+    const hasRequiredParams = appId && notification && notification.id;
 
     if (!hasRequiredParams || !appConfig.receiveReceiptsEnable) {
-      return Promise.resolve(null);
+      return null;
     }
  
     // JSON.stringify() does not include undefined values

--- a/test/unit/context/sw/ServiceWorker.ts
+++ b/test/unit/context/sw/ServiceWorker.ts
@@ -347,7 +347,7 @@ test('onNotificationClicked - notification PUT Before openWindow', async t => {
    stubServerAppConfig(true);
    fakeSetSubscription();
 
-   await ServiceWorkerReal.sendConfirmedDelivery({ id: notificationId });
+   await OSServiceWorker.sendConfirmedDelivery({ id: notificationId });
    t.false(notificationPutCall.isDone());
  });
 
@@ -357,7 +357,7 @@ test('onNotificationClicked - notification PUT Before openWindow', async t => {
   stubServerAppConfig(true);
   fakeSetSubscription();
 
-  await ServiceWorkerReal.sendConfirmedDelivery({ id: notificationId });
+  await OSServiceWorker.sendConfirmedDelivery({ id: notificationId });
   t.true(notificationPutCall.isDone());
  });
 
@@ -367,6 +367,6 @@ test('onNotificationClicked - notification PUT Before openWindow', async t => {
   stubServerAppConfig(false);
   fakeSetSubscription();
 
-  await ServiceWorkerReal.sendConfirmedDelivery({ id: notificationId });
+  await OSServiceWorker.sendConfirmedDelivery({ id: notificationId });
   t.false(notificationPutCall.isDone());
  });


### PR DESCRIPTION
# Motivation
Confirmed Deliveries provide accurate click-through rates as well as confirmation that notifications are successfully being delivered to your users. Every device that receives a notification will confirm to OneSignal that the notification was indeed received.

This is incredibly useful for monitoring the health of your messaging pipeline and providing metrics to better debug your implementation.

# Implementation
- The service worker sends OneSignal acknowledgment of delivery upon receipt of notification. Thus, the SW should do so in the `onPushReceived` method listener. This is where the new method `sendConfirmedDelivery` fires (after series of promises)
- The `sendConfirmedDelivery` method is designed to be controlled by a remote param: `receive_receipts_enable` which can be passed by the backend as a response to the `api/v1/sync` request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/601)
<!-- Reviewable:end -->
