### PR TITLE
Use the build arguments for staging environment URLs.

### DIFF
--- a/src/managers/SdkEnvironment.ts
+++ b/src/managers/SdkEnvironment.ts
@@ -257,7 +257,7 @@ export default class SdkEnvironment {
       case EnvironmentKind.Development:
         return new URL(`https://${apiOrigin}:${API_URL_PORT}/api/v1`);
       case EnvironmentKind.Staging:
-        return new URL(`https://${window.location.host}/api/v1`);
+        return new URL(`https://${apiOrigin}/api/v1`);
       case EnvironmentKind.Production:
         return new URL('https://onesignal.com/api/v1');
       default:
@@ -277,7 +277,7 @@ export default class SdkEnvironment {
         origin = `${protocol}://${buildOrigin}:${port}`;
         break;
       case EnvironmentKind.Staging:
-        origin = `https://${window.location.host}`;
+        origin = `https://${buildOrigin}`;
         break;
       case EnvironmentKind.Production:
         origin = "https://onesignal.com";

--- a/src/utils/OneSignalShimLoader.ts
+++ b/src/utils/OneSignalShimLoader.ts
@@ -35,7 +35,7 @@ export class OneSignalShimLoader {
       case "development":
         return `${protocol}://${buildOrigin}:${port}/sdks/Dev-`;
       case "staging":
-        return `https://${window.location.host}/sdks/Staging-`;
+        return `https://${buildOrigin}/sdks/Staging-`;
       default:
         return productionOrigin;
     }


### PR DESCRIPTION
The current staging environment URLs rely on the `window.location.host` value.  This won't work on SDKs outside of being on the same host when loading the external resources.  This change uses build arguments instead of the browser environment to build those URLs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/620)
<!-- Reviewable:end -->
