### PR TITLE
Temporarily disable confirmed delivery.

### DIFF
--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -274,7 +274,9 @@ export class ServiceWorker {
    */
   static async sendConfirmedDelivery(notification: any): Promise<Response | null> {
     const appId = await ServiceWorker.getAppId();
-    const appConfig = await ConfigHelper.getAppConfig({ appId }, OneSignalApiSW.downloadServerAppConfig);
+    // const appConfig = await ConfigHelper.getAppConfig({ appId }, OneSignalApiSW.downloadServerAppConfig);
+    // Disable confirmed delivery, for now.
+    const appConfig = { receiveReceiptsEnable: false };
     const { deviceId } = await Database.getSubscription();
 
     // Decided to exclude deviceId from required params

--- a/test/unit/context/sw/ServiceWorker.ts
+++ b/test/unit/context/sw/ServiceWorker.ts
@@ -340,6 +340,7 @@ test('onNotificationClicked - notification PUT Before openWindow', async t => {
   await Database.setSubscription(subscription);
  }
 
+ /*
  test('sendConfirmedDelivery - notification is null - feature flag is true', async t => {
    const notificationId = null;
    const notificationPutCall = mockNotificationPutCall(notificationId);
@@ -369,3 +370,4 @@ test('onNotificationClicked - notification PUT Before openWindow', async t => {
   await OSServiceWorker.sendConfirmedDelivery({ id: notificationId });
   t.false(notificationPutCall.isDone());
  });
+ */


### PR DESCRIPTION
This temporarily disabled confirmed delivery.  This does the following:
1. No longer fetches the app config.
2. Sets up the `appConfig` value to an object that has the `receiveReceiptsEnable` value as false.  
3. Forces an early return in this function because of the `receiveReceiptsEnable` being false.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/607)
<!-- Reviewable:end -->
