### PR TITLE
Fix logical comparison bug for environment build detection of HTTPS, README update

### DIFF
--- a/build/config/page-sdk-es6.config.js
+++ b/build/config/page-sdk-es6.config.js
@@ -25,7 +25,7 @@ async function getWebpackPlugins() {
         __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
         __API_TYPE__: JSON.stringify(apiEnv),
         __API_ORIGIN__: JSON.stringify(apiOrigin),
-        __IS_HTTPS__: isHttps == "true",
+        __IS_HTTPS__: isHttps === "true",
         __TEST__: !!tests,
         __VERSION__: sdkVersion,
         __LOGGING__: env === "development",

--- a/build/config/page-sdk-es6.config.js
+++ b/build/config/page-sdk-es6.config.js
@@ -25,7 +25,7 @@ async function getWebpackPlugins() {
         __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
         __API_TYPE__: JSON.stringify(apiEnv),
         __API_ORIGIN__: JSON.stringify(apiOrigin),
-        __IS_HTTPS__: isHttps == true,
+        __IS_HTTPS__: isHttps == "true",
         __TEST__: !!tests,
         __VERSION__: sdkVersion,
         __LOGGING__: env === "development",

--- a/build/config/sdk.config.js
+++ b/build/config/sdk.config.js
@@ -62,7 +62,7 @@ async function getWebpackPlugins() {
         __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
         __API_TYPE__: JSON.stringify(apiEnv),
         __API_ORIGIN__: JSON.stringify(apiOrigin),
-        __IS_HTTPS__: isHttps == true,
+        __IS_HTTPS__: isHttps == "true",
         __TEST__: !!tests,
         __VERSION__: sdkVersion,
         __LOGGING__: env === "development",

--- a/build/config/sdk.config.js
+++ b/build/config/sdk.config.js
@@ -62,7 +62,7 @@ async function getWebpackPlugins() {
         __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
         __API_TYPE__: JSON.stringify(apiEnv),
         __API_ORIGIN__: JSON.stringify(apiOrigin),
-        __IS_HTTPS__: isHttps == "true",
+        __IS_HTTPS__: isHttps === "true",
         __TEST__: !!tests,
         __VERSION__: sdkVersion,
         __LOGGING__: env === "development",

--- a/build/config/serviceworker.config.js
+++ b/build/config/serviceworker.config.js
@@ -23,7 +23,7 @@ async function getWebpackPlugins() {
       __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
       __API_TYPE__: JSON.stringify(apiEnv),
       __API_ORIGIN__: JSON.stringify(apiOrigin),
-      __IS_HTTPS__: isHttps == "true",
+      __IS_HTTPS__: isHttps === "true",
       __TEST__: !!tests,
       __VERSION__: sdkVersion,
       __LOGGING__: env === "development",

--- a/build/config/serviceworker.config.js
+++ b/build/config/serviceworker.config.js
@@ -23,7 +23,7 @@ async function getWebpackPlugins() {
       __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
       __API_TYPE__: JSON.stringify(apiEnv),
       __API_ORIGIN__: JSON.stringify(apiOrigin),
-      __IS_HTTPS__: isHttps == true,
+      __IS_HTTPS__: isHttps == "true",
       __TEST__: !!tests,
       __VERSION__: sdkVersion,
       __LOGGING__: env === "development",

--- a/express_webpack/README.md
+++ b/express_webpack/README.md
@@ -13,6 +13,7 @@
       ```
       docker cp <containerId>:sdk/express_webpack/certs/dev-ssl.crt .
       ```
+      You can get the container id by running `docker ps`
    - If you're running the container in a VM, get the cert file onto the VM's host (e.g: use `scp`)
    - add cert to keychain (mac OSX): 
       ```
@@ -39,11 +40,7 @@ yarn build:<type>-<type>
 ```
 **Example**: `yarn build:dev-prod` builds the SDK with the BUILD environment as "development" and the API environment as "production"
 
-### HTTP
-All builds default to `https` unless `--http` is passed to the end of the build command...
-**Example**: `yarn build:dev-prod --http` or `yarn build:dev-prod -b localhost --http`
-
-#### CUSTOM ORIGIN PARAMS: 
+### CUSTOM ORIGIN PARAMS: 
 You can pass two additional parameters to the above command, the first being the origin of the build environment and the second being that of the api environment. These parameters use option flags. 
 
    - Option flags are:
@@ -52,22 +49,46 @@ You can pass two additional parameters to the above command, the first being the
 
 If no custom origins are set, defaults will be used: `localhost` for build and `onesignal.com` for api. 
 
-**Note:**: make sure custom origins make sense with respect to the build and api environments set (e.g: you cannot use a `prod` api environment and expect a custom api origin to be used).
+**Note:** make sure custom origins make sense with respect to the build and api environments set (e.g: you cannot use a `prod` api environment and expect a custom api origin to be used).
 
 **Examples**:
 ```
 yarn build:dev-prod -b texas
 ```
-This sets the BUILD environment origin to `localhost` which will result in SDK files being fetched from `https://localhost:4001/sdks/` and the API environment origin to `localhost` which will make all onesignal api calls to that origin such as `https://localhost:3001/api/v1/apps/<app>`
+This sets the BUILD environment origin to `texas` which will result in SDK files being fetched from `https://texas:4001/sdks/` and the API environment origin to production which will make all onesignal api calls to the production origin `https://onesignal.com/api/v1/apps/<app>`
 
 ```
-yarn build:dev-dev -b texas -a <ip>
+yarn build:dev-dev -b localhost -a texas
 ```
-This sets the BUILD environment origin to `texas` which will result in SDK files being fetched from `https://texas:4001/sdks/` and the API environment origin to the default `https://onesignal.com/api/v1/apps/<app_id>`
+This sets the BUILD environment origin to `localhost` which will result in SDK files being fetched from `https://localhost:4001/sdks/` and the API environment origin to the default `https://texas:3001/api/v1/apps/<app_id>`
 
-#### NOTE ON PORTS:
+### HTTP
+All builds default to `https` unless `--http` is passed to the end of the build command...
+
+**Example**: `yarn build:dev-prod --http` or `yarn build:dev-prod -b localhost --http`
+
+### NOTE ON PORTS:
 **SDK**: SDK files will automatically be fetched from the 4000s ports depending on the HTTP/S setting
    - HTTP: `4000`
    - HTTPS: `4001`
 
 **API**: dev-environment API calls will be made to the `3001` port (e.g: `<custom-origin>:3001`)
+
+### Running in Combination with OneSignal Container (dev-dev)
+You may want to run the Web SDK Sandbox with the configuration `dev-dev`. You will need to make sure to follow some steps first so that both the **Express Webpack** and **OneSignal** containers work in conjunction...
+
+1. Make sure your browser can make secure connections to wherever your OneSignal container is running, VM or otherwise. This may involve adding a cert to your keychain and/or visiting the container's frontend (Dashboard) and allowing the browser to proceed past the "unsafe" warning.
+
+2. If you are running the OneSignal container on a machine with a different IP address, add an alias to your hosts file which you can then use easily in your API environment option at build time.
+ 
+   ```
+   // file: /etc/hosts
+
+   192.168.40.21 texas
+   ```
+   See above for example on using `texas` as the API environment option
+
+3. Make sure that the OneSignal container is using the URLs to your WebSDK container's build files. To do this, 
+   - change the URLs in the file `development.rb` so that they point to the files' absolute paths (these are the files in the `build` directory after running `yarn build:<>-<>`)
+
+4. Remove the `$PREFIX` var from the `publish.sh` script for all map files


### PR DESCRIPTION
Javascript comparison quirk was leading to a dev environment build issue.

Added to Express Webpack README to clarify sandbox build process

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/606)
<!-- Reviewable:end -->
