### PR TITLE
Building outcomes on top of new session logic

### DIFF
--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -48,5 +48,7 @@
     <br />
     <input id="outcome_weight" value=""/>
     <button onclick="javascript:sendOutcomeWithWeight();">Send outcome with weight</button>
+    <br/>
+    <div class='onesignal-customlink-container'></div>
 </body>
 </html>

--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -19,6 +19,21 @@
     OneSignal.push(function() {
       OneSignal.init({appId});
     });
+
+    function sendOutcome() {
+        OneSignal.push(function() {
+            const outcomeName = document.querySelector('#outcome_name').value;
+            OneSignal.sendOutcome(outcomeName);
+        });
+    }
+
+    function sendOutcomeWithWeight() {
+        OneSignal.push(function() {
+            const outcomeName = document.querySelector('#outcome_name').value;
+            const outcomeWeight = parseFloat(document.querySelector('#outcome_weight').value);
+            OneSignal.sendOutcome(outcomeName, outcomeWeight);
+        });
+    }
   </script>
 <head>
     <meta charset="utf-8">
@@ -28,5 +43,10 @@
 <body>
     <h1>OneSignal WebSDK Sandbox</h1>
     <p class="description">WebSDK Sandbox Environment</p>
+    <input id="outcome_name" value="iryna-022020" />
+    <button onclick="javascript:sendOutcome();">Send outcome</button>
+    <br />
+    <input id="outcome_weight" value=""/>
+    <button onclick="javascript:sendOutcomeWithWeight();">Send outcome with weight</button>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "deepmerge": "^4.2.2",
     "dom-storage": "^2.0.2",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
-    "fake-indexeddb": "github:OneSignal/fakeIndexedDB#onesignal",
+    "fake-indexeddb": "^2.1.1",
     "imports-loader": "^0.7.1",
     "md5-file": "^3.2.2",
     "nock": "^9.1.6",

