### PR TITLE
Moved received receipts flag to payload

### DIFF
--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -273,6 +273,9 @@ export class ServiceWorker {
    * @returns {Promise}
    */
   static async sendConfirmedDelivery(notification: any): Promise<Response | null> {
+    if (!notification)
+      return null;
+
     // Received receipts enabled?
     if (notification.rr !== "y")
       return null;
@@ -280,10 +283,9 @@ export class ServiceWorker {
     const appId = await ServiceWorker.getAppId();
     const { deviceId } = await Database.getSubscription();
 
-    // Decided to exclude deviceId from required params
+    // app and notification ids are required, decided to exclude deviceId from required params
     // In rare case we don't have it we can still report as confirmed to backend to increment count
-    const hasRequiredParams = appId && notification && notification.id;
-
+    const hasRequiredParams = !!(appId && notification.id);
     if (!hasRequiredParams) {
       return null;
     }

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -273,15 +273,18 @@ export class ServiceWorker {
    * @returns {Promise}
    */
   static async sendConfirmedDelivery(notification: any): Promise<Response | null> {
+    // Received receipts enabled?
+    if (notification.rr !== "y")
+      return null;
+
     const appId = await ServiceWorker.getAppId();
-    const appConfig = await ConfigHelper.getAppConfig({ appId }, OneSignalApiSW.downloadServerAppConfig);
     const { deviceId } = await Database.getSubscription();
 
     // Decided to exclude deviceId from required params
     // In rare case we don't have it we can still report as confirmed to backend to increment count
     const hasRequiredParams = appId && notification && notification.id;
 
-    if (!hasRequiredParams || !appConfig.receiveReceiptsEnable) {
+    if (!hasRequiredParams) {
       return null;
     }
  


### PR DESCRIPTION
* Changed to a payload flag to remove the need to pull down feature flags on every push received
* Used a short "rr" flag so this bloats the payload as little as possible.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/608)
<!-- Reviewable:end -->