--- a/package.json
+++ b/package.json
@@ -120,12 +120,12 @@
     },
     {
       "path": "./build/bundles/OneSignalPageSDKES6.js",
-      "maxSize": "55 kB",
+      "maxSize": "58 kB",
       "compression": "gzip"
     },
     {
       "path": "./build/bundles/OneSignalSDKWorker.js",
-      "maxSize": "31 kB",
+      "maxSize": "35 kB",
       "compression": "gzip"
     },
     {

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -53,7 +53,7 @@ import { ProcessOneSignalPushCalls } from "./utils/ProcessOneSignalPushCalls";
 import { AutoPromptOptions } from "./managers/PromptsManager";
 import { EnvironmentInfoHelper } from './context/browser/helpers/EnvironmentInfoHelper';
 import { EnvironmentInfo } from './context/browser/models/EnvironmentInfo';
-import { SessionManager } from './managers/SessionManager';
+import { SessionManager } from './managers/sessionManager/page/SessionManager';
 import OutcomesHelper from "./helpers/shared/OutcomesHelper";
 import { OutcomeAttributionType } from "./models/Outcomes";
 

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -847,28 +847,14 @@ export default class OneSignal {
 
       if (matchingNotifications.length > 0) {
         const max: number = OneSignal.config!.userConfig.outcomes!.indirect.influencedNotificationsLimit;
-        let counter: number = 0;
-        const promises: Promise<void>[] = [];
         /**
          * To handle correctly the case when user got subscribed to a new app id
          * we check the appId on notifications to match the current app.
          */
-        for (let i = 0; i < matchingNotifications.length && counter < max; i++) {
-          const matchingNotification = matchingNotifications[i];
-          if (matchingNotification.appId !== OneSignal.config!.appId) {
-            continue;
-          }
-          promises.push(
-            (async (notif: NotificationReceived) => {
-              await OneSignal.context.updateManager.sendOutcomeInfluenced(
-                notif.appId, notif.notificationId, outcomeName, outcomeWeight);
-            })(matchingNotification)
-          );
-          counter++;
-        }
-        if (promises.length > 0) {
-          await Promise.all(promises);
-        }
+        const notificationIds = matchingNotifications.filter(notif => notif.appId === OneSignal.config!.appId)
+          .slice(0, max).map(notif => notif.notificationId);
+        await OneSignal.context.updateManager.sendOutcomeInfluenced(
+          OneSignal.config!.appId, notificationIds, outcomeName, outcomeWeight);
         return;
       }
     }

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -30,6 +30,7 @@ import SubscriptionPopupHost from './modules/frames/SubscriptionPopupHost';
 import OneSignalApi from './OneSignalApi';
 import Popover from './popover/Popover';
 import Database from './services/Database';
+import { Utils } from "./context/shared/utils/Utils";
 
 import IndexedDb from './services/IndexedDb';
 import {
@@ -828,8 +829,7 @@ export default class OneSignal {
     if (OneSignal.config!.userConfig.outcomes!.direct.enabled) {
       const clickedNotification: NotificationClicked | null = await OneSignal.database.getNotificationClickedByUrl(
         window.location.href, OneSignal.config!.appId);
-
-        if (clickedNotification) {
+      if (clickedNotification) {
         await OneSignal.context.updateManager.sendOutcomeDirect(
           clickedNotification.appId, clickedNotification.notificationId, outcomeName, outcomeWeight);
         return;
@@ -849,8 +849,11 @@ export default class OneSignal {
          * To handle correctly the case when user got subscribed to a new app id
          * we check the appId on notifications to match the current app.
          */
+
+        Utils.sortArrayOfObjects(matchingNotifications, (notif: NotificationReceived) => notif.timestamp, true, true);
         const notificationIds = matchingNotifications.filter(notif => notif.appId === OneSignal.config!.appId)
           .slice(0, max).map(notif => notif.notificationId);
+
         await OneSignal.context.updateManager.sendOutcomeInfluenced(
           OneSignal.config!.appId, notificationIds, outcomeName, outcomeWeight);
         return;

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -840,7 +840,7 @@ export default class OneSignal {
     if (OneSignal.config!.userConfig.outcomes!.indirect.enabled) {
       const timeframeMs = OneSignal.config!.userConfig.outcomes!.indirect.influencedTimePeriodMin * 60 * 1000;
       const beginningOfTimeframe = new Date(new Date().getTime() - timeframeMs);
-      const maxTimestamp = beginningOfTimeframe.getTime().toString();
+      const maxTimestamp = beginningOfTimeframe.getTime();
       const matchingNotifications: NotificationReceived[] =
         await OneSignal.database.getNotificationReceivedForTimeRange(maxTimestamp);
       if (matchingNotifications.length > 0) {

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -934,6 +934,7 @@ export default class OneSignal {
     CONNECTED: 'connect',
     REMOTE_NOTIFICATION_PERMISSION: 'postmam.remoteNotificationPermission',
     REMOTE_DATABASE_GET: 'postmam.remoteDatabaseGet',
+    REMOTE_DATABASE_GET_ALL: 'postmam.remoteDatabaseGetAll',
     REMOTE_DATABASE_PUT: 'postmam.remoteDatabasePut',
     REMOTE_DATABASE_REMOVE: 'postmam.remoteDatabaseRemove',
     REMOTE_OPERATION_COMPLETE: 'postman.operationComplete',

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -816,11 +816,28 @@ export default class OneSignal {
 
     if (matchingNotifications.length > 0) {
       const max: number = OneSignal.config!.userConfig.outcomes.influencedNotificationsLimit;
-      const promises = matchingNotifications.slice(0, max).map(async (notif: NotificationReceived) => {
-        await OneSignal.context.updateManager.sendOutcomeInfluenced(
-          OneSignal.config!.appId, notif.notificationId, outcomeName, outcomeWeight);
-      });
-      await Promise.all(promises);
+      let counter: number = 0;
+      const promises: Promise<void>[] = [];
+      /**
+       * To handle correctly the case when user got subscribed to a new app id
+       * we check the appId on notifications to match the current app.
+       */
+      for (let i = 0; i < matchingNotifications.length && counter < max; i++) {
+        const matchingNotification = matchingNotifications[i];
+        if (matchingNotification.appId !== OneSignal.config!.appId) {
+          continue;
+        }
+        promises.push(
+          (async (notif: NotificationReceived) => {
+            await OneSignal.context.updateManager.sendOutcomeInfluenced(
+              notif.appId, notif.notificationId, outcomeName, outcomeWeight);
+          })(matchingNotification)
+        );
+        counter++;
+      }
+      if (promises.length > 0) {
+        await Promise.all(promises);
+      }
       return;
     }
 

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -17,7 +17,7 @@ import LegacyManager from './managers/LegacyManager';
 import SdkEnvironment from './managers/SdkEnvironment';
 import { AppConfig, AppUserConfig, AppUserConfigNotifyButton } from './models/AppConfig';
 import Context from './models/Context';
-import { Notification, NotificationReceived, NotificationClicked } from "./models/Notification";
+import { Notification } from "./models/Notification";
 import { NotificationActionButton } from './models/NotificationActionButton';
 import { NotificationPermission } from './models/NotificationPermission';
 import { WindowEnvironmentKind } from './models/WindowEnvironmentKind';
@@ -207,6 +207,11 @@ export default class OneSignal {
     const appConfig = await new ConfigManager().getAppConfig(options);
     Log.debug(`OneSignal: Final web app config: %c${JSON.stringify(appConfig, null, 4)}`, getConsoleStyle('code'));
 
+    // TODO: environmentInfo is explicitly dependent on existence of OneSignal.config. Needs refactor.
+    // Workaround to temp assign config so that it can be used in context.
+    OneSignal.config = appConfig;
+    OneSignal.environmentInfo = EnvironmentInfoHelper.getEnvironmentInfo();
+
     OneSignal.context = new Context(appConfig);
     OneSignal.config = OneSignal.context.appConfig;
   }
@@ -221,8 +226,6 @@ export default class OneSignal {
     await InitHelper.polyfillSafariFetch();
     InitHelper.errorIfInitAlreadyCalled();
     await OneSignal.initializeConfig(options);
-
-    OneSignal.environmentInfo = EnvironmentInfoHelper.getEnvironmentInfo();
 
     if (!OneSignal.config) {
       throw new Error("OneSignal config not initialized!");

--- a/src/OneSignalApiSW.ts
+++ b/src/OneSignalApiSW.ts
@@ -4,6 +4,7 @@ import { SubscriptionStateKind } from "./models/SubscriptionStateKind";
 import { FlattenedDeviceRecord } from "./models/DeviceRecord";
 import Log from "./libraries/Log";
 import { Utils } from "./context/shared/utils/Utils";
+import { OutcomeAttribution, OutcomeAttributionType } from "./models/Outcomes";
 
 export class OneSignalApiSW {
   static async downloadServerAppConfig(appId: string): Promise<ServerAppConfig> {
@@ -62,15 +63,27 @@ export class OneSignalApiSW {
   };
 
   public static async sendSessionDuration(
-    appId: string, deviceId: string, sessionDuration: number, deviceType: number
+    appId: string, deviceId: string, sessionDuration: number, deviceType: number, attribution: OutcomeAttribution
   ): Promise<void> {
     const funcToExecute = async () => {
-      const payload = {
+      const payload: any = {
         app_id: appId,
         type: 1,
         state: "ping",
         active_time: sessionDuration,
         device_type: deviceType,
+      };
+      switch (attribution.type) {
+        case OutcomeAttributionType.Direct:
+          payload.direct = true;
+          payload.notification_ids = attribution.notificationIds;
+          break;
+        case OutcomeAttributionType.Indirect:
+          payload.direct = false;
+          payload.notification_ids = attribution.notificationIds;
+          break;
+        default:
+          break;
       }
       await OneSignalApiBase.post(`players/${deviceId}/on_focus`, payload);
     }

--- a/src/OneSignalApiShared.ts
+++ b/src/OneSignalApiShared.ts
@@ -6,6 +6,7 @@ import { EmailDeviceRecord } from './models/EmailDeviceRecord';
 import { OutcomeRequestData } from "./models/OutcomeRequestData";
 import OneSignalApiBase from "./OneSignalApiBase";
 import Utils from "./context/shared/utils/Utils";
+import Log from "./libraries/Log";
 
 export default class OneSignalApiShared {
   static getPlayer(appId: string, playerId: string) {
@@ -129,7 +130,7 @@ export default class OneSignalApiShared {
     try {
       await OneSignalApiBase.post("outcomes/measure", data);
     } catch(e) {
-      console.log("sendOutcome", e);
+      Log.error("sendOutcome", e);
     }
   }
 }

--- a/src/context/shared/utils/Utils.ts
+++ b/src/context/shared/utils/Utils.ts
@@ -189,6 +189,28 @@ export class Utils {
       } else throw e;
     }
   }
+
+  static sortArrayOfObjects<TObject, TProperty>(
+    arrayToSort: TObject[],
+    predicateForProperty: (obj: TObject) => TProperty,
+    descending: boolean = false,
+    doItInPlace: boolean = true
+  ): TObject[] {
+    const internalArrayToSort = doItInPlace ? arrayToSort : arrayToSort.slice();
+    internalArrayToSort.sort((a: TObject, b: TObject) => {
+      const propertyA = predicateForProperty(a);
+      const propertyB = predicateForProperty(b);
+
+      if (propertyA > propertyB) {
+        return !!descending ? -1 : 1;
+      }
+      if (propertyA < propertyB) {
+        return !!descending ? 1 : -1;
+      }
+      return 0;
+    })
+    return internalArrayToSort;
+  }
 }
 
 export default Utils;

--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -393,11 +393,7 @@ export class ConfigHelper {
           allowLocalhostAsSecureOrigin: serverConfig.config.setupBehavior ?
             serverConfig.config.setupBehavior.allowLocalhostAsSecureOrigin : undefined,
           requiresUserPrivacyConsent: userConfig.requiresUserPrivacyConsent,
-          outcomes: {
-            ...serverConfig.config.outcomes,
-            influencedTimePeriodMin: serverConfig.config.outcomes.influencedTimePeriodMin,
-            influencedNotificationsLimit: serverConfig.config.outcomes.influencedNotificationsLimit,
-          }
+          outcomes: serverConfig.config.outcomes,
         };
       case IntegrationConfigurationKind.JavaScript:
         /*
@@ -424,11 +420,7 @@ export class ConfigHelper {
                 : 'OneSignalSDUpdaterKWorker.js',
             path: !!userConfig.path ? userConfig.path : '/'
           },
-          outcomes: {
-            ...serverConfig.config.outcomes,
-            influencedTimePeriodMin: serverConfig.config.outcomes.influencedTimePeriodMin,
-            influencedNotificationsLimit: serverConfig.config.outcomes.influencedNotificationsLimit,
-          }
+          outcomes: serverConfig.config.outcomes,
         };
 
         if (userConfig.hasOwnProperty("autoResubscribe")) {

--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -120,11 +120,11 @@ export class ConfigHelper {
         SERVER_CONFIG_DEFAULTS_SESSION.enableOnSessionForUnsubcribed
       ),
       sessionThreshold: Utils.valueOrDefault(
-        serverConfig.config.sessionThreshold,
+        serverConfig.features.session_threshold,
         SERVER_CONFIG_DEFAULTS_SESSION.reportingThreshold
       ),
       enableSessionDuration: Utils.valueOrDefault(
-        serverConfig.features.enableSessionDuration,
+        serverConfig.features.web_on_focus_enabled,
         SERVER_CONFIG_DEFAULTS_SESSION.enableOnFocus
       )
     };
@@ -393,7 +393,16 @@ export class ConfigHelper {
           allowLocalhostAsSecureOrigin: serverConfig.config.setupBehavior ?
             serverConfig.config.setupBehavior.allowLocalhostAsSecureOrigin : undefined,
           requiresUserPrivacyConsent: userConfig.requiresUserPrivacyConsent,
-          outcomes: serverConfig.config.outcomes,
+          outcomes: {
+            direct: serverConfig.config.outcomes.direct,
+            indirect: {
+              enabled: serverConfig.config.outcomes.indirect.enabled,
+              influencedTimePeriodMin:
+                serverConfig.config.outcomes.indirect.notification_attribution.minutes_since_displayed,
+              influencedNotificationsLimit: serverConfig.config.outcomes.indirect.notification_attribution.limit,
+            },
+            unattributed: serverConfig.config.outcomes.unattributed,
+          }
         };
       case IntegrationConfigurationKind.JavaScript:
         /*
@@ -420,7 +429,16 @@ export class ConfigHelper {
                 : 'OneSignalSDUpdaterKWorker.js',
             path: !!userConfig.path ? userConfig.path : '/'
           },
-          outcomes: serverConfig.config.outcomes,
+          outcomes: {
+            direct: serverConfig.config.outcomes.direct,
+            indirect: {
+              enabled: serverConfig.config.outcomes.indirect.enabled,
+              influencedTimePeriodMin:
+                serverConfig.config.outcomes.indirect.notification_attribution.minutes_since_displayed,
+              influencedNotificationsLimit: serverConfig.config.outcomes.indirect.notification_attribution.limit,
+            },
+            unattributed: serverConfig.config.outcomes.unattributed,
+          }
         };
 
         if (userConfig.hasOwnProperty("autoResubscribe")) {

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -46,6 +46,9 @@ export default class InitHelper {
     // Always check for an updated service worker
     await OneSignal.context.serviceWorkerManager.installWorker();
 
+    const sessionManager = OneSignal.context.sessionManager;
+    OneSignal.emitter.on(OneSignal.EVENTS.SESSION_STARTED,
+      sessionManager.sendOnSessionUpdateFromPage.bind(sessionManager));
     OneSignal.context.pageViewManager.incrementPageViewCount();
 
     if (document.visibilityState !== 'visible') {

--- a/src/helpers/MainHelper.ts
+++ b/src/helpers/MainHelper.ts
@@ -11,6 +11,8 @@ import { PushDeviceRecord } from "../models/PushDeviceRecord";
 import { OneSignalUtils } from "../utils/OneSignalUtils";
 import { PermissionUtils } from "../utils/PermissionUtils";
 import { Utils } from "../context/shared/utils/Utils";
+import { RawPushSubscription } from "../models/RawPushSubscription";
+import SubscriptionHelper from "./SubscriptionHelper";
 
 export default class MainHelper {
 
@@ -228,8 +230,19 @@ export default class MainHelper {
     }
   }
 
-  static async createDeviceRecord(appId: string): Promise<PushDeviceRecord> {
-    const deviceRecord = new PushDeviceRecord();
+  static async createDeviceRecord(
+    appId: string, includeSubscription: boolean = false): Promise<PushDeviceRecord> {
+    let subscription: RawPushSubscription | undefined;
+    if (includeSubscription) {
+      // TODO: (iryna) refactor to replace with dependency injection
+      const rawSubscription = await SubscriptionHelper.getRawPushSubscription(
+        OneSignal.environmentInfo!, OneSignal.config.safariWebId
+      );
+      if (rawSubscription) {
+        subscription = rawSubscription;
+      }
+    }
+    const deviceRecord = new PushDeviceRecord(subscription);
     deviceRecord.appId = appId;
     deviceRecord.subscriptionState = await MainHelper.getCurrentNotificationType();
     return deviceRecord;

--- a/src/helpers/MainHelper.ts
+++ b/src/helpers/MainHelper.ts
@@ -234,7 +234,7 @@ export default class MainHelper {
     appId: string, includeSubscription: boolean = false): Promise<PushDeviceRecord> {
     let subscription: RawPushSubscription | undefined;
     if (includeSubscription) {
-      // TODO: (iryna) refactor to replace with dependency injection
+      // TODO: refactor to replace config with dependency injection
       const rawSubscription = await SubscriptionHelper.getRawPushSubscription(
         OneSignal.environmentInfo!, OneSignal.config.safariWebId
       );

--- a/src/helpers/ServiceWorkerHelper.ts
+++ b/src/helpers/ServiceWorkerHelper.ts
@@ -75,6 +75,7 @@ export default class ServiceWorkerHelper {
        * since player#create call updates last_session field on player.
        */
       if (sessionOrigin !== SessionOrigin.PlayerCreate) {
+        // TODO: (iryna) add notification id to on_session payload for direct session application
         const newPlayerId = await OneSignalApiSW.updateUserSession(deviceId, deviceRecord);
         // If the returned player id is different, save the new id to indexed db and update session
         if (newPlayerId !== deviceId) {

--- a/src/helpers/ServiceWorkerHelper.ts
+++ b/src/helpers/ServiceWorkerHelper.ts
@@ -6,18 +6,11 @@ import { InvalidStateError, InvalidStateReason } from "../errors/InvalidStateErr
 import { OneSignalUtils } from "../utils/OneSignalUtils";
 import Database from "../services/Database";
 import { SerializedPushDeviceRecord } from "../models/PushDeviceRecord";
+import PageServiceWorkerHelper from "./page/ServiceWorkerHelper";
 
 export default class ServiceWorkerHelper {
-  // Gets details on the service-worker (if any) that controls the current page
   public static async getRegistration(): Promise<ServiceWorkerRegistration | null | undefined> {
-    try {
-      // location.href is used for <base> tag compatibility when it is set to a different origin
-      return await navigator.serviceWorker.getRegistration(location.href);
-    } catch (e) {
-      // This could be null in an HTTP context or error if the user doesn't accept cookies
-      Log.warn("[Service Worker Status] Error Checking service worker registration", location.href, e);
-      return null;
-    }
+    return await PageServiceWorkerHelper.getRegistration();
   }
 
   public static getServiceWorkerHref(

--- a/src/helpers/SubscriptionHelper.ts
+++ b/src/helpers/SubscriptionHelper.ts
@@ -18,7 +18,6 @@ import { PushDeviceRecord } from "../models/PushDeviceRecord";
 import PageServiceWorkerHelper from "./page/ServiceWorkerHelper";
 import { EnvironmentInfo } from "../context/browser/models/EnvironmentInfo";
 import { Browser } from "../context/browser/models/Browser";
-import NotImplementedError from '../errors/NotImplementedError';
 
 export default class SubscriptionHelper {
   public static async registerForPush(): Promise<Subscription | null> {
@@ -176,7 +175,8 @@ export default class SubscriptionHelper {
   }
 
   static async getRawPushSubscriptionWhenUsingSubscriptionWorkaround(): Promise<RawPushSubscription | null> {
-    throw new NotImplementedError();
+    // we would need to message service worker to get it. we'll get it from inside if necessary
+    return null;
   }
 
   static async getRawPushSubscription(

--- a/src/helpers/page/ServiceWorkerHelper.ts
+++ b/src/helpers/page/ServiceWorkerHelper.ts
@@ -1,0 +1,15 @@
+import Log from "../../libraries/Log";
+
+export default class ServiceWorkerHelper {
+  // Gets details on the service-worker (if any) that controls the current page
+  static async getRegistration(): Promise<ServiceWorkerRegistration | null | undefined> {
+    try {
+      // location.href is used for <base> tag compatibility when it is set to a different origin
+      return await navigator.serviceWorker.getRegistration(location.href);
+    } catch (e) {
+      // This could be null in an HTTP context or error if the user doesn't accept cookies
+      Log.warn("[Service Worker Status] Error Checking service worker registration", location.href, e);
+      return null;
+    }
+  }
+}

--- a/src/helpers/shared/OutcomesHelper.ts
+++ b/src/helpers/shared/OutcomesHelper.ts
@@ -1,0 +1,77 @@
+import { OutcomesConfig, OutcomeAttribution, OutcomeAttributionType } from '../../models/Outcomes';
+import { NotificationClicked, NotificationReceived } from '../../models/Notification';
+import Database from "../../services/Database";
+import Log from "../../libraries/Log";
+import { Utils } from "../../context/shared/utils/Utils";
+
+export default class OutcomesHelper {
+  static async getAttribution(outcomesConfig: OutcomesConfig): Promise<OutcomeAttribution> {
+    /**
+     * Flow:
+     * 1. check if the url was opened as a result of a notif;
+     * 2. if so, send an api call reporting direct notification outcome
+     *    (currently takes into account the match strategy selected in the app's settings);
+     * 3. else check all received notifs within timeframe from config;
+     * 4. send an api call reporting an influenced outcome for each matching notification
+     *    respecting the limit from config too;
+     * 5. if no influencing notification found, report unattributed outcome to the api.
+     */
+
+    /* direct notifications */
+    if (outcomesConfig.direct && outcomesConfig.direct.enabled) {
+      const clickedNotifications = await Database.getAll<NotificationClicked>("NotificationClicked");
+      if (clickedNotifications.length > 0) {
+        return {
+          type: OutcomeAttributionType.Direct,
+          notificationIds: [clickedNotifications[0].notificationId],
+        }
+      }
+    }
+
+    /* influencing notifications */
+    if (outcomesConfig.indirect && outcomesConfig.indirect.enabled) {
+      const timeframeMs = outcomesConfig.indirect.influencedTimePeriodMin * 60 * 1000;
+      const beginningOfTimeframe = new Date(new Date().getTime() - timeframeMs);
+      const maxTimestamp = beginningOfTimeframe.getTime();
+
+      const matchingNotifications = await Database.getAll<NotificationReceived>("NotificationReceived");
+      Log.debug(`Found total of ${matchingNotifications.length} received notifications`);
+
+      if (matchingNotifications.length > 0) {
+        const max: number = outcomesConfig.indirect.influencedNotificationsLimit;
+        /**
+         * To handle correctly the case when user got subscribed to a new app id
+         * we check the appId on notifications to match the current app.
+         */
+
+        const sortedArray = Utils.sortArrayOfObjects(
+          matchingNotifications, (notif: NotificationReceived) => notif.timestamp, true, false
+        );
+        const notificationIds = sortedArray
+          .filter(notif => notif.timestamp >= maxTimestamp)
+          .slice(0, max)
+          .map(notif => notif.notificationId);
+        Log.debug(`Total of ${notificationIds.length} received notifications are within reporting window`);
+        if (notificationIds.length > 0) {
+          return {
+            type: OutcomeAttributionType.Indirect,
+            notificationIds,
+          }
+        }
+      }
+    }
+
+    /* unattributed outcome report */
+    if (outcomesConfig.unattributed && outcomesConfig.unattributed.enabled) {
+      return {
+        type: OutcomeAttributionType.Unattributed,
+        notificationIds: [],
+      }
+    }
+
+    return {
+      type: OutcomeAttributionType.NotSupported,
+      notificationIds: [],
+    };
+  }
+}

--- a/src/helpers/sw/CancelableTimeout.ts
+++ b/src/helpers/sw/CancelableTimeout.ts
@@ -35,7 +35,7 @@ export function cancelableTimeout(callback: () => Promise<void>, delayInSeconds:
       Log.debug("Cancel called");
       self.clearTimeout(timerId); 
       if (!startedExecution) {
-        reject();
+        resolve();
       }
     }
   });

--- a/src/helpers/sw/CancelableTimeout.ts
+++ b/src/helpers/sw/CancelableTimeout.ts
@@ -1,0 +1,55 @@
+import Log from "../../libraries/Log";
+
+export interface CancelableTimeoutPromise {
+  cancel: () => void;
+  promise: Promise<void>;
+}
+
+const doNothing = () => {
+  Log.debug("Do nothing");
+};
+
+export function cancelableTimeout(callback: () => Promise<void>, delayInSeconds: number): CancelableTimeoutPromise {
+  const delayInMilliseconds = delayInSeconds * 1000;
+
+  let timerId: number | undefined;
+  let clearTimeoutHandle: (() => void) | undefined = undefined;
+
+  const promise = new Promise<void>((resolve, reject) => {
+    let startedExecution: boolean = false;
+
+    timerId = self.setTimeout(
+      async () => {
+        startedExecution = true;
+        try {
+          await callback();
+          resolve();
+        } catch(e) {
+          Log.error("Failed to execute callback", e);
+          reject();
+        }
+      }, 
+      delayInMilliseconds);
+    
+    clearTimeoutHandle = () => {
+      Log.debug("Cancel called");
+      self.clearTimeout(timerId); 
+      if (!startedExecution) {
+        reject();
+      }
+    }
+  });
+
+  if (!clearTimeoutHandle) {
+    Log.warn("clearTimeoutHandle was not assigned.");
+    return {
+      promise,
+      cancel: doNothing,
+    }
+  }
+
+  return {
+    promise,
+    cancel: clearTimeoutHandle,
+  }
+}

--- a/src/managers/SdkEnvironment.ts
+++ b/src/managers/SdkEnvironment.ts
@@ -11,6 +11,7 @@ const RESOURCE_HTTP_PORT = 4000;
 const RESOURCE_HTTPS_PORT = 4001;
 const API_URL_PORT = 3001;
 const TURBINE_API_URL_PORT = 18080;
+const TURBINE_ENDPOINTS = ["outcomes", "on_focus"];
 
 declare var self: ServiceWorkerGlobalScope | undefined;
 
@@ -267,7 +268,7 @@ export default class SdkEnvironment {
 
     switch (buildEnv) {
       case EnvironmentKind.Development:
-        if (action && action.indexOf("outcomes") > -1) {
+        if (SdkEnvironment.isTurbineEndpoint(action)) {
           return new URL(`https://${apiOrigin}:${TURBINE_API_URL_PORT}/api/v1`);
         }
         return new URL(`https://${apiOrigin}:${API_URL_PORT}/api/v1`);
@@ -317,5 +318,11 @@ export default class SdkEnvironment {
       default:
         throw new InvalidArgumentError('buildEnv', InvalidArgumentReason.EnumOutOfRange);
     }
+  }
+
+  static isTurbineEndpoint(action?: string): boolean {
+    if (!action) { return false; }
+
+    return TURBINE_ENDPOINTS.some(turbine_endpoint => action.indexOf(turbine_endpoint) > -1);
   }
 }

--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -414,8 +414,6 @@ export class ServiceWorkerManager {
     const isHttps = OneSignalUtils.isHttps();
     const isSafari = OneSignalUtils.isSafari();
 
-    // TODO: fix types. Seems like it's "{data: {payload: PageVisibilityRequest;}}" for https
-    //       and "PageVisibilityRequest" for http
     workerMessenger.on(WorkerMessengerCommand.AreYouVisible, (incomingPayload: PageVisibilityRequest) => {
       // For https sites in Chrome and Firefox service worker (SW) can get correct value directly.
       // For Safari, unfortunately, we need this messaging workaround because SW always gets false.

--- a/src/managers/SessionManager.ts
+++ b/src/managers/SessionManager.ts
@@ -92,6 +92,12 @@ export class SessionManager {
       }
 
       // TODO: (iryna) need to send deactivate from here?
+      const [deviceId, deviceRecord] = await Promise.all([
+        MainHelper.getDeviceId(),
+        MainHelper.createDeviceRecord(this.context.appConfig.appId)
+      ]);
+  
+      await this.notifySWToDeactivateSession(deviceId, deviceRecord, SessionOrigin.VisibilityHidden);
       return;
     }
 

--- a/src/managers/SessionManager.ts
+++ b/src/managers/SessionManager.ts
@@ -188,7 +188,10 @@ export class SessionManager {
   ): Promise<void> {
     const sessionPromise = this.notifySWToUpsertSession(deviceId, deviceRecord, sessionOrigin);
 
-    if (OneSignalUtils.isHttps()) {
+    if (
+      this.context.environmentInfo.isBrowserAndSupportsServiceWorkers ||
+      this.context.environmentInfo.isUsingSubscriptionWorkaround
+    ) {
       this.setupSessionEventListeners();
     } else if (
       !this.context.environmentInfo.isBrowserAndSupportsServiceWorkers &&
@@ -202,6 +205,15 @@ export class SessionManager {
   }
 
   setupSessionEventListeners(): void {
+    // Only want these events if it's using subscription workaround
+    if (
+      !this.context.environmentInfo.isBrowserAndSupportsServiceWorkers &&
+      !this.context.environmentInfo.isUsingSubscriptionWorkaround
+    ) {
+      Log.debug("Not setting session event listeners. No SW possible.");
+      return;
+    }
+
     // Page lifecycle events https://developers.google.com/web/updates/2018/07/page-lifecycle-api
 
     this.setupOnFocusAndOnBlurForSession();

--- a/src/managers/SessionManager.ts
+++ b/src/managers/SessionManager.ts
@@ -1,15 +1,19 @@
-import { ContextSWInterface } from "../models/ContextSW";
+import { ContextInterface } from "../models/Context";
 import { PushDeviceRecord } from "../models/PushDeviceRecord";
 import { UpsertSessionPayload, DeactivateSessionPayload, SessionOrigin } from "../models/Session";
 import MainHelper from "../helpers/MainHelper";
 import Log from "../libraries/Log";
 import { WorkerMessengerCommand } from "../libraries/WorkerMessenger";
 import { OneSignalUtils } from "../utils/OneSignalUtils";
+import { SubscriptionStateKind } from "../models/SubscriptionStateKind";
+import OneSignalApiShared from "../OneSignalApiShared";
+import Database from "../services/Database";
 
 export class SessionManager {
-  private context: ContextSWInterface;
+  private context: ContextInterface;
+  private onSessionSent: boolean = false;
 
-  constructor(context: ContextSWInterface) {
+  constructor(context: ContextInterface) {
     this.context = context;
   }
 
@@ -30,12 +34,18 @@ export class SessionManager {
       isSafari: OneSignalUtils.isSafari(),
       outcomesConfig: this.context.appConfig.userConfig.outcomes!,
     };
-    if (isHttps) {
+    if (
+      this.context.environmentInfo.isBrowserAndSupportsServiceWorkers &&
+        !this.context.environmentInfo.isUsingSubscriptionWorkaround
+    ) {
       Log.debug("Notify SW to upsert session");
       await this.context.workerMessenger.unicast(WorkerMessengerCommand.SessionUpsert, payload);
-    } else {
+    } else if (this.context.environmentInfo.isUsingSubscriptionWorkaround) {
       Log.debug("Notify iframe to notify SW to upsert session");
       await OneSignal.proxyFrameHost.runCommand(OneSignal.POSTMAM_COMMANDS.SESSION_UPSERT, payload);
+    } else { // http w/o our iframe
+      // we probably shouldn't even be here
+      Log.debug("Notify upsert: do nothing");
     }
   }
 
@@ -55,12 +65,18 @@ export class SessionManager {
       isSafari: OneSignalUtils.isSafari(),
       outcomesConfig: this.context.appConfig.userConfig.outcomes!,
     };
-    if (isHttps) {
+    if (
+      this.context.environmentInfo.isBrowserAndSupportsServiceWorkers &&
+        !this.context.environmentInfo.isUsingSubscriptionWorkaround
+    ) {
       Log.debug("Notify SW to deactivate session");
       await this.context.workerMessenger.unicast(WorkerMessengerCommand.SessionDeactivate, payload);
-    } else {
+    } else if (this.context.environmentInfo.isUsingSubscriptionWorkaround) {
       Log.debug("Notify SW to deactivate session");
       await OneSignal.proxyFrameHost.runCommand(OneSignal.POSTMAM_COMMANDS.SESSION_DEACTIVATE, payload);
+    } else { // http w/o our iframe
+      // we probably shouldn't even be here
+      Log.debug("Notify deactivate: do nothing");
     }
   }
 
@@ -174,7 +190,11 @@ export class SessionManager {
 
     if (OneSignalUtils.isHttps()) {
       this.setupSessionEventListeners();
-    } else {
+    } else if (
+      !this.context.environmentInfo.isBrowserAndSupportsServiceWorkers &&
+      !this.context.environmentInfo.isUsingSubscriptionWorkaround
+    ) {
+      this.onSessionSent = sessionOrigin === SessionOrigin.PlayerCreate;
       OneSignal.emitter.emit(OneSignal.EVENTS.SESSION_STARTED);
     }
 
@@ -231,5 +251,46 @@ export class SessionManager {
     }
 
     OneSignal.context.sessionManager.setupSessionEventListeners();
+  }
+
+  // If user has been subscribed before, send the on_session update to our backend on the first page view.
+  async sendOnSessionUpdateFromPage(deviceRecord?: PushDeviceRecord): Promise<void> {
+    if (this.onSessionSent) {
+      return;
+    }
+
+    if (!this.context.pageViewManager.isFirstPageView()) {
+      return;
+    }
+
+    const existingUser = await this.context.subscriptionManager.isAlreadyRegisteredWithOneSignal();
+    if (!existingUser) {
+      Log.debug("Not sending the on session because user is not registered with OneSignal (no device id)");
+      return;
+    }
+
+    const deviceId = await MainHelper.getDeviceId();
+    if (!deviceRecord) {
+      deviceRecord = await MainHelper.createDeviceRecord(this.context.appConfig.appId);
+    }
+
+    if (deviceRecord.subscriptionState !== SubscriptionStateKind.Subscribed &&
+      OneSignal.config.enableOnSession !== true) {
+      return;
+    }
+
+    try {
+      const newPlayerId = await OneSignalApiShared.updateUserSession(deviceId!, deviceRecord);
+      this.onSessionSent = true;
+
+      // If the returned player id is different, save the new id.
+      if (newPlayerId !== deviceId) {
+        const subscription = await Database.getSubscription();
+        subscription.deviceId = newPlayerId;
+        await Database.setSubscription(subscription);
+      }
+    } catch(e) {
+      Log.error(`Failed to update user session. Error "${e.message}" ${e.stack}`);
+    }
   }
 }

--- a/src/managers/SessionManager.ts
+++ b/src/managers/SessionManager.ts
@@ -23,11 +23,12 @@ export class SessionManager {
     const payload: UpsertSessionPayload = {
       deviceId,
       deviceRecord: deviceRecord.serialize(),
-      sessionThreshold: OneSignal.config.sessionThreshold,
-      enableSessionDuration: OneSignal.config.enableSessionDuration,
+      sessionThreshold: this.context.appConfig.sessionThreshold || 0,
+      enableSessionDuration: !!this.context.appConfig.enableSessionDuration,
       sessionOrigin,
       isHttps,
       isSafari: OneSignalUtils.isSafari(),
+      outcomesConfig: this.context.appConfig.userConfig.outcomes!,
     };
     if (isHttps) {
       Log.debug("Notify SW to upsert session");
@@ -47,11 +48,12 @@ export class SessionManager {
     const payload: DeactivateSessionPayload = {
       deviceId,
       deviceRecord: deviceRecord ? deviceRecord.serialize() : undefined,
-      sessionThreshold: OneSignal.config.sessionThreshold,
-      enableSessionDuration: OneSignal.config.enableSessionDuration,
+      sessionThreshold: this.context.appConfig.sessionThreshold!,
+      enableSessionDuration: this.context.appConfig.enableSessionDuration!,
       sessionOrigin,
       isHttps,
       isSafari: OneSignalUtils.isSafari(),
+      outcomesConfig: this.context.appConfig.userConfig.outcomes!,
     };
     if (isHttps) {
       Log.debug("Notify SW to deactivate session");
@@ -110,11 +112,12 @@ export class SessionManager {
     // have to skip adding device record to the payload
     const isHttps = OneSignalUtils.isHttps();
     const payload: DeactivateSessionPayload = {
-      sessionThreshold: OneSignal.config.sessionThreshold,
-      enableSessionDuration: OneSignal.config.enableSessionDuration,
+      sessionThreshold: this.context.appConfig.sessionThreshold!,
+      enableSessionDuration: this.context.appConfig.enableSessionDuration!,
       sessionOrigin: SessionOrigin.BeforeUnload,
       isHttps,
       isSafari: OneSignalUtils.isSafari(),
+      outcomesConfig: this.context.appConfig.userConfig.outcomes!,
     };
 
     if (isHttps) {

--- a/src/managers/SessionManager.ts
+++ b/src/managers/SessionManager.ts
@@ -67,7 +67,7 @@ export class SessionManager {
 
     const [deviceId, deviceRecord] = await Promise.all([
       MainHelper.getDeviceId(),
-      MainHelper.createDeviceRecord(this.context.appConfig.appId)
+      MainHelper.createDeviceRecord(this.context.appConfig.appId, true)
     ]);
 
     if (visibilityState === "visible") {
@@ -81,6 +81,7 @@ export class SessionManager {
     }
 
     if (visibilityState === "hidden") {
+      Log.debug("handleVisibilityChange", "hidden");
       if (OneSignal.cache.focusHandler && OneSignal.cache.isFocusEventSetup) {
         window.removeEventListener("focus", OneSignal.cache.focusHandler, true);
         OneSignal.cache.isFocusEventSetup = false;
@@ -89,6 +90,8 @@ export class SessionManager {
         window.removeEventListener("blur", OneSignal.cache.blurHandler, true);
         OneSignal.cache.isBlurEventSetup = false;
       }
+
+      // TODO: (iryna) need to send deactivate from here?
       return;
     }
 
@@ -129,7 +132,7 @@ export class SessionManager {
     }
     const [deviceId, deviceRecord] = await Promise.all([
       MainHelper.getDeviceId(),
-      MainHelper.createDeviceRecord(this.context.appConfig.appId)
+      MainHelper.createDeviceRecord(this.context.appConfig.appId, true)
     ]);
 
     await this.notifySWToUpsertSession(deviceId, deviceRecord, SessionOrigin.Focus);

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -583,7 +583,10 @@ export class SubscriptionManager {
         //    to change the applicationServerKey, unsubscribe then resubscribe.
         Log.warn("[Subscription Manager] Couldn't re-subscribe due to applicationServerKey changing, " +
           "unsubscribe and attempting to subscribe with new key.", e);
-        await SubscriptionManager.doPushUnsubscribe(await pushManager.getSubscription());
+        const subscription = await pushManager.getSubscription();
+        if (subscription) {
+          await SubscriptionManager.doPushUnsubscribe(subscription);
+        }
         return [await pushManager.subscribe(subscriptionOptions), true];
       }
       else

--- a/src/managers/UpdateManager.ts
+++ b/src/managers/UpdateManager.ts
@@ -125,7 +125,7 @@ export class UpdateManager {
       app_id: appId,
       id: outcomeName,
       device_type: deviceRecord.deliveryPlatform,
-      notification_id: notificationId,
+      notification_ids: [notificationId],
       direct: true,
     }
     if (value !== undefined) {
@@ -134,13 +134,13 @@ export class UpdateManager {
     await OneSignalApiShared.sendOutcome(outcomeRequestData);
   }
 
-  public async sendOutcomeInfluenced(appId: string, notificationId: string, outcomeName: string, value?: number) {
+  public async sendOutcomeInfluenced(appId: string, notificationIds: string[], outcomeName: string, value?: number) {
     const deviceRecord = await this.createDeviceRecord();
     const outcomeRequestData: OutcomeRequestData = {
       app_id: appId,
       id: outcomeName,
       device_type: deviceRecord.deliveryPlatform,
-      notification_id: notificationId,
+      notification_ids: notificationIds,
       direct: false,
     }
     if (value !== undefined) {

--- a/src/managers/UpdateManager.ts
+++ b/src/managers/UpdateManager.ts
@@ -119,13 +119,13 @@ export class UpdateManager {
     });
   }
 
-  public async sendOutcomeDirect(appId: string, notificationId: string, outcomeName: string, value?: number) {
+  public async sendOutcomeDirect(appId: string, notificationIds: string[], outcomeName: string, value?: number) {
     const deviceRecord = await this.createDeviceRecord();
     const outcomeRequestData: OutcomeRequestData = {
       app_id: appId,
       id: outcomeName,
       device_type: deviceRecord.deliveryPlatform,
-      notification_ids: [notificationId],
+      notification_ids: notificationIds,
       direct: true,
     }
     if (value !== undefined) {

--- a/src/managers/UpdateManager.ts
+++ b/src/managers/UpdateManager.ts
@@ -120,42 +120,44 @@ export class UpdateManager {
   }
 
   public async sendOutcomeDirect(appId: string, notificationId: string, outcomeName: string, value?: number) {
+    const deviceRecord = await this.createDeviceRecord();
     const outcomeRequestData: OutcomeRequestData = {
       app_id: appId,
-      outcome_id: outcomeName,
-      device_type: 3, // TODO: where do I get device_type from?
-      id: notificationId,
+      id: outcomeName,
+      device_type: deviceRecord.deliveryPlatform,
+      notification_id: notificationId,
       direct: true,
     }
     if (value !== undefined) {
-      outcomeRequestData.value = value;
+      outcomeRequestData.weight = value;
     }
     await OneSignalApiShared.sendOutcome(outcomeRequestData);
   }
 
   public async sendOutcomeInfluenced(appId: string, notificationId: string, outcomeName: string, value?: number) {
+    const deviceRecord = await this.createDeviceRecord();
     const outcomeRequestData: OutcomeRequestData = {
       app_id: appId,
-      outcome_id: outcomeName,
-      id: notificationId,
-      device_type: 3, // TODO: where do I get device_type from?
+      id: outcomeName,
+      device_type: deviceRecord.deliveryPlatform,
+      notification_id: notificationId,
       direct: false,
     }
     if (value !== undefined) {
-      outcomeRequestData.value = value;
+      outcomeRequestData.weight = value;
     }
     await OneSignalApiShared.sendOutcome(outcomeRequestData);
   }
 
   public async sendOutcomeUnattributed(appId: string, outcomeName: string, value?: number) {
+    const deviceRecord = await this.createDeviceRecord();
     const outcomeRequestData: OutcomeRequestData = {
       app_id: appId,
-      outcome_id: outcomeName,
-      device_type: 3, // TODO: where do I get device_type from?
-      direct: true,
+      id: outcomeName,
+      device_type: deviceRecord.deliveryPlatform,
     }
     if (value !== undefined) {
-      outcomeRequestData.value = value;
+      outcomeRequestData.weight = value;
     }
     await OneSignalApiShared.sendOutcome(outcomeRequestData);
   }

--- a/src/managers/sessionManager/page/SessionManager.ts
+++ b/src/managers/sessionManager/page/SessionManager.ts
@@ -1,15 +1,16 @@
-import { ContextInterface } from "../models/Context";
-import { PushDeviceRecord } from "../models/PushDeviceRecord";
-import { UpsertSessionPayload, DeactivateSessionPayload, SessionOrigin } from "../models/Session";
-import MainHelper from "../helpers/MainHelper";
-import Log from "../libraries/Log";
-import { WorkerMessengerCommand } from "../libraries/WorkerMessenger";
-import { OneSignalUtils } from "../utils/OneSignalUtils";
-import { SubscriptionStateKind } from "../models/SubscriptionStateKind";
-import OneSignalApiShared from "../OneSignalApiShared";
-import Database from "../services/Database";
+import { ContextInterface } from "../../../models/Context";
+import { PushDeviceRecord } from "../../../models/PushDeviceRecord";
+import { UpsertSessionPayload, DeactivateSessionPayload, SessionOrigin } from "../../../models/Session";
+import MainHelper from "../../../helpers/MainHelper";
+import Log from "../../../libraries/Log";
+import { WorkerMessengerCommand } from "../../../libraries/WorkerMessenger";
+import { OneSignalUtils } from "../../../utils/OneSignalUtils";
+import { SubscriptionStateKind } from "../../../models/SubscriptionStateKind";
+import OneSignalApiShared from "../../../OneSignalApiShared";
+import Database from "../../../services/Database";
+import { ISessionManager } from "../types";
 
-export class SessionManager {
+export class SessionManager implements ISessionManager {
   private context: ContextInterface;
   private onSessionSent: boolean = false;
 

--- a/src/managers/sessionManager/sw/SessionManager.ts
+++ b/src/managers/sessionManager/sw/SessionManager.ts
@@ -1,0 +1,16 @@
+import { ContextSWInterface } from "../../../models/ContextSW";
+import { PushDeviceRecord } from "../../../models/PushDeviceRecord";
+import { SessionOrigin } from "../../../models/Session";
+import { ISessionManager } from "../types";
+
+export class SessionManager implements ISessionManager {
+  constructor(_context: ContextSWInterface) { }
+
+  async upsertSession(
+    _deviceId: string,
+    _deviceRecord: PushDeviceRecord,
+    _sessionOrigin: SessionOrigin
+  ): Promise<void> {
+    // TODO: how should it be implemented if called from inside of service worker???
+  }
+}

--- a/src/managers/sessionManager/types.ts
+++ b/src/managers/sessionManager/types.ts
@@ -1,0 +1,6 @@
+import { PushDeviceRecord } from "../../models/PushDeviceRecord";
+import { SessionOrigin } from "../../models/Session";
+
+export interface ISessionManager {
+  upsertSession: (deviceId: string, deviceRecord: PushDeviceRecord, sessionOrigin: SessionOrigin) => Promise<void>;
+}

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -1,3 +1,5 @@
+import { OutcomesConfig } from "./Outcomes";
+
 export interface AppConfig {
   /**
    * The OneSignal dashboard app ID. Although this value is provided, it isn't
@@ -102,20 +104,6 @@ export interface AppUserConfig {
   requiresUserPrivacyConsent?: boolean;
   pageUrl?: string;
   outcomes?: OutcomesConfig;
-}
-
-export interface OutcomesConfig {
-  direct: {
-    enabled: boolean;
-  }
-  indirect: {
-    enabled: boolean;
-    influencedTimePeriodMin: number;
-    influencedNotificationsLimit: number;
-  }
-  unattributed: {
-    enabled: boolean;
-  }
 }
 
 interface BasePromptOptions {

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -101,6 +101,21 @@ export interface AppUserConfig {
   allowLocalhostAsSecureOrigin?: boolean;
   requiresUserPrivacyConsent?: boolean;
   pageUrl?: string;
+  outcomes?: OutcomesConfig;
+}
+
+export interface OutcomesConfig {
+  direct: {
+    enabled: boolean;
+  }
+  indirect: {
+    enabled: boolean;
+    influencedTimePeriodMin: number;
+    influencedNotificationsLimit: number;
+  }
+  unattributed: {
+    enabled: boolean;
+  }
 }
 
 interface BasePromptOptions {
@@ -373,10 +388,7 @@ export interface ServerAppConfig {
         persist: boolean;
       };
     };
-    outcomes: {
-      influencedTimePeriodMin: number;
-      influencedNotificationsLimit: number;
-    },
+    outcomes: OutcomesConfig,
     vapid_public_key: string;
     onesignal_vapid_public_key: string;
     http_use_onesignal_com?: boolean;

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -1,4 +1,4 @@
-import { OutcomesConfig } from "./Outcomes";
+import { OutcomesConfig, OutcomesServerConfig } from "./Outcomes";
 
 export interface AppConfig {
   /**
@@ -322,7 +322,8 @@ export interface ServerAppConfig {
     };
     enable_on_session?: boolean;
     receive_receipts_enable?: boolean;
-    enableSessionDuration: boolean;
+    web_on_focus_enabled: boolean;
+    session_threshold: number;
   };
   config: {
     /**
@@ -332,7 +333,6 @@ export interface ServerAppConfig {
     origin: string;
     staticPrompts: ServerAppConfigPrompt;
     autoResubscribe: boolean;
-    sessionThreshold: number;
     siteInfo: {
       name: string;
       origin: string;
@@ -376,7 +376,7 @@ export interface ServerAppConfig {
         persist: boolean;
       };
     };
-    outcomes: OutcomesConfig,
+    outcomes: OutcomesServerConfig,
     vapid_public_key: string;
     onesignal_vapid_public_key: string;
     http_use_onesignal_com?: boolean;

--- a/src/models/Context.ts
+++ b/src/models/Context.ts
@@ -19,12 +19,12 @@ export interface ContextInterface extends ContextSWInterface {
   dynamicResourceLoader: DynamicResourceLoader;
   cookieSyncer: CookieSyncer;
   metricsManager: MetricsManager;
-  environmentInfo: EnvironmentInfo;
+  environmentInfo?: EnvironmentInfo;
 }
 
 export default class Context implements ContextInterface {
   public appConfig: AppConfig;
-  public environmentInfo: EnvironmentInfo;
+  public environmentInfo?: EnvironmentInfo;
   public dynamicResourceLoader: DynamicResourceLoader;
   public subscriptionManager: SubscriptionManager;
   public serviceWorkerManager: ServiceWorkerManager;
@@ -39,7 +39,9 @@ export default class Context implements ContextInterface {
 
   constructor(appConfig: AppConfig) {
     this.appConfig = appConfig;
-    this.environmentInfo = OneSignal.environmentInfo;
+    if (typeof OneSignal !== "undefined" && !!OneSignal.environmentInfo) {
+      this.environmentInfo = OneSignal.environmentInfo;
+    }
     this.subscriptionManager = ContextHelper.getSubscriptionManager(this);
     this.serviceWorkerManager = ContextHelper.getServiceWorkerManager(this);
     this.pageViewManager = new PageViewManager();

--- a/src/models/Context.ts
+++ b/src/models/Context.ts
@@ -11,7 +11,8 @@ import { ContextSWInterface } from "./ContextSW";
 import ContextHelper from "../helpers/ContextHelper";
 import { UpdateManager } from "../managers/UpdateManager";
 import { PromptsManager } from "../managers/PromptsManager";
-import { SessionManager } from "../managers/SessionManager";
+import { ISessionManager } from "../managers/sessionManager/types";
+import { SessionManager } from "../managers/sessionManager/page/SessionManager";
 import { EnvironmentInfo } from "../context/browser/models/EnvironmentInfo";
 
 export interface ContextInterface extends ContextSWInterface {
@@ -34,7 +35,7 @@ export default class Context implements ContextInterface {
   public metricsManager: MetricsManager;
   public updateManager: UpdateManager;
   public promptsManager: PromptsManager;
-  public sessionManager: SessionManager;
+  public sessionManager: ISessionManager;
 
   constructor(appConfig: AppConfig) {
     this.appConfig = appConfig;

--- a/src/models/Context.ts
+++ b/src/models/Context.ts
@@ -12,15 +12,18 @@ import ContextHelper from "../helpers/ContextHelper";
 import { UpdateManager } from "../managers/UpdateManager";
 import { PromptsManager } from "../managers/PromptsManager";
 import { SessionManager } from "../managers/SessionManager";
+import { EnvironmentInfo } from "../context/browser/models/EnvironmentInfo";
 
 export interface ContextInterface extends ContextSWInterface {
   dynamicResourceLoader: DynamicResourceLoader;
   cookieSyncer: CookieSyncer;
   metricsManager: MetricsManager;
+  environmentInfo: EnvironmentInfo;
 }
 
 export default class Context implements ContextInterface {
   public appConfig: AppConfig;
+  public environmentInfo: EnvironmentInfo;
   public dynamicResourceLoader: DynamicResourceLoader;
   public subscriptionManager: SubscriptionManager;
   public serviceWorkerManager: ServiceWorkerManager;
@@ -35,6 +38,7 @@ export default class Context implements ContextInterface {
 
   constructor(appConfig: AppConfig) {
     this.appConfig = appConfig;
+    this.environmentInfo = OneSignal.environmentInfo;
     this.subscriptionManager = ContextHelper.getSubscriptionManager(this);
     this.serviceWorkerManager = ContextHelper.getServiceWorkerManager(this);
     this.pageViewManager = new PageViewManager();

--- a/src/models/ContextSW.ts
+++ b/src/models/ContextSW.ts
@@ -6,7 +6,8 @@ import { PageViewManager } from '../managers/PageViewManager';
 import PermissionManager from '../managers/PermissionManager';
 import ContextHelper from "../helpers/ContextHelper";
 import { UpdateManager } from "../managers/UpdateManager";
-import { SessionManager } from '../managers/SessionManager';
+import { ISessionManager } from "../managers/sessionManager/types";
+import { SessionManager } from "../managers/sessionManager/sw/SessionManager";
 
 
 // TODO: Ideally this file should only import classes used by ServiceWorker.ts.
@@ -18,7 +19,7 @@ export interface ContextSWInterface {
   subscriptionManager: SubscriptionManager;
   serviceWorkerManager: ServiceWorkerManager;
   pageViewManager: PageViewManager;
-  sessionManager: SessionManager;
+  sessionManager: ISessionManager;
   permissionManager: PermissionManager;
   workerMessenger: WorkerMessenger;
   updateManager: UpdateManager;
@@ -29,7 +30,7 @@ export default class ContextSW implements ContextSWInterface {
   public subscriptionManager: SubscriptionManager;
   public serviceWorkerManager: ServiceWorkerManager;
   public pageViewManager: PageViewManager;
-  public sessionManager: SessionManager;
+  public sessionManager: ISessionManager;
   public permissionManager: PermissionManager;
   public workerMessenger: WorkerMessenger;
   public updateManager: UpdateManager;

--- a/src/models/Notification.ts
+++ b/src/models/Notification.ts
@@ -80,12 +80,12 @@ export interface NotificationReceived {
     notificationId: string;
     appId: string;
     url: string;
-    timestamp: string;
+    timestamp: number;
 }
 
 export interface NotificationClicked {
     notificationId: string;
     appId: string;
     url: string;
-    timestamp: string;
+    timestamp: number;
 }

--- a/src/models/Notification.ts
+++ b/src/models/Notification.ts
@@ -78,7 +78,7 @@ export class Notification {
 
 export interface NotificationReceived {
     notificationId: string;
-    // appId: string;
+    appId: string;
     url: string;
     timestamp: string;
     sent: boolean;
@@ -86,7 +86,7 @@ export interface NotificationReceived {
 
 export interface NotificationClicked {
     notificationId: string;
-    // appId: string;
+    appId: string;
     url: string;
     timestamp: string;
     sent: boolean;

--- a/src/models/Notification.ts
+++ b/src/models/Notification.ts
@@ -81,7 +81,6 @@ export interface NotificationReceived {
     appId: string;
     url: string;
     timestamp: string;
-    sent: boolean;
 }
 
 export interface NotificationClicked {
@@ -89,5 +88,4 @@ export interface NotificationClicked {
     appId: string;
     url: string;
     timestamp: string;
-    sent: boolean;
 }

--- a/src/models/OutcomeRequestData.ts
+++ b/src/models/OutcomeRequestData.ts
@@ -3,6 +3,6 @@ export interface OutcomeRequestData {
   id: string;
   device_type: number;
   direct?: boolean;
-  notification_id?: string;
+  notification_ids?: string[];
   weight?: number;
 }

--- a/src/models/OutcomeRequestData.ts
+++ b/src/models/OutcomeRequestData.ts
@@ -1,8 +1,8 @@
 export interface OutcomeRequestData {
   app_id: string;
-  outcome_id: string;
+  id: string;
   device_type: number;
   direct?: boolean;
-  id?: string;
-  value?: number;
+  notification_id?: string;
+  weight?: number;
 }

--- a/src/models/Outcomes.ts
+++ b/src/models/Outcomes.ts
@@ -1,3 +1,19 @@
+export interface OutcomesServerConfig {
+  direct: {
+    enabled: boolean;
+  }
+  indirect: {
+    enabled: boolean;
+    notification_attribution: {
+      minutes_since_displayed: number;
+      limit: number;
+    }
+  }
+  unattributed: {
+    enabled: boolean;
+  }
+}
+
 export interface OutcomesConfig {
   direct: {
     enabled: boolean;

--- a/src/models/Outcomes.ts
+++ b/src/models/Outcomes.ts
@@ -1,0 +1,13 @@
+export interface OutcomesConfig {
+  direct: {
+    enabled: boolean;
+  }
+  indirect: {
+    enabled: boolean;
+    influencedTimePeriodMin: number;
+    influencedNotificationsLimit: number;
+  }
+  unattributed: {
+    enabled: boolean;
+  }
+}

--- a/src/models/Outcomes.ts
+++ b/src/models/Outcomes.ts
@@ -11,3 +11,15 @@ export interface OutcomesConfig {
     enabled: boolean;
   }
 }
+
+export enum OutcomeAttributionType {
+  Direct = 1,
+  Indirect = 2,
+  Unattributed = 3,
+  NotSupported = 4,
+}
+
+export interface OutcomeAttribution {
+  type: OutcomeAttributionType;
+  notificationIds: string[];
+}

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -51,6 +51,14 @@ export interface DeactivateSessionPayload extends BaseSessionPayload {
   deviceRecord?: SerializedPushDeviceRecord;
 }
 
+export interface PageVisibilityRequest {
+  timestamp: number;
+}
+
+export interface PageVisibilityResponse extends PageVisibilityRequest {
+  focused: boolean;
+}
+
 export const ONESIGNAL_SESSION_KEY = "oneSignalSession";
 
 export function initializeNewSession(options: NewSessionOptions): Session {

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -1,4 +1,5 @@
-import { SerializedPushDeviceRecord } from "../models/PushDeviceRecord";
+import { SerializedPushDeviceRecord } from "./PushDeviceRecord";
+import { OutcomesConfig } from "./Outcomes";
 
 export enum SessionStatus {
   Active = "active",
@@ -39,6 +40,7 @@ interface BaseSessionPayload {
   sessionOrigin: SessionOrigin;
   isHttps: boolean;
   isSafari: boolean;
+  outcomesConfig: OutcomesConfig;
 }
 
 export interface UpsertSessionPayload extends BaseSessionPayload {

--- a/src/modules/frames/ProxyFrame.ts
+++ b/src/modules/frames/ProxyFrame.ts
@@ -151,7 +151,6 @@ export default class ProxyFrame extends RemoteFrame {
 
   async onRemoteDatabaseGetAll(message: MessengerMessageEvent) {
     const table: OneSignalDbTable = message.data.table;
-    console.log("onRemoteDatabaseGetAll", table);
     const results = await Database.getAll(table);
     
     message.reply(results);

--- a/src/modules/frames/ProxyFrame.ts
+++ b/src/modules/frames/ProxyFrame.ts
@@ -9,9 +9,10 @@ import { unsubscribeFromPush } from '../../utils';
 import RemoteFrame from './RemoteFrame';
 import Context from '../../models/Context';
 import Log from '../../libraries/Log';
-import { UpsertSessionPayload, DeactivateSessionPayload } from "../../models/Session";
+import {
+  UpsertSessionPayload, DeactivateSessionPayload, PageVisibilityResponse
+} from "../../models/Session";
 import { WorkerMessengerCommand } from "../../libraries/WorkerMessenger";
-import { PageVisibilityResponse } from "../../service-worker/types";
 
 /**
  * The actual OneSignal proxy frame contents / implementation, that is loaded

--- a/src/modules/frames/ProxyFrame.ts
+++ b/src/modules/frames/ProxyFrame.ts
@@ -49,6 +49,7 @@ export default class ProxyFrame extends RemoteFrame {
     this.messenger.on(OneSignal.POSTMAM_COMMANDS.REMOTE_NOTIFICATION_PERMISSION,
       this.onRemoteNotificationPermission.bind(this));
     this.messenger.on(OneSignal.POSTMAM_COMMANDS.REMOTE_DATABASE_GET, this.onRemoteDatabaseGet.bind(this));
+    this.messenger.on(OneSignal.POSTMAM_COMMANDS.REMOTE_DATABASE_GET_ALL, this.onRemoteDatabaseGetAll.bind(this));
     this.messenger.on(OneSignal.POSTMAM_COMMANDS.REMOTE_DATABASE_PUT, this.onRemoteDatabasePut.bind(this));
     this.messenger.on(OneSignal.POSTMAM_COMMANDS.REMOTE_DATABASE_REMOVE, this.onRemoteDatabaseRemove.bind(this));
     this.messenger.on(OneSignal.POSTMAM_COMMANDS.UNSUBSCRIBE_FROM_PUSH, this.onUnsubscribeFromPush.bind(this));
@@ -144,6 +145,15 @@ export default class ProxyFrame extends RemoteFrame {
       retrievalOpPromises.push(Database.get(table, key));
     }
     const results = await Promise.all(retrievalOpPromises);
+    message.reply(results);
+    return false;
+  }
+
+  async onRemoteDatabaseGetAll(message: MessengerMessageEvent) {
+    const table: OneSignalDbTable = message.data.table;
+    console.log("onRemoteDatabaseGetAll", table);
+    const results = await Database.getAll(table);
+    
     message.reply(results);
     return false;
   }

--- a/src/modules/frames/ProxyFrameHost.ts
+++ b/src/modules/frames/ProxyFrameHost.ts
@@ -5,7 +5,7 @@ import Postmam from '../../Postmam';
 import { timeoutPromise, triggerNotificationPermissionChanged } from '../../utils';
 import { ServiceWorkerActiveState } from "../../helpers/ServiceWorkerHelper";
 import Log from '../../libraries/Log';
-import { PageVisibilityRequest } from "../../service-worker/types";
+import { PageVisibilityRequest } from "../../models/Session";
 
 interface Reply {
   data: any;

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -1,7 +1,7 @@
 import bowser from "bowser";
 
 import Environment from "../Environment";
-import { WorkerMessenger, WorkerMessengerCommand } from "../libraries/WorkerMessenger";
+import { WorkerMessenger, WorkerMessengerCommand, WorkerMessengerMessage } from "../libraries/WorkerMessenger";
 import SdkEnvironment from "../managers/SdkEnvironment";
 import ContextSW from "../models/ContextSW";
 import OneSignalApiBase from "../OneSignalApiBase";
@@ -23,6 +23,7 @@ import {
 } from "./types";
 import ServiceWorkerHelper from "../helpers/ServiceWorkerHelper";
 import { NotificationReceived, NotificationClicked } from "../models/Notification";
+import { cancelableTimeout } from "src/helpers/sw/CancelableTimeout";
 
 declare var self: ServiceWorkerGlobalScope & OSServiceWorkerFields;
 declare var Notification: Notification;
@@ -95,6 +96,28 @@ export class ServiceWorker {
     self.addEventListener('activate', ServiceWorker.onServiceWorkerActivated);
     self.addEventListener('pushsubscriptionchange', (event: PushSubscriptionChangeEvent) => {
       event.waitUntil(ServiceWorker.onPushSubscriptionChange(event))
+    });
+
+
+    self.addEventListener('message', (event: ExtendableMessageEvent) => {
+      const data: WorkerMessengerMessage = event.data;
+      if (!data || !data.command) {
+        return;
+      }
+      const payload = data.payload;
+
+      switch(data.command) {
+        case WorkerMessengerCommand.SessionUpsert:
+          Log.debug("[Service Worker] Received SessionUpsert", payload);
+          ServiceWorker.debounceRefreshSession(event, payload as UpsertSessionPayload);
+          break;
+        case WorkerMessengerCommand.SessionDeactivate:
+          Log.debug("[Service Worker] Received SessionDeactivate", payload);
+          ServiceWorker.debounceRefreshSession(event, payload as DeactivateSessionPayload);
+          break;
+        default:
+          return;
+      }
     });
     /*
       According to
@@ -178,23 +201,6 @@ export class ServiceWorker {
       const context = new ContextSW(appConfig);
       await context.subscriptionManager.unsubscribe(UnsubscriptionStrategy.MarkUnsubscribed);
       ServiceWorker.workerMessenger.broadcast(WorkerMessengerCommand.AmpUnsubscribe, null);
-    });
-    ServiceWorker.workerMessenger.on(WorkerMessengerCommand.SessionUpsert, async (payload: UpsertSessionPayload) => {
-      Log.debug("[Service Worker] Received SessionUpsert", payload);
-      try {
-        ServiceWorker.debounceRefreshSession(payload);
-      } catch(e) {
-        Log.error("Error in SW.SessionUpsert handler", e.message, e);
-      }
-    });
-
-    ServiceWorker.workerMessenger.on(WorkerMessengerCommand.SessionDeactivate, async (payload: DeactivateSessionPayload) => {
-      Log.debug("[Service Worker] Received SessionDeactivate", payload);
-      try {
-        ServiceWorker.debounceRefreshSession(payload);
-      } catch(e) {
-        Log.error("Error in SW.SessionDeactivate handler", e);
-      }
     });
     ServiceWorker.workerMessenger.on(
       WorkerMessengerCommand.AreYouVisibleResponse, async (payload: PageVisibilityResponse) => {
@@ -384,6 +390,7 @@ export class ServiceWorker {
   }
 
   static async updateSessionBasedOnHasActive(
+    event: ExtendableMessageEvent,
     hasAnyActiveSessions: boolean, options: DeactivateSessionPayload
   ) {
     if (hasAnyActiveSessions) {
@@ -396,12 +403,17 @@ export class ServiceWorker {
         options.outcomesConfig
       );
     } else {
-      self.finalizeSessionTimerId = await ServiceWorkerHelper.deactivateSession(
-        options.sessionThreshold, options.enableSessionDuration, options.outcomesConfig);
+      const cancelableFinalize = await ServiceWorkerHelper.deactivateSession(
+        options.sessionThreshold, options.enableSessionDuration, options.outcomesConfig
+      );
+      if (cancelableFinalize) {
+        self.cancel = cancelableFinalize.cancel;
+        event.waitUntil(cancelableFinalize.promise);
+      }
     }
   }
 
-  static async refreshSession(options: DeactivateSessionPayload): Promise<void> {
+  static async refreshSession(event: ExtendableMessageEvent, options: DeactivateSessionPayload): Promise<void> {
     Log.debug("[Service Worker] refreshSession");
     /**
      * if https -> getActiveClients -> check for the first focused
@@ -417,22 +429,24 @@ export class ServiceWorker {
       );
 
       if (options.isSafari) {
-        ServiceWorker.checkIfAnyClientsFocusedAndUpdateSession(windowClients, options);
+        await ServiceWorker.checkIfAnyClientsFocusedAndUpdateSession(event, windowClients, options);
       } else {
         const hasAnyActiveSessions: boolean = windowClients.some(w => (w as WindowClient).focused);
         Log.debug("[Service Worker] isHttps hasAnyActiveSessions", hasAnyActiveSessions);
-        await ServiceWorker.updateSessionBasedOnHasActive(hasAnyActiveSessions, options);
+        await ServiceWorker.updateSessionBasedOnHasActive(event, hasAnyActiveSessions, options);
       }
       return;
     } else {
       const osClients = await ServiceWorker.getActiveClients();
-      ServiceWorker.checkIfAnyClientsFocusedAndUpdateSession(osClients, options);
+      await ServiceWorker.checkIfAnyClientsFocusedAndUpdateSession(event, osClients, options);
     }
   }
 
-  static checkIfAnyClientsFocusedAndUpdateSession(
-    windowClients: Client[], sessionInfo: DeactivateSessionPayload
-  ): void {
+  static async checkIfAnyClientsFocusedAndUpdateSession(
+    event: ExtendableMessageEvent,
+    windowClients: Client[],
+    sessionInfo: DeactivateSessionPayload
+  ): Promise<void> {
     const timestamp = new Date().getTime();
     self.clientsStatus = {
       timestamp,
@@ -448,32 +462,35 @@ export class ServiceWorker {
       }
       c.postMessage({ command: WorkerMessengerCommand.AreYouVisible, payload })
     });
-    self.setTimeout(() => {
+    const updateOnHasActive = async () => {
       if (!self.clientsStatus) { return; }
       if (self.clientsStatus.timestamp !== timestamp) { return; }
 
       Log.debug("updateSessionBasedOnHasActive", self.clientsStatus);
-      ServiceWorker.updateSessionBasedOnHasActive(
+      await ServiceWorker.updateSessionBasedOnHasActive(event,
         self.clientsStatus.hasAnyActiveSessions, sessionInfo);
       self.clientsStatus = undefined;
-    }, 500);
+    }
+    const getClientStatusesCancelable = cancelableTimeout(updateOnHasActive, 0.5);
+    self.cancel = getClientStatusesCancelable.cancel;
+    event.waitUntil(getClientStatusesCancelable.promise);
   }
 
-  static debounceRefreshSession(options: DeactivateSessionPayload ) {
+  static debounceRefreshSession(event: ExtendableMessageEvent, options: DeactivateSessionPayload) {
     Log.debug("[Service Worker] debounceRefreshSession", options);
-    const executeRefreshSession = () => {
-      if (self.finalizeSessionTimerId !== undefined) {
-        self.clearTimeout(self.finalizeSessionTimerId);
-        self.finalizeSessionTimerId = undefined;
-      }
-      ServiceWorker.refreshSession(options);
-    };
 
-    if (self.debounceSessionTimerId !== undefined) {
-      self.clearTimeout(self.debounceSessionTimerId);
+    if (self.cancel) {
+      self.cancel();
+      self.cancel = undefined;
     }
 
-    self.debounceSessionTimerId = self.setTimeout(executeRefreshSession, 1000);
+    const executeRefreshSession = async () => {
+      await ServiceWorker.refreshSession(event, options);
+    };
+
+    const cancelableRefreshSession = cancelableTimeout(executeRefreshSession, 1);
+    self.cancel = cancelableRefreshSession.cancel;
+    event.waitUntil(cancelableRefreshSession.promise);
   }
 
   /**

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -977,6 +977,7 @@ export class ServiceWorker {
   }
 
   static onServiceWorkerInstalled(event) {
+    Log.info("Installing service worker...");
     // At this point, the old service worker is still in control
     event.waitUntil(self.skipWaiting());
   }

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -222,10 +222,11 @@ export class ServiceWorker {
 
     event.waitUntil(
         ServiceWorker.parseOrFetchNotifications(event)
-            .then((notifications: any) => {
+            .then(async (notifications: any) => {
               //Display push notifications in the order we received them
               const notificationEventPromiseFns = [];
               const notificationReceivedPromises: Promise<void>[] = [];
+              const appId = await Database.get<string>("Ids", "appId");
 
               for (let rawNotification of notifications) {
                 Log.debug('Raw Notification from OneSignal:', rawNotification);
@@ -233,6 +234,7 @@ export class ServiceWorker {
 
                 const notificationReceived: NotificationReceived = {
                   notificationId: notification.id,
+                  appId,
                   url: notification.url,
                   timestamp: new Date().getTime().toString(),
                   sent: false,
@@ -774,8 +776,10 @@ export class ServiceWorker {
     const notificationOpensLink: boolean = ServiceWorker.shouldOpenNotificationUrl(launchUrl);
     let saveNotificationClickedPromise: Promise<void> | undefined;
     if (notificationOpensLink) {
+      const appId = await Database.get<string>("Ids", "appId");
       const notificationClicked: NotificationClicked = {
         notificationId: notificationData.id,
+        appId,
         url: launchUrl,
         timestamp: new Date().getTime().toString(),
         sent: false,

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -237,7 +237,6 @@ export class ServiceWorker {
                   appId,
                   url: notification.url,
                   timestamp: new Date().getTime().toString(),
-                  sent: false,
                 };
                 notificationReceivedPromises.push(Database.put("NotificationReceived", notificationReceived));
                 // TODO: decide what to do with all the notif received promises
@@ -782,7 +781,6 @@ export class ServiceWorker {
         appId,
         url: launchUrl,
         timestamp: new Date().getTime().toString(),
-        sent: false,
       }
       Log.info("NotificationClicked", notificationClicked);
       saveNotificationClickedPromise = (async (notificationClicked) => {

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -392,11 +392,12 @@ export class ServiceWorker {
         options.enableSessionDuration,
         options.deviceRecord!,
         options.deviceId,
-        options.sessionOrigin
+        options.sessionOrigin,
+        options.outcomesConfig
       );
     } else {
       self.finalizeSessionTimerId = await ServiceWorkerHelper.deactivateSession(
-        options.sessionThreshold, options.enableSessionDuration);
+        options.sessionThreshold, options.enableSessionDuration, options.outcomesConfig);
     }
   }
 

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -26,7 +26,7 @@ import {
 } from "./types";
 import ServiceWorkerHelper from "../helpers/ServiceWorkerHelper";
 import { NotificationReceived, NotificationClicked } from "../models/Notification";
-import { cancelableTimeout } from "src/helpers/sw/CancelableTimeout";
+import { cancelableTimeout } from "../helpers/sw/CancelableTimeout";
 
 declare var self: ServiceWorkerGlobalScope & OSServiceWorkerFields;
 declare var Notification: Notification;

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -236,7 +236,7 @@ export class ServiceWorker {
                   notificationId: notification.id,
                   appId,
                   url: notification.url,
-                  timestamp: new Date().getTime().toString(),
+                  timestamp: new Date().getTime(),
                 };
                 notificationReceivedPromises.push(Database.put("NotificationReceived", notificationReceived));
                 // TODO: decide what to do with all the notif received promises
@@ -780,7 +780,7 @@ export class ServiceWorker {
         notificationId: notificationData.id,
         appId,
         url: launchUrl,
-        timestamp: new Date().getTime().toString(),
+        timestamp: new Date().getTime(),
       }
       Log.info("NotificationClicked", notificationClicked);
       saveNotificationClickedPromise = (async (notificationClicked) => {

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -802,7 +802,14 @@ export class ServiceWorker {
       }
       Log.info("NotificationClicked", notificationClicked);
       saveNotificationClickedPromise = (async (notificationClicked) => {
-        return await Database.put("NotificationClicked", notificationClicked)
+        try {
+          const existingSession = await Database.getCurrentSession();
+          if (!existingSession) {
+            await Database.put("NotificationClicked", notificationClicked)
+          }
+        } catch(e) {
+          Log.error("Failed to save clicked notification.", e);
+        }
       })(notificationClicked);
     }
 

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -13,13 +13,16 @@ import { RawPushSubscription } from "../models/RawPushSubscription";
 import { SubscriptionStateKind } from "../models/SubscriptionStateKind";
 import { SubscriptionStrategyKind } from "../models/SubscriptionStrategyKind";
 import { PushDeviceRecord } from "../models/PushDeviceRecord";
-import { UpsertSessionPayload, DeactivateSessionPayload } from "../models/Session";
+import { 
+  UpsertSessionPayload, DeactivateSessionPayload,
+  PageVisibilityRequest, PageVisibilityResponse
+} from "../models/Session";
 import Log from "../libraries/Log";
 import { ConfigHelper } from "../helpers/ConfigHelper";
 import { OneSignalUtils } from "../utils/OneSignalUtils";
 import { Utils } from "../context/shared/utils/Utils";
 import {
-  OSWindowClient, OSServiceWorkerFields, PageVisibilityRequest, PageVisibilityResponse
+  OSWindowClient, OSServiceWorkerFields
 } from "./types";
 import ServiceWorkerHelper from "../helpers/ServiceWorkerHelper";
 import { NotificationReceived, NotificationClicked } from "../models/Notification";
@@ -460,7 +463,7 @@ export class ServiceWorker {
         // keeping track of number of sent requests mostly for debugging purposes
         self.clientsStatus.sentRequestsCount++;
       }
-      c.postMessage({ command: WorkerMessengerCommand.AreYouVisible, payload })
+      c.postMessage({ command: WorkerMessengerCommand.AreYouVisible, payload });
     });
     const updateOnHasActive = async () => {
       if (!self.clientsStatus) { return; }

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -395,7 +395,7 @@ export class ServiceWorker {
         options.sessionOrigin
       );
     } else {
-      self.timerId = await ServiceWorkerHelper.deactivateSession(
+      self.finalizeSessionTimerId = await ServiceWorkerHelper.deactivateSession(
         options.sessionThreshold, options.enableSessionDuration);
     }
   }
@@ -461,18 +461,18 @@ export class ServiceWorker {
   static debounceRefreshSession(options: DeactivateSessionPayload ) {
     Log.debug("[Service Worker] debounceRefreshSession", options);
     const executeRefreshSession = () => {
-      if (self.timerId !== undefined) {
-        self.clearTimeout(self.timerId);
-        self.timerId = undefined;
+      if (self.finalizeSessionTimerId !== undefined) {
+        self.clearTimeout(self.finalizeSessionTimerId);
+        self.finalizeSessionTimerId = undefined;
       }
       ServiceWorker.refreshSession(options);
     };
 
-    if (self.timerId !== undefined) {
-      self.clearTimeout(self.timerId);
+    if (self.debounceSessionTimerId !== undefined) {
+      self.clearTimeout(self.debounceSessionTimerId);
     }
 
-    self.timerId = self.setTimeout(executeRefreshSession, 1000);
+    self.debounceSessionTimerId = self.setTimeout(executeRefreshSession, 1000);
   }
 
   /**

--- a/src/service-worker/types.ts
+++ b/src/service-worker/types.ts
@@ -9,14 +9,6 @@ export interface ClientStatus {
   hasAnyActiveSessions: boolean;
 }
 
-export interface PageVisibilityRequest {
-  timestamp: number;
-}
-
-export interface PageVisibilityResponse extends PageVisibilityRequest {
-  focused: boolean;
-}
-
 export interface OSServiceWorkerFields { 
   debounceSessionTimerId?: number;
   finalizeSessionTimerId?: number;

--- a/src/service-worker/types.ts
+++ b/src/service-worker/types.ts
@@ -21,4 +21,5 @@ export interface OSServiceWorkerFields {
   debounceSessionTimerId?: number;
   finalizeSessionTimerId?: number;
   clientsStatus?: ClientStatus;
+  cancel?: () => void;
 }

--- a/src/service-worker/types.ts
+++ b/src/service-worker/types.ts
@@ -18,6 +18,7 @@ export interface PageVisibilityResponse extends PageVisibilityRequest {
 }
 
 export interface OSServiceWorkerFields { 
-  timerId?: number;
+  debounceSessionTimerId?: number;
+  finalizeSessionTimerId?: number;
   clientsStatus?: ClientStatus;
 }

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -140,7 +140,7 @@ export default class Database {
     }
   }
 
-  public async queryFromIndex<T>(table: OneSignalDbTable, index: OneSignalIndex, key?: string): Promise<T[]> {
+  public async queryFromIndex<T, TKey>(table: OneSignalDbTable, index: OneSignalIndex, key?: TKey): Promise<T[]> {
     if (this.shouldUsePostmam()) {
       return await new Promise<T[]>(async (resolve) => {
         OneSignal.proxyFrameHost.message(OneSignal.POSTMAM_COMMANDS.REMOTE_DATABASE_QUERY_INDEX, [{
@@ -151,7 +151,7 @@ export default class Database {
         });
       });
     } else {
-      return await this.database.queryFromIndex<T>(table, index, key);
+      return await this.database.queryFromIndex<T, TKey>(table, index, key);
     }
   }
 
@@ -414,8 +414,8 @@ export default class Database {
     return await this.get<NotificationReceived | null>("NotificationReceived", notificationId);
   }
 
-  async getNotificationReceivedForTimeRange(maxTimestamp: string): Promise<NotificationReceived[]> {
-    return await this.queryFromIndex<NotificationReceived>("NotificationReceived", "timestamp", maxTimestamp);
+  async getNotificationReceivedForTimeRange(maxTimestamp: number): Promise<NotificationReceived[]> {
+    return await this.queryFromIndex<NotificationReceived, number>("NotificationReceived", "timestamp", maxTimestamp);
   }
 
   /**
@@ -513,7 +513,7 @@ export default class Database {
     return await Database.singletonInstance.getNotificationReceivedById(notificationId);
   }
 
-  static async getNotificationReceivedForTimeRange(maxTimestamp: string): Promise<NotificationReceived[]> {
+  static async getNotificationReceivedForTimeRange(maxTimestamp: number): Promise<NotificationReceived[]> {
     return await Database.singletonInstance.getNotificationReceivedForTimeRange(maxTimestamp);
   }
 

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -567,5 +567,9 @@ export default class Database {
   static async get<T>(table: OneSignalDbTable, key?: string): Promise<T> {
     return await Database.singletonInstance.get<T>(table, key);
   }
+
+  static async getAll<T>(table: OneSignalDbTable): Promise<Array<T>> {
+    return await Database.singletonInstance.getAll<T>(table);
+  }
   // END: Static mappings to instance methods
 }

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -140,7 +140,7 @@ export default class Database {
     }
   }
 
-  async queryFromIndex<T>(table: OneSignalDbTable, index: OneSignalIndex, key?: string): Promise<T[]> {
+  public async queryFromIndex<T>(table: OneSignalDbTable, index: OneSignalIndex, key?: string): Promise<T[]> {
     if (this.shouldUsePostmam()) {
       return await new Promise<T[]>(async (resolve) => {
         OneSignal.proxyFrameHost.message(OneSignal.POSTMAM_COMMANDS.REMOTE_DATABASE_QUERY_INDEX, [{

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -389,7 +389,18 @@ export default class Database {
     await this.remove("Sessions", sessionKey);
   }
 
-  private async getNotificationClickedByUrl(url: string, appId: string): Promise<NotificationClicked | null> {
+  async getLastNotificationClicked(appId: string): Promise<NotificationClicked | null> {
+    let allClickedNotifications: NotificationClicked[] = [];
+    try {
+      allClickedNotifications = await this.getAll<NotificationClicked>("NotificationClicked");
+    } catch(e) {
+      Log.error("Database.getNotificationClickedByUrl", e);
+    }
+    const predicate = (notification: NotificationClicked) => notification.appId === appId;
+    return allClickedNotifications.find(predicate) || null;
+  }
+
+  async getNotificationClickedByUrl(url: string, appId: string): Promise<NotificationClicked | null> {
     let allClickedNotifications: NotificationClicked[] = [];
     try {
       allClickedNotifications = await this.getAll<NotificationClicked>("NotificationClicked");
@@ -416,6 +427,14 @@ export default class Database {
 
   async getNotificationReceivedForTimeRange(maxTimestamp: number): Promise<NotificationReceived[]> {
     return await this.queryFromIndex<NotificationReceived, number>("NotificationReceived", "timestamp", maxTimestamp);
+  }
+
+  async removeNotificationClickedById(notificationId: string): Promise<void> {
+    await this.remove("NotificationClicked", notificationId);
+  }
+
+  async removeAllNotificationClicked(): Promise<void> {
+    await this.remove("NotificationClicked");
   }
 
   /**
@@ -499,6 +518,18 @@ export default class Database {
 
   static async getExternalUserId(): Promise<string | undefined | null> {
     return await Database.singletonInstance.getExternalUserId();
+  }
+
+  static async getLastNotificationClicked(appId: string): Promise<NotificationClicked | null> {
+    return await Database.singletonInstance.getLastNotificationClicked(appId);
+  }
+
+  static async removeNotificationClickedById(notificationId: string): Promise<void> {
+    return await Database.singletonInstance.removeNotificationClickedById(notificationId);
+  }
+
+  static async removeAllNotificationClicked(): Promise<void> {
+    return await Database.singletonInstance.removeAllNotificationClicked();
   }
 
   static async getNotificationClickedByUrl(url: string, appId: string): Promise<NotificationClicked | null> {

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -126,10 +126,11 @@ export default class Database {
   public async getAll<T>(table: OneSignalDbTable): Promise<T[]> {
     if (this.shouldUsePostmam()) {
       return await new Promise<T[]>(async (resolve) => {
-        OneSignal.proxyFrameHost.message(OneSignal.POSTMAM_COMMANDS.REMOTE_DATABASE_GET_ALL, [{
+        OneSignal.proxyFrameHost.message(OneSignal.POSTMAM_COMMANDS.REMOTE_DATABASE_GET_ALL, {
           table: table
-        }], (reply: T[]) => {
-          resolve(reply);
+        }, (reply: any) => {
+          const result = reply.data;
+          resolve(result);
         });
       });
     } else {

--- a/src/services/IndexedDb.ts
+++ b/src/services/IndexedDb.ts
@@ -180,7 +180,7 @@ export default class IndexedDb {
     });
   }
 
-  public async queryFromIndex<T>(table: string, indexName: string, key?: string): Promise<T[]> {
+  public async queryFromIndex<T, TKey>(table: string, indexName: string, key?: TKey): Promise<T[]> {
     const database = await this.ensureDatabaseOpen();
     return await new Promise<T[]>((resolve, reject) => {
       const result: T[] = [];
@@ -211,7 +211,7 @@ export default class IndexedDb {
     await this.ensureDatabaseOpen();
     return await new Promise((resolve, reject) => {
       try {
-        let request = this.database.transaction([table], 'readwrite').objectStore(table).put(key);
+        let request = this.database!.transaction([table], 'readwrite').objectStore(table).put(key);
         request.onsuccess = () => {
           resolve(key);
         };

--- a/src/services/IndexedDb.ts
+++ b/src/services/IndexedDb.ts
@@ -105,14 +105,8 @@ export default class IndexedDb {
     db.createObjectStore("Options", { keyPath: "key" });
     db.createObjectStore("Sessions", { keyPath: "sessionKey" });
 
-    const notificationReceivedStore = db.createObjectStore("NotificationReceived", {
-      keyPath: "notificationId"
-    });
-    notificationReceivedStore.createIndex("timestamp", "timestamp", { unique: false });
-    const notificationClickedStore = db.createObjectStore("NotificationClicked", {
-      keyPath: "notificationId"
-    });
-    notificationClickedStore.createIndex("timestamp", "timestamp", { unique: false });
+    db.createObjectStore("NotificationReceived", { keyPath: "notificationId" });
+    db.createObjectStore("NotificationClicked", { keyPath: "notificationId" });
     // Wrap in conditional for tests
     if (typeof OneSignal !== "undefined") {
       OneSignal._isNewVisitor = true;

--- a/src/services/IndexedDb.ts
+++ b/src/services/IndexedDb.ts
@@ -129,7 +129,7 @@ export default class IndexedDb {
     if (key) {
       // Return a table-key value
       return await new Promise((resolve, reject) => {
-        var request: IDBRequest = database.transaction(table).objectStore(table).get(key);
+        const request: IDBRequest = database.transaction(table).objectStore(table).get(key);
         request.onsuccess = () => {
           resolve(request.result);
         };
@@ -143,7 +143,7 @@ export default class IndexedDb {
         let jsonResult: {[key: string]: any} = {};
         let cursor = database.transaction(table).objectStore(table).openCursor();
         cursor.onsuccess = (event: any) => {
-          var cursorResult: IDBCursorWithValue = event.target.result;
+          const cursorResult: IDBCursorWithValue = event.target.result;
           if (cursorResult) {
             let cursorResultKey: string = cursorResult.key as string;
             jsonResult[cursorResultKey] = cursorResult.value;

--- a/src/services/IndexedDb.ts
+++ b/src/services/IndexedDb.ts
@@ -160,6 +160,26 @@ export default class IndexedDb {
     }
   }
 
+  public async getAll<T>(table: string): Promise<T[]> {
+    return await new Promise<T[]>(async (resolve, reject) => {
+      const database = await this.ensureDatabaseOpen();
+      let cursor = database.transaction(table).objectStore(table).openCursor();
+      const result: T[] = [];
+      cursor.onsuccess = (event: any) => {
+        var cursorResult: IDBCursorWithValue = event.target.result;
+        if (cursorResult) {
+          result.push(cursorResult.value as T);
+          cursorResult.continue();
+        } else {
+          resolve(result);
+        }
+      };
+      cursor.onerror = () => {
+        reject(cursor.error);
+      };
+    });
+  }
+
   public async queryFromIndex<T>(table: string, indexName: string, key?: string): Promise<T[]> {
     const database = await this.ensureDatabaseOpen();
     return await new Promise<T[]>((resolve, reject) => {

--- a/src/services/IndexedDb.ts
+++ b/src/services/IndexedDb.ts
@@ -165,7 +165,7 @@ export default class IndexedDb {
       let cursor = database.transaction(table).objectStore(table).openCursor();
       const result: T[] = [];
       cursor.onsuccess = (event: any) => {
-        var cursorResult: IDBCursorWithValue = event.target.result;
+        const cursorResult: IDBCursorWithValue = event.target.result;
         if (cursorResult) {
           result.push(cursorResult.value as T);
           cursorResult.continue();
@@ -177,30 +177,6 @@ export default class IndexedDb {
         reject(cursor.error);
       };
     });
-  }
-
-  public async queryFromIndex<T, TKey>(table: string, indexName: string, key?: TKey): Promise<T[]> {
-    const database = await this.ensureDatabaseOpen();
-    return await new Promise<T[]>((resolve, reject) => {
-      const result: T[] = [];
-
-      // Match anything up to, including the key
-      var lowerBoundOpenKeyRange = IDBKeyRange.lowerBound(key);
-      const indexCursor = database.transaction(table).objectStore(table)
-        .index(indexName).openCursor(lowerBoundOpenKeyRange);
-      indexCursor.onsuccess = (event: any) => {
-        let cursorResult: IDBCursorWithValue = event.target.result;
-        if (cursorResult) {
-          result.push(cursorResult.value as T);
-          cursorResult.continue();
-        }
-        resolve(result);
-      };
-      indexCursor.onerror = () => {
-        reject(indexCursor.error);
-      };
-    });
-    
   }
 
   /**

--- a/src/utils/OneSignalStub.ts
+++ b/src/utils/OneSignalStub.ts
@@ -57,7 +57,8 @@ export abstract class OneSignalStub<T> implements IndexableByString<any> {
     "getExternalUserId",
     "provideUserConsent",
     "isOptedOut",
-    "getEmailId"
+    "getEmailId",
+    "sendOutcome"
   ];
 
   public abstract isPushNotificationsSupported(): boolean;

--- a/test/support/polyfills/polyfills.ts
+++ b/test/support/polyfills/polyfills.ts
@@ -6,6 +6,7 @@ declare var global: any;
 
 global.URL = require('url').URL;
 global.indexedDB = require('fake-indexeddb');
+global.IDBKeyRange = require("fake-indexeddb/lib/FDBKeyRange");
 global.Headers = require('./Headers');
 global.fetch = fetch;
 

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -116,7 +116,7 @@ export class TestEnvironment {
   /**
    * Intercepts requests to our virtual DOM to return fake responses.
    */
-  static onVirtualDomResourceRequested(resource, callback: Function) {
+  static onVirtualDomResourceRequested(resource: any, callback: Function) {
     const pathname = resource.url.pathname;
     if (pathname.startsWith('https://test.node/scripts/')) {
       if (pathname.startsWith('https://test.node/scripts/delayed')) {
@@ -147,7 +147,7 @@ export class TestEnvironment {
     }
   }
 
-  static onVirtualDomDelayedResourceRequested(resource, callback: Function) {
+  static onVirtualDomDelayedResourceRequested(resource: any, callback: Function) {
     const pathname = resource.url.pathname;
     var delay = pathname.match(/\d+/) || 1000;
     // Simulate a delayed request
@@ -220,7 +220,7 @@ export class TestEnvironment {
           ProcessExternalResources: ['script']
         },
         resourceLoader: TestEnvironment.onVirtualDomResourceRequested,
-        done: (err, window) => {
+        done: (err: any, window: Window) => {
           if (err) {
             console.log(err);
             reject('Failed to create a JsDom mock browser environment:' + err);
@@ -254,7 +254,7 @@ export class TestEnvironment {
   }
 
   static addCustomEventPolyfill(windowDef: any) {
-    function CustomEvent(event, params) {
+    function CustomEvent(event: any, params: any) {
       params = params || { bubbles: false, cancelable: false, detail: undefined };
       const evt = document.createEvent( 'CustomEvent' );
       evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
@@ -402,11 +402,11 @@ export class TestEnvironment {
             enable: true,
             mixpanel_reporting_token: "7c2582e45a6ecf1501aa3ca7887f3673"
           },
-          enableSessionDuration: true,
+          web_on_focus_enabled: true,
+          session_threshold: 30
         },
         config: {
           autoResubscribe: true,
-          sessionThreshold: 30,
           siteInfo: {
             name: "localhost https",
             origin: "https://localhost:3001",
@@ -520,8 +520,10 @@ export class TestEnvironment {
             },
             indirect: {
               enabled: true,
-              influencedTimePeriodMin: 60,
-              influencedNotificationsLimit: 5,
+              notification_attribution: {
+                limit: 5,
+                minutes_since_displayed: 60
+              }
             },
             unattributed: {
               enabled: true,
@@ -574,14 +576,14 @@ export class TestEnvironment {
         email: {
           require_auth: true,
         },
-        enableSessionDuration: true
+        web_on_focus_enabled: true,
+        session_threshold: 30
       },
       config: {
         origin: "https://example.com",
         subdomain: undefined,
         http_use_onesignal_com: false,
         autoResubscribe: false,
-        sessionThreshold: 30,
         staticPrompts: {
           native: {
             enabled: false,
@@ -711,8 +713,10 @@ export class TestEnvironment {
           },
           indirect: {
             enabled: true,
-            influencedTimePeriodMin: 60,
-            influencedNotificationsLimit: 5,
+            notification_attribution: {
+              minutes_since_displayed: 60,
+              limit: 5
+            }
           },
           unattributed: {
             enabled: true,

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -505,6 +505,19 @@ export class TestEnvironment {
           onesignal_vapid_public_key: "BMzCIzYqtgz2Bx7S6aPVK6lDWets7kGm-pgo2H4RixFikUaNIoPqjPBBOEWMAfeFjuT9mAvbe-lckGi6vvNEiW0",
           origin: "https://localhost:3001",
           subdomain: undefined,
+          outcomes: {
+            direct: {
+              enabled: true,
+            },
+            indirect: {
+              enabled: true,
+              influencedTimePeriodMin: 60,
+              influencedNotificationsLimit: 5,
+            },
+            unattributed: {
+              enabled: true,
+            }
+          }
         },
         "generated_at": 1531177265
       };
@@ -682,7 +695,20 @@ export class TestEnvironment {
         vapid_public_key: 'BLJozaErc0QXdS7ykMyqniAcvfmdoziwfoSN-Mde_OckAbN_XrOC9Zt2Sfz4pD0UnYT5w3frWjF2iTTtjqEBgbE',
         onesignal_vapid_public_key:
           'BMzCIzYqtgz2Bx7S6aPVK6lDWets7kGm-pgo2H4RixFikUaNIoPqjPBBOEWMAfeFjuT9mAvbe-lckGi6vvNEiW0',
-        safari_web_id: 'web.onesignal.auto.017d7a1b-f1ef-4fce-a00c-21a546b5491d'
+        safari_web_id: 'web.onesignal.auto.017d7a1b-f1ef-4fce-a00c-21a546b5491d',
+        outcomes: {
+          direct: {
+            enabled: true,
+          },
+          indirect: {
+            enabled: true,
+            influencedTimePeriodMin: 60,
+            influencedNotificationsLimit: 5,
+          },
+          unattributed: {
+            enabled: true,
+          }
+        }
       },
       generated_at: 1511912065
     };

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -27,6 +27,7 @@ import { addServiceWorkerGlobalScopeToGlobal } from "../polyfills/polyfills";
 import deepmerge = require("deepmerge");
 import { RecursivePartial } from '../../../src/context/shared/utils/Utils';
 import { EnvironmentInfo } from  '../../../src/context/browser/models/EnvironmentInfo';
+import { EnvironmentInfoHelper } from '../../../src/context/browser/helpers/EnvironmentInfoHelper';
 
 // NodeJS.Global
 declare var global: any;
@@ -356,6 +357,8 @@ export class TestEnvironment {
     };
 
     const fakeMergedConfig: AppConfig = TestEnvironment.getFakeMergedConfig(config);
+    OneSignal.config = fakeMergedConfig;
+    OneSignal.environmentInfo = EnvironmentInfoHelper.getEnvironmentInfo();
     OneSignal.context = new Context(fakeMergedConfig);
     OneSignal.config = fakeMergedConfig;
   }

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -1,3 +1,4 @@
+import "../../support/polyfills/polyfills";
 import OneSignal from "../../../src/OneSignal";
 import Random from "../tester/Random";
 import Database from "../../../src/services/Database";

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -352,6 +352,7 @@ export class TestEnvironment {
     const fakeMergedConfig: AppConfig = TestEnvironment.getFakeMergedConfig(config);
     OneSignal.context = new Context(fakeMergedConfig);
     OneSignal.config = fakeMergedConfig;
+    OneSignal.config.appId = OneSignal.config.userConfig.appId!;
   }
 
   static getFakeAppConfig(): AppConfig {

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -31,6 +31,12 @@ import { EnvironmentInfo } from  '../../../src/context/browser/models/Environmen
 // NodeJS.Global
 declare var global: any;
 
+const APP_ID = "34fcbe85-278d-4fd2-a4ec-0f80e95072c5";
+
+export interface ServiceWorkerTestEnvironment extends ServiceWorkerGlobalScope {
+  OneSignal: ServiceWorker;
+}
+
 export enum HttpHttpsEnvironment {
   Http = "Http",
   Https = "Https"
@@ -352,12 +358,11 @@ export class TestEnvironment {
     const fakeMergedConfig: AppConfig = TestEnvironment.getFakeMergedConfig(config);
     OneSignal.context = new Context(fakeMergedConfig);
     OneSignal.config = fakeMergedConfig;
-    OneSignal.config.appId = OneSignal.config.userConfig.appId!;
   }
 
-  static getFakeAppConfig(): AppConfig {
+  static getFakeAppConfig(appId: string = APP_ID): AppConfig {
     return {
-      appId: Random.getRandomUuid(),
+      appId,
       subdomain: undefined,
       httpUseOneSignalCom: false,
       cookieSyncEnabled: true,
@@ -375,15 +380,17 @@ export class TestEnvironment {
     };
   }
 
+  // TODO: make sure new appId param does not conflict with app_id in overrideServerConfig section
   static getFakeServerAppConfig(
     configIntegrationKind: ConfigIntegrationKind,
     isHttps: boolean = true,
-    overrideServerConfig: RecursivePartial<ServerAppConfig> | null = null
+    overrideServerConfig: RecursivePartial<ServerAppConfig> | null = null,
+    appId: string = APP_ID
   ): ServerAppConfig {
     if (configIntegrationKind === ConfigIntegrationKind.Custom) {
       const customConfigHttps: ServerAppConfig = {
         success: true,
-        app_id: "3d9dbff9-3956-49b3-9521-b0d755b350e5",
+        app_id: appId,
         features: {
           restrict_origin: {
             enable: true
@@ -552,7 +559,7 @@ export class TestEnvironment {
 
     const remoteConfigMockDefaults: ServerAppConfig = {
       success: true,
-      app_id: '34fcbe85-278d-4fd2-a4ec-0f80e95072c5',
+      app_id: appId,
       features: {
         restrict_origin: {
           enable: false,
@@ -721,9 +728,9 @@ export class TestEnvironment {
       );
   }
 
-  static getFakeAppUserConfig(): AppUserConfig {
+  static getFakeAppUserConfig(appId: string = APP_ID): AppUserConfig {
     return {
-      appId: '34fcbe85-278d-4fd2-a4ec-0f80e95072c5',
+      appId,
       autoRegister: true,
       autoResubscribe: true,
       path: '/fake-page',

--- a/test/unit/context/sw/ServiceWorker.ts
+++ b/test/unit/context/sw/ServiceWorker.ts
@@ -4,7 +4,6 @@ import nock from 'nock';
 
 import OneSignal from '../../../../src/OneSignal';
 import Database from '../../../../src/services/Database';
-import Context from '../../../../src/models/Context';
 import { ServiceWorker as OSServiceWorker } from "../../../../src/service-worker/ServiceWorker";
 
 import { TestEnvironment, BrowserUserAgent } from "../../../support/sdk/TestEnvironment";
@@ -20,16 +19,14 @@ import OneSignalUtils from '../../../../src/utils/OneSignalUtils';
 declare var self: MockServiceWorkerGlobalScope;
 
 let sandbox: SinonSandbox;
+const appConfig = TestEnvironment.getFakeAppConfig();
 
 test.beforeEach(async function() {
   sandbox = sinon.sandbox.create();
   
   await TestEnvironment.initializeForServiceWorker();
 
-  const appConfig = TestEnvironment.getFakeAppConfig();
   await Database.setAppConfig(appConfig);
-
-  OneSignal.context = new Context(appConfig);
 });
 
 test.afterEach(function () {
@@ -215,7 +212,7 @@ test('onNotificationClicked - notification click sends PUT api/v1/notification',
     .put(`/api/v1/notifications/${notificationId}`)
     .reply(200, (_uri: string, requestBody: string) => {
       t.deepEqual(JSON.parse(requestBody), {
-        app_id: OneSignal.context.appConfig.appId,
+        app_id: appConfig.appId,
         opened: true,
         player_id: playerId
       });

--- a/test/unit/managers/AltOriginManager.ts
+++ b/test/unit/managers/AltOriginManager.ts
@@ -33,7 +33,7 @@ test(`should get correct canonical subscription URL for staging environment`, as
 
   const stagingUrlsOsTcDomain = AltOriginManager.getCanonicalSubscriptionUrls(config, EnvironmentKind.Staging);
   t.is(stagingUrlsOsTcDomain.length, 2);
-  t.is(stagingUrlsOsTcDomain[0].host, new URL('https://test.staging-01.onesignal.com').host);
+  t.is(stagingUrlsOsTcDomain[0].host, new URL('https://test.localhost').host);
   t.is(stagingUrlsOsTcDomain[1].host, new URL('https://test.os.tc').host);
 
   config.httpUseOneSignalCom = false;

--- a/test/unit/managers/ServiceWorkerManager.ts
+++ b/test/unit/managers/ServiceWorkerManager.ts
@@ -53,7 +53,6 @@ test.beforeEach(async function() {
   const appConfig = TestEnvironment.getFakeAppConfig();
   appConfig.appId = Random.getRandomUuid();
   OneSignal.context = new Context(appConfig);
-
   (global as any).OneSignal = OneSignal;
 });
 
@@ -405,7 +404,7 @@ test("Service worker failed to install in popup. No handling.", async t => {
 test('installWorker() should not install when on an HTTPS site with a subdomain set', async t => {
   // 1. Mock site page as HTTPS
   await TestEnvironment.initialize({ httpOrHttps: HttpHttpsEnvironment.Https });
-
+  TestEnvironment.mockInternalOneSignal();
   // 2. Set is set to use our subdomain however
   const subdomain = "abc";
   const testConfig: TestEnvironmentConfig = {

--- a/test/unit/meta/database.ts
+++ b/test/unit/meta/database.ts
@@ -187,7 +187,6 @@ test("queryFromIndex should work correctly", async t => {
       appId,
       url,
       timestamp: i.toString(),
-      sent: false,
     }
     if (i >= index) {
       expectedResult.push(i.toString());

--- a/test/unit/meta/database.ts
+++ b/test/unit/meta/database.ts
@@ -178,7 +178,7 @@ test("queryFromIndex should work correctly", async t => {
   const url = "https://localhost:3001";
 
   const index = 5;
-  const expectedResult: string[] = [];
+  const expectedResult: number[] = [];
 
   const promises: Promise<void>[] = [];
   for (let i = 0; i < 10; i++) {
@@ -186,18 +186,17 @@ test("queryFromIndex should work correctly", async t => {
       notificationId: Random.getRandomUuid(),
       appId,
       url,
-      timestamp: i.toString(),
+      timestamp: i,
     }
     if (i >= index) {
-      expectedResult.push(i.toString());
+      expectedResult.push(i);
     }
     promises.push(Database.put("NotificationClicked", notif));
   }
   await Promise.all(promises);
 
-  const timestamp = index.toString();
-  const result = await Database.singletonInstance.queryFromIndex<NotificationClicked>(
-    "NotificationClicked", "timestamp", timestamp
+  const result = await Database.singletonInstance.queryFromIndex<NotificationClicked, number>(
+    "NotificationClicked", "timestamp", index
   );
 
   t.is(result.length, expectedResult.length);

--- a/test/unit/meta/database.ts
+++ b/test/unit/meta/database.ts
@@ -172,33 +172,3 @@ test("setDeviceId", async t => {
   subscription = await Database.getSubscription();
   t.is(subscription!.deviceId, null);
 });
-
-test("queryFromIndex should work correctly", async t => {
-  const appId = Random.getRandomUuid();
-  const url = "https://localhost:3001";
-
-  const index = 5;
-  const expectedResult: number[] = [];
-
-  const promises: Promise<void>[] = [];
-  for (let i = 0; i < 10; i++) {
-    const notif: NotificationClicked = {
-      notificationId: Random.getRandomUuid(),
-      appId,
-      url,
-      timestamp: i,
-    }
-    if (i >= index) {
-      expectedResult.push(i);
-    }
-    promises.push(Database.put("NotificationClicked", notif));
-  }
-  await Promise.all(promises);
-
-  const result = await Database.singletonInstance.queryFromIndex<NotificationClicked, number>(
-    "NotificationClicked", "timestamp", index
-  );
-
-  t.is(result.length, expectedResult.length);
-  t.deepEqual(result.map(i => i.timestamp), expectedResult);
-});

--- a/test/unit/modules/sdkEnvironment.ts
+++ b/test/unit/modules/sdkEnvironment.ts
@@ -71,7 +71,7 @@ test('API URL should be valid for development environment', async t => {
 });
 
 test('API URL should be valid for staging environment', async t => {
-  const expectedUrl = `https://${window.location.host}/api/v1`;
+  const expectedUrl = "https://localhost/api/v1";
   t.is(SdkEnvironment.getOneSignalApiUrl(EnvironmentKind.Staging).toString(), expectedUrl);
 });
 

--- a/test/unit/modules/workerMessenger.ts
+++ b/test/unit/modules/workerMessenger.ts
@@ -1,9 +1,8 @@
 import "../../support/polyfills/polyfills";
 import { TestEnvironment } from "../../support/sdk/TestEnvironment";
 import { WorkerMessenger, WorkerMessengerCommand } from '../../../src/libraries/WorkerMessenger';
-import Context from '../../../src/models/Context';
-import { ConfigIntegrationKind } from '../../../src/models/AppConfig';
-import test, { TestContext } from "ava";
+import ContextSW from '../../../src/models/ContextSW';
+import test from "ava";
 import Random from "../../support/tester/Random";
 
 
@@ -13,7 +12,7 @@ test('service worker should gracefully handle unexpected page messages', async t
   });
 
   const appConfig = TestEnvironment.getFakeAppConfig();
-  const context = new Context(appConfig);
+  const context = new ContextSW(appConfig);
   const workerMessenger = new WorkerMessenger(context);
 
   /* We should be guaranteed a MessageEvent with at least an `event.data` property. */
@@ -58,7 +57,7 @@ test(
     });
 
     const appConfig = TestEnvironment.getFakeAppConfig();
-    const context = new Context(appConfig);
+    const context = new ContextSW(appConfig);
     const workerMessenger = new WorkerMessenger(context);
 
     /* We should be guaranteed a MessageEvent with at least an `event.data` property. */

--- a/test/unit/public-sdk-apis/onSession.ts
+++ b/test/unit/public-sdk-apis/onSession.ts
@@ -18,7 +18,7 @@ import { ServiceWorkerManager } from "../../../src/managers/ServiceWorkerManager
 import { NotificationPermission } from "../../../src/models/NotificationPermission";
 import { UpdateManager } from '../../../src/managers/UpdateManager';
 import { PageViewManager } from "../../../src/managers/PageViewManager";
-import { SessionManager } from "../../../src/managers/SessionManager";
+import { SessionManager } from "../../../src/managers/sessionManager/page/SessionManager";
 import { SubscriptionManager } from "../../../src/managers/SubscriptionManager";
 import InitHelper from "../../../src/helpers/InitHelper";
 import {

--- a/test/unit/public-sdk-apis/sendOutcome.ts
+++ b/test/unit/public-sdk-apis/sendOutcome.ts
@@ -117,7 +117,6 @@ test("when outcome is direct and feature enabled it sends an api call", async t 
     appId: OneSignal.config!.appId!,
     url: "https://localhost:3001",
     timestamp: new Date().getTime().toString(),
-    sent: false,
   }
   await Database.put("NotificationClicked", notificationClicked);
   const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
@@ -146,7 +145,6 @@ test("when outcome is direct and feature disabled there are no api calls", async
     appId: OneSignal.config!.appId!,
     url: "https://localhost:3001",
     timestamp: new Date().getTime().toString(),
-    sent: false,
   }
   await Database.put("NotificationClicked", notificationClicked);
   const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
@@ -163,7 +161,6 @@ test("when outcome is direct and feature enabled and has weight it sends an api 
     appId: OneSignal.config!.appId!,
     url: "https://localhost:3001",
     timestamp: new Date().getTime().toString(),
-    sent: false,
   }
   await Database.put("NotificationClicked", notificationClicked);
   const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
@@ -199,7 +196,6 @@ const setupReceivedNotifications = async () => {
       appId: OneSignal.config!.appId!,
       url: "https://localhost:3001",
       timestamp,
-      sent: false,
     }
     if (notificationReceived.timestamp >= maxTimestamp && receivedNotificationIdsWithinTimeframe.length < limit) {
       receivedNotificationIdsWithinTimeframe.push(notificationReceived.notificationId);

--- a/test/unit/public-sdk-apis/sendOutcome.ts
+++ b/test/unit/public-sdk-apis/sendOutcome.ts
@@ -116,7 +116,7 @@ test("when outcome is direct and feature enabled it sends an api call", async t 
     notificationId: Random.getRandomUuid(),
     appId: OneSignal.config!.appId!,
     url: "https://localhost:3001",
-    timestamp: new Date().getTime().toString(),
+    timestamp: new Date().getTime(),
   }
   await Database.put("NotificationClicked", notificationClicked);
   const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
@@ -144,7 +144,7 @@ test("when outcome is direct and feature disabled there are no api calls", async
     notificationId: Random.getRandomUuid(),
     appId: OneSignal.config!.appId!,
     url: "https://localhost:3001",
-    timestamp: new Date().getTime().toString(),
+    timestamp: new Date().getTime(),
   }
   await Database.put("NotificationClicked", notificationClicked);
   const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
@@ -160,7 +160,7 @@ test("when outcome is direct and feature enabled and has weight it sends an api 
     notificationId: Random.getRandomUuid(),
     appId: OneSignal.config!.appId!,
     url: "https://localhost:3001",
-    timestamp: new Date().getTime().toString(),
+    timestamp: new Date().getTime(),
   }
   await Database.put("NotificationClicked", notificationClicked);
   const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
@@ -185,12 +185,12 @@ const setupReceivedNotifications = async () => {
   const now = new Date().getTime();
   const timeframeMs = OneSignal.config!.userConfig.outcomes!.indirect.influencedTimePeriodMin * 60 * 1000;
   const beginningOfTimeframe = new Date(new Date().getTime() - timeframeMs);
-  const maxTimestamp = beginningOfTimeframe.getTime().toString();
+  const maxTimestamp = beginningOfTimeframe.getTime();
   const limit = OneSignal.config!.userConfig.outcomes!.indirect.influencedNotificationsLimit;
 
   const receivedNotificationIdsWithinTimeframe: string[] = [];
   for (let i = 0; i < limit + 3; i++) {
-    const timestamp = new Date(now - i * TEN_MINUTES_MS).getTime().toString();
+    const timestamp = new Date(now - i * TEN_MINUTES_MS).getTime();
     const notificationReceived: NotificationReceived = {
       notificationId: Random.getRandomUuid(),
       appId: OneSignal.config!.appId!,

--- a/test/unit/public-sdk-apis/sendOutcome.ts
+++ b/test/unit/public-sdk-apis/sendOutcome.ts
@@ -1,0 +1,264 @@
+import test from "ava";
+import OneSignal from "../../../src/OneSignal";
+import sinon, { SinonSandbox } from "sinon";
+import { TestEnvironment } from "../../support/sdk/TestEnvironment";
+import OneSignalApiShared from "../../../src/OneSignalApiShared";
+import { OutcomeRequestData } from "../../../src/models/OutcomeRequestData";
+import { DeliveryPlatformKind } from "../../../src/models/DeliveryPlatformKind";
+import { SubscriptionStateKind } from "../../../src/models/SubscriptionStateKind";
+import MainHelper from "../../../src/helpers/MainHelper";
+import Log from "../../../src/libraries/Log";
+import Database from "../../../src/services/Database";
+import { NotificationReceived, NotificationClicked } from "../../../src/models/Notification";
+import Random from "../../support/tester/Random";
+import timemachine from "timemachine";
+
+const OUTCOME_NAME = "test_outcome";
+const OUTCOME_WEIGHT = 55.6;
+
+const sinonSandbox: SinonSandbox = sinon.sandbox.create();
+
+test.beforeEach(async () => {
+  await TestEnvironment.initialize();
+  TestEnvironment.mockInternalOneSignal();
+
+  const now = new Date().getTime();
+  timemachine.config({
+    timestamp: now,
+  });
+});
+
+test.afterEach(() => {
+  sinonSandbox.restore();
+  timemachine.reset();
+});
+
+test("outcome name is required", async t => {
+  const logSpy = sinonSandbox.stub(Log, "error");
+  const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
+  await (OneSignal as any).sendOutcome();
+  t.is(logSpy.callCount, 1);
+  t.is(apiSpy.callCount, 0);
+});
+
+test("outcome weight cannot be other than number or undefined", async t => {
+  const logSpy = sinonSandbox.stub(Log, "error");
+  const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
+  await (OneSignal as any).sendOutcome(OUTCOME_NAME, {});
+  t.is(logSpy.callCount, 1);
+  t.is(apiSpy.callCount, 0);
+});
+
+test("reporting outcome requires the sdk to be initialized", async t => {
+  OneSignal.initialized = false;
+
+  const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
+  sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(true);
+  sinonSandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.Subscribed);
+  const sendOutcomePromise = OneSignal.sendOutcome(OUTCOME_NAME);
+  t.is(apiSpy.callCount, 0);
+
+  OneSignal.emitter.emit(OneSignal.EVENTS.SDK_INITIALIZED);
+  await sendOutcomePromise;
+
+  t.is(apiSpy.callCount, 1);
+});
+
+test("reporting outcome should only work for subscribed users", async t => {
+  const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
+  sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(false);
+  await OneSignal.sendOutcome(OUTCOME_NAME);
+  t.is(apiSpy.callCount, 0);
+});
+
+test("when outcome is unattributed and feature enabled it sends an api call",  async t => {
+  const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
+  sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(true);
+  sinonSandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.Subscribed);
+  await OneSignal.sendOutcome(OUTCOME_NAME);
+
+  t.is(apiSpy.callCount, 1);
+  const outcomeRequestData = apiSpy.getCall(0).args[0] as OutcomeRequestData;
+  t.is(outcomeRequestData.app_id, OneSignal.config!.appId!);
+  t.is(outcomeRequestData.id, OUTCOME_NAME);
+  t.is(outcomeRequestData.weight, undefined);
+  t.is(outcomeRequestData.notification_ids, undefined);
+  t.is(outcomeRequestData.device_type, DeliveryPlatformKind.ChromeLike);
+});
+
+test("when outcome is unattributed and feature disabled there are no api calls",  async t => {
+  OneSignal.config!.userConfig.outcomes!.unattributed.enabled = false;
+
+  const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome");
+  await OneSignal.sendOutcome(OUTCOME_NAME);
+
+  t.is(apiSpy.callCount, 0);
+});
+
+test("when outcome is unattributed and feature enabled and has weight it sends an api call",  async t => {
+  const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
+  sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(true);
+  sinonSandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.Subscribed);
+  await OneSignal.sendOutcome(OUTCOME_NAME, OUTCOME_WEIGHT);
+
+  t.is(apiSpy.callCount, 1);
+  const outcomeRequestData = apiSpy.getCall(0).args[0] as OutcomeRequestData;
+  t.is(outcomeRequestData.app_id, OneSignal.config!.appId!);
+  t.is(outcomeRequestData.id, OUTCOME_NAME);
+  t.is(outcomeRequestData.weight, OUTCOME_WEIGHT);
+  t.is(outcomeRequestData.notification_ids, undefined);
+  t.is(outcomeRequestData.device_type, DeliveryPlatformKind.ChromeLike);
+  t.is(outcomeRequestData.direct, undefined);
+});
+
+test("when outcome is direct and feature enabled it sends an api call", async t => {
+  const notificationClicked: NotificationClicked = {
+    notificationId: Random.getRandomUuid(),
+    appId: OneSignal.config!.appId!,
+    url: "https://localhost:3001",
+    timestamp: new Date().getTime().toString(),
+    sent: false,
+  }
+  await Database.put("NotificationClicked", notificationClicked);
+  const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
+  sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(true);
+  sinonSandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.Subscribed);
+  await OneSignal.sendOutcome(OUTCOME_NAME);
+
+  t.is(apiSpy.callCount, 1);
+  const outcomeRequestData = apiSpy.getCall(0).args[0] as OutcomeRequestData;
+  t.is(outcomeRequestData.id, OUTCOME_NAME);
+  t.is(outcomeRequestData.app_id, OneSignal.config!.userConfig.appId!);
+  t.is(outcomeRequestData.weight, undefined);
+  t.is(outcomeRequestData.notification_ids!.length, 1);
+  t.is(outcomeRequestData.notification_ids![0], notificationClicked.notificationId);
+  t.is(outcomeRequestData.device_type, DeliveryPlatformKind.ChromeLike);
+  t.is(outcomeRequestData.direct, true);
+});
+
+test("when outcome is direct and feature disabled there are no api calls", async t => {
+  OneSignal.config!.userConfig.outcomes!.direct.enabled = false;
+  OneSignal.config!.userConfig.outcomes!.indirect.enabled = false;
+  OneSignal.config!.userConfig.outcomes!.unattributed.enabled = false;
+
+  const notificationClicked: NotificationClicked = {
+    notificationId: Random.getRandomUuid(),
+    appId: OneSignal.config!.appId!,
+    url: "https://localhost:3001",
+    timestamp: new Date().getTime().toString(),
+    sent: false,
+  }
+  await Database.put("NotificationClicked", notificationClicked);
+  const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
+  sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(true);
+  sinonSandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.Subscribed);
+  await OneSignal.sendOutcome(OUTCOME_NAME);
+
+  t.is(apiSpy.callCount, 0);
+});
+
+test("when outcome is direct and feature enabled and has weight it sends an api call", async t => {
+  const notificationClicked: NotificationClicked = {
+    notificationId: Random.getRandomUuid(),
+    appId: OneSignal.config!.appId!,
+    url: "https://localhost:3001",
+    timestamp: new Date().getTime().toString(),
+    sent: false,
+  }
+  await Database.put("NotificationClicked", notificationClicked);
+  const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
+  sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(true);
+  sinonSandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.Subscribed);
+  await OneSignal.sendOutcome(OUTCOME_NAME, OUTCOME_WEIGHT);
+
+  t.is(apiSpy.callCount, 1);
+  const outcomeRequestData = apiSpy.getCall(0).args[0] as OutcomeRequestData;
+  t.is(outcomeRequestData.id, OUTCOME_NAME);
+  t.is(outcomeRequestData.app_id, OneSignal.config!.userConfig.appId!);
+  t.is(outcomeRequestData.weight, OUTCOME_WEIGHT);
+  t.is(outcomeRequestData.notification_ids!.length, 1);
+  t.is(outcomeRequestData.notification_ids![0], notificationClicked.notificationId);
+  t.is(outcomeRequestData.device_type, DeliveryPlatformKind.ChromeLike);
+  t.is(outcomeRequestData.direct, true);
+});
+
+const TEN_MINUTES_MS = 10 * 60 * 1000;
+
+const setupReceivedNotifications = async () => {
+  const now = new Date().getTime();
+  const timeframeMs = OneSignal.config!.userConfig.outcomes!.indirect.influencedTimePeriodMin * 60 * 1000;
+  const beginningOfTimeframe = new Date(new Date().getTime() - timeframeMs);
+  const maxTimestamp = beginningOfTimeframe.getTime().toString();
+  const limit = OneSignal.config!.userConfig.outcomes!.indirect.influencedNotificationsLimit;
+
+  const receivedNotificationIdsWithinTimeframe: string[] = [];
+  for (let i = 0; i < limit + 3; i++) {
+    const timestamp = new Date(now - i * TEN_MINUTES_MS).getTime().toString();
+    const notificationReceived: NotificationReceived = {
+      notificationId: Random.getRandomUuid(),
+      appId: OneSignal.config!.appId!,
+      url: "https://localhost:3001",
+      timestamp,
+      sent: false,
+    }
+    if (notificationReceived.timestamp >= maxTimestamp && receivedNotificationIdsWithinTimeframe.length < limit) {
+      receivedNotificationIdsWithinTimeframe.push(notificationReceived.notificationId);
+    }
+    await Database.put("NotificationReceived", notificationReceived);
+  }
+
+  return receivedNotificationIdsWithinTimeframe;
+}
+
+test("when outcome is indirect and feature enabled it sends an api call", async t => {
+  const receivedNotificationIdsWithinTimeframe = await setupReceivedNotifications();
+
+  const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
+  sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(true);
+  sinonSandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.Subscribed);
+  await OneSignal.sendOutcome(OUTCOME_NAME);
+
+  t.is(apiSpy.callCount, 1);
+  const outcomeRequestData = apiSpy.getCall(0).args[0] as OutcomeRequestData;
+  t.is(outcomeRequestData.id, OUTCOME_NAME);
+  t.is(outcomeRequestData.app_id, OneSignal.config!.userConfig.appId!);
+  t.is(outcomeRequestData.weight, undefined);
+  t.is(outcomeRequestData.notification_ids!.length, receivedNotificationIdsWithinTimeframe.length);
+  outcomeRequestData.notification_ids!.sort();
+  receivedNotificationIdsWithinTimeframe.sort();
+  t.deepEqual(outcomeRequestData.notification_ids!, receivedNotificationIdsWithinTimeframe);
+  t.is(outcomeRequestData.device_type, DeliveryPlatformKind.ChromeLike);
+  t.is(outcomeRequestData.direct, false);
+});
+
+test("when outcome is indirect and feature disabled there are no api calls", async t => {
+  OneSignal.config!.userConfig.outcomes!.direct.enabled = false;
+  OneSignal.config!.userConfig.outcomes!.indirect.enabled = false;
+  OneSignal.config!.userConfig.outcomes!.unattributed.enabled = false;
+
+  await setupReceivedNotifications();
+  const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
+  sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(true);
+  sinonSandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.Subscribed);
+  await OneSignal.sendOutcome(OUTCOME_NAME);
+
+  t.is(apiSpy.callCount, 0);
+});
+
+test("when outcome is indirect and feature enabled and has weight it sends an api call", async t => {
+  const receivedNotificationIdsWithinTimeframe = await setupReceivedNotifications();
+  const apiSpy = sinonSandbox.stub(OneSignalApiShared, "sendOutcome").resolves();
+  sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(true);
+  sinonSandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.Subscribed);
+  await OneSignal.sendOutcome(OUTCOME_NAME);
+
+  t.is(apiSpy.callCount, 1);
+  const outcomeRequestData = apiSpy.getCall(0).args[0] as OutcomeRequestData;
+  t.is(outcomeRequestData.id, OUTCOME_NAME);
+  t.is(outcomeRequestData.app_id, OneSignal.config!.userConfig.appId!);
+  t.is(outcomeRequestData.weight, undefined);
+  t.is(outcomeRequestData.notification_ids!.length, receivedNotificationIdsWithinTimeframe.length);
+  t.deepEqual(outcomeRequestData.notification_ids!, receivedNotificationIdsWithinTimeframe);
+  t.is(outcomeRequestData.device_type, DeliveryPlatformKind.ChromeLike);
+  t.is(outcomeRequestData.direct, false);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -396,14 +396,6 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
-array.prototype.find@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-1.0.0.tgz#52d81768eb1c5692577ee29d96ca603dc76eb3a6"
-
-array.prototype.findindex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array.prototype.findindex/-/array.prototype.findindex-1.0.0.tgz#1966efa59f7cd281114d37ef542f51201e72b8fd"
-
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -1283,6 +1275,11 @@ balanced-match@^0.4.2:
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
+
+base64-arraybuffer-es6@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.5.0.tgz#27877d01148bcfb3919c17ecf64ea163d9bdba62"
+  integrity sha512-UCIPaDJrNNj5jG2ZL+nzJ7czvZV/ZYX6LaIRgfVU1k1edJOQg7dkbiSKzwHkNp6aHEHER/PhlFBrMYnlvJJQEw==
 
 base64-js@^1.0.2:
   version "1.2.3"
@@ -2214,6 +2211,11 @@ core-js@^2.0.0, core-js@^2.4.0, core-js@^2.4.1, core-js@^2.5.0:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.4.tgz#f2c8bf181f2a80b92f360121429ce63a2f0aeae0"
 
+core-js@^2.5.3:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
+  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2434,10 +2436,6 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
-cyclonejs@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/cyclonejs/-/cyclonejs-1.1.4.tgz#1668db83c55f4e19c832dd11ae5fcaf660216f59"
-
 dargs@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-5.1.0.tgz#ec7ea50c78564cd36c9d5ec18f66329fade27829"
@@ -2640,6 +2638,13 @@ dom-storage@^2.0.2:
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
+
+domexception@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+  integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
+  dependencies:
+    webidl-conversions "^4.0.2"
 
 dot-prop@^4.1.0:
   version "4.2.0"
@@ -3022,13 +3027,13 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
-"fake-indexeddb@github:OneSignal/fakeIndexedDB#onesignal":
-  version "1.0.11"
-  resolved "https://codeload.github.com/OneSignal/fakeIndexedDB/tar.gz/1a15315603fbc799ff92f59cd3ed738321cce37d"
+fake-indexeddb@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fake-indexeddb/-/fake-indexeddb-2.1.1.tgz#0a72a53f3844ac76320d15e3f15860d4ce19f0ce"
+  integrity sha512-di5PzbH6/gleD4qcpxT1IDtNNMTKuEs+C2KeJDP1e4mwP2L0UY+vPcTkCdIGq8IcaUUph6IkCrUZJvtpFUdhfg==
   dependencies:
-    array.prototype.find "^1.0.0"
-    array.prototype.findindex "^1.0.0"
-    cyclonejs "^1.1.4"
+    core-js "^2.4.1"
+    realistic-structured-clone "^2.0.1"
     setimmediate "^1.0.5"
 
 fast-deep-equal@^1.0.0:
@@ -4698,6 +4703,11 @@ lodash.merge@^4.6.0:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
 lodash.tail@^4.1.1:
   version "4.1.1"
@@ -6508,6 +6518,16 @@ readdirp@^2.0.0, readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
+realistic-structured-clone@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/realistic-structured-clone/-/realistic-structured-clone-2.0.2.tgz#2f8ec225b1f9af20efc79ac96a09043704414959"
+  integrity sha512-5IEvyfuMJ4tjQOuKKTFNvd+H9GSbE87IcendSBannE28PTrbolgaVg5DdEApRKhtze794iXqVUFKV60GLCNKEg==
+  dependencies:
+    core-js "^2.5.3"
+    domexception "^1.0.1"
+    typeson "^5.8.2"
+    typeson-registry "^1.0.0-alpha.20"
+
 recast@^0.12.5:
   version "0.12.9"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.12.9.tgz#e8e52bdb9691af462ccbd7c15d5a5113647a15f1"
@@ -7612,6 +7632,13 @@ tough-cookie@~2.4.3:
     psl "^1.1.24"
     punycode "^1.4.1"
 
+tr46@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  integrity sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=
+  dependencies:
+    punycode "^2.1.0"
+
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
@@ -7723,6 +7750,20 @@ typedarray@^0.0.6:
 typescript@^2.7.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
+
+typeson-registry@^1.0.0-alpha.20:
+  version "1.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/typeson-registry/-/typeson-registry-1.0.0-alpha.28.tgz#cc76b71cdafa7f39c0d39fba9573114675ff098b"
+  integrity sha512-WQD4dPXak+20mUiFFeaI0xh+dqiMQs2fmPFzX6akg1+WN74ocVFjYFwRbWNdtLuCUomxXrxAMP9dxjCakZQHvQ==
+  dependencies:
+    base64-arraybuffer-es6 "0.5.0"
+    typeson "5.13.0"
+    whatwg-url "7.0.0"
+
+typeson@5.13.0, typeson@^5.8.2:
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/typeson/-/typeson-5.13.0.tgz#dc65b23ea1978a315ed4c95e58a5b6936bcc3591"
+  integrity sha512-xcSaSt+hY/VcRYcqZuVkJwMjDXXJb4CZd51qDocpYw8waA314ygyOPlKhsGsw4qKuJ0tfLLUrxccrm+xvyS0AQ==
 
 uglify-es@^3.3.4:
   version "3.3.9"
@@ -8001,7 +8042,7 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
 
-webidl-conversions@^4.0.0:
+webidl-conversions@^4.0.0, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
@@ -8101,6 +8142,15 @@ whatwg-encoding@^1.0.1:
   resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz#57c235bc8657e914d24e1a397d3c82daee0a6ba3"
   dependencies:
     iconv-lite "0.4.19"
+
+whatwg-url@7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
+  integrity sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 whatwg-url@^4.3.0:
   version "4.8.0"


### PR DESCRIPTION
Outcomes is a feature recently introduced in OneSignal dashboard and currently supported by ios and android only. This PR adds outcomes support to Web SDK.

How outcomes work:
- Browser tracks all incoming notifications saving them to local db table with timestamps.
- Browser tracks all clicked notifications. If a clicked notification results in a new session to be created, it's considered direct.
- Each app can configure its own attribution window for outcomes. I believe the default is now 1 hour. If a new session is created within that time frame since getting a notif, the session is considered indirectly attributed to 1 or more notifications.
- If session is not directly attributed and there are no notifications within outcomes attribution time frame, session is considered unattributed.
- Session reports both attribution and duration of the session which is translated into weighted outcome.
- Same logic applies to custom outcomes. The only difference is that they have to be triggered by user's code via `OneSignal.sendOutcome(value, optional_value)`. The attribution is decided the same way as described above.

New session logic and outcomes implementation heavily rely on service worker (SW) and having push as part of SW so it's best supported by browsers that implemented push via SW events.

Safari's way of handling push makes it impossible to track direct and indirect outcomes making all of them to be unattributed.

This branch also includes improvements and bug fixes for session logic that became obvious during testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/621)
<!-- Reviewable:end -->
