### PR TITLE
Fixes for iframe subdomain on non-prod envs

### DIFF
--- a/src/context/shared/utils/Utils.ts
+++ b/src/context/shared/utils/Utils.ts
@@ -138,6 +138,16 @@ export class Utils {
   }
 
   /**
+   * Gives back the last x number of parts providing a string with a delimiter.
+   * Example: lastParts("api.staging.onesignal.com", ".", 3) will return "staging.onesignal.com"
+   */
+  public static lastParts(subject: string, delimiter: string, maxParts: number): string {
+    const parts = subject.split(delimiter);
+    const skipParts = Math.max(parts.length - maxParts, 0);
+    return parts.slice(skipParts).join(delimiter);
+  }
+
+  /**
    * Checks if a version is number is greater than or equal (AKA at least) to a specific compare
    *   to version.
    * Limited to only checking for major and minor version values, patch versions are ignored

--- a/src/managers/AltOriginManager.ts
+++ b/src/managers/AltOriginManager.ts
@@ -2,6 +2,7 @@ import { AppConfig } from '../models/AppConfig';
 import { EnvironmentKind } from '../models/EnvironmentKind';
 import ProxyFrameHost from '../modules/frames/ProxyFrameHost';
 import SdkEnvironment from './SdkEnvironment';
+import { Utils } from '../context/shared/utils/Utils';
 
 export default class AltOriginManager {
 
@@ -33,8 +34,7 @@ export default class AltOriginManager {
     if (subscribedProxyFrameHosts.length === 0) {
       // Use the first (preferred) host (os.tc in this case) if not subscribed to any
       preferredProxyFrameHost = allProxyFrameHosts[0];
-    }
-    else {
+    } else {
       // Otherwise if their was one or more use the highest preferred one in the list
       preferredProxyFrameHost = subscribedProxyFrameHosts[0];
     }

--- a/src/managers/AltOriginManager.ts
+++ b/src/managers/AltOriginManager.ts
@@ -1,7 +1,6 @@
 import { AppConfig } from '../models/AppConfig';
 import { EnvironmentKind } from '../models/EnvironmentKind';
 import ProxyFrameHost from '../modules/frames/ProxyFrameHost';
-import { contains } from '../utils';
 import SdkEnvironment from './SdkEnvironment';
 
 export default class AltOriginManager {
@@ -10,7 +9,13 @@ export default class AltOriginManager {
 
   }
 
-  static async discoverAltOrigin(appConfig): Promise<ProxyFrameHost> {
+  /*
+  * This loads all possible iframes that a site could be subscribed to
+  * (os.tc & onesignal.com) then checks to see we are subscribed to any.
+  * If we find what we are subscribed to both unsubscribe from onesignal.com.
+  * This method prefers os.tc over onesignal.com where possible.
+  */
+  static async discoverAltOrigin(appConfig: AppConfig): Promise<ProxyFrameHost> {
     const iframeUrls = AltOriginManager.getOneSignalProxyIframeUrls(appConfig);
 
     const allProxyFrameHosts: ProxyFrameHost[] = [];

--- a/src/managers/AltOriginManager.ts
+++ b/src/managers/AltOriginManager.ts
@@ -125,17 +125,4 @@ export default class AltOriginManager {
 
     return urls;
   }
-
-  /**
-   * Returns the URL of the OneSignal subscription popup.
-   */
-  static getOneSignalSubscriptionPopupUrls(config: AppConfig): Array<URL> {
-    const urls = AltOriginManager.getCanonicalSubscriptionUrls(config);
-
-    for (const url of urls) {
-      url.pathname = 'subscribe';
-    }
-
-    return urls;
-  }
 }

--- a/src/managers/AltOriginManager.ts
+++ b/src/managers/AltOriginManager.ts
@@ -87,20 +87,21 @@ export default class AltOriginManager {
   }
 
   /**
+   * Only used for sites using a OneSignal subdomain (AKA HTTP setup).
+   * 
    * Returns the array of possible URL in which the push subscription and
    * IndexedDb site data will be stored.
    *
-   * For native HTTPS sites not using a subdomain of our service, this is the
-   * top-level URL.
-   *
-   * For sites using a subdomain of our service, this URL was typically
-   * subdomain.onesignal.com, until we switched to subdomain.os.tc for a shorter
-   * origin to fit into Mac's native notifications on Chrome 59+.
+   * This URL was typically subdomain.onesignal.com, until we switched
+   * to subdomain.os.tc for a shorter origin to fit into Mac's native
+   * notifications on Chrome 59+.
    *
    * Because a user may be subscribed to subdomain.onesignal.com or
    * subdomain.os.tc, we have to load both in certain scenarios to determine
    * which the user is subscribed to; hence, this method returns an array of
    * possible URLs.
+   * 
+   * Order of URL is in priority order of one should be used.
    */
   static getCanonicalSubscriptionUrls(config: AppConfig,
                                       buildEnv: EnvironmentKind = SdkEnvironment.getApiEnv()
@@ -113,7 +114,7 @@ export default class AltOriginManager {
       return [legacyDomainUrl];
     }
 
-    // Always add subdomain.os.tc
+    // Use os.tc as a first pick
     const urls = [new URL(`https://${config.subdomain}.os.tc`)];
 
     if (config.httpUseOneSignalCom) {

--- a/src/managers/AltOriginManager.ts
+++ b/src/managers/AltOriginManager.ts
@@ -105,22 +105,19 @@ export default class AltOriginManager {
   static getCanonicalSubscriptionUrls(config: AppConfig,
                                       buildEnv: EnvironmentKind = SdkEnvironment.getApiEnv()
                                      ): Array<URL> {
-    let urls = [];
+    const apiUrl = SdkEnvironment.getOneSignalApiUrl(buildEnv);
+    const legacyDomainUrl = new URL(`https://${config.subdomain}.${apiUrl.host}`);
 
-    if (config.httpUseOneSignalCom) {
-      let legacyDomainUrl = SdkEnvironment.getOneSignalApiUrl(buildEnv);
-      // Add subdomain.onesignal.com
-      legacyDomainUrl.host = [config.subdomain, legacyDomainUrl.host].join('.');
-      urls.push(legacyDomainUrl);
+    // Staging and Dev don't support going through the os.tc domain
+    if (buildEnv !== EnvironmentKind.Production) {
+      return [legacyDomainUrl];
     }
 
-    let osTcDomainUrl = SdkEnvironment.getOneSignalApiUrl(buildEnv);
     // Always add subdomain.os.tc
-    osTcDomainUrl.host = [config.subdomain, 'os.tc'].join('.');
-    urls.push(osTcDomainUrl);
+    const urls = [new URL(`https://${config.subdomain}.os.tc`)];
 
-    for (const url of urls) {
-      url.pathname = '';
+    if (config.httpUseOneSignalCom) {
+      urls.push(legacyDomainUrl);
     }
 
     return urls;

--- a/test/unit/managers/AltOriginManager.ts
+++ b/test/unit/managers/AltOriginManager.ts
@@ -43,7 +43,41 @@ test(`should get correct canonical subscription URL for staging environment`, as
   t.is(stagingUrls[0].host, new URL(`https://test.${stagingDomain}`).host);
 });
 
+
+test(`should get correct canonical subscription URL when api.staging.onesignal.com is used`, async t => {
+  const stagingDomain = "staging.onesignal.com";
+  (<any>global).__API_ORIGIN__ = `api.${stagingDomain}`; 
+  const config = TestEnvironment.getFakeAppConfig();
+  config.subdomain = 'test';
+  config.httpUseOneSignalCom = true;
+
+  const browser = await TestEnvironment.stubDomEnvironment();
+  browser.changeURL(window, `http://${stagingDomain}`);
+
+  const stagingUrlsOsTcDomain = AltOriginManager.getCanonicalSubscriptionUrls(config, EnvironmentKind.Staging);
+  t.is(stagingUrlsOsTcDomain.length, 1);
+  t.is(stagingUrlsOsTcDomain[0].host, new URL(`https://test.${stagingDomain}`).host);
+});
+
 test(`should get correct canonical subscription URL for production environment`, async t => {
+  const config = TestEnvironment.getFakeAppConfig();
+  config.subdomain = 'test';
+  config.httpUseOneSignalCom = true;
+
+  const prodUrlsOsTcDomain = AltOriginManager.getCanonicalSubscriptionUrls(config, EnvironmentKind.Production);
+  t.is(prodUrlsOsTcDomain.length, 2);
+  t.is(prodUrlsOsTcDomain[0].host, new URL('https://test.os.tc').host);
+  t.is(prodUrlsOsTcDomain[1].host, new URL('https://test.onesignal.com').host);
+
+  config.httpUseOneSignalCom = false;
+  
+  const prodUrls = AltOriginManager.getCanonicalSubscriptionUrls(config, EnvironmentKind.Production);
+  t.is(prodUrls.length, 1);
+  t.is(prodUrls[0].host, new URL('https://test.os.tc').host);
+});
+
+test(`should get correct canonical subscription URL for production environment with api. prefix`, async t => {
+  (<any>global).__API_ORIGIN__ = `api.onesignal.com`; 
   const config = TestEnvironment.getFakeAppConfig();
   config.subdomain = 'test';
   config.httpUseOneSignalCom = true;

--- a/test/unit/managers/AltOriginManager.ts
+++ b/test/unit/managers/AltOriginManager.ts
@@ -12,35 +12,35 @@ test(`should get correct canonical subscription URL for development environment`
   config.httpUseOneSignalCom = true;
 
   const devUrlsOsTcDomain = AltOriginManager.getCanonicalSubscriptionUrls(config, EnvironmentKind.Development);
-  t.is(devUrlsOsTcDomain.length, 2);
+  t.is(devUrlsOsTcDomain.length, 1);
   t.is(devUrlsOsTcDomain[0].host, new URL('https://test.localhost:3001').host);
-  t.is(devUrlsOsTcDomain[1].host, new URL('https://test.os.tc:3001').host);
 
   config.httpUseOneSignalCom = false;
 
   const devUrls = AltOriginManager.getCanonicalSubscriptionUrls(config, EnvironmentKind.Development);
   t.is(devUrls.length, 1);
-  t.is(devUrls[0].host, new URL('https://test.os.tc:3001').host);
+  t.is(devUrls[0].host, new URL('https://test.localhost:3001').host);
 });
 
 test(`should get correct canonical subscription URL for staging environment`, async t => {
+  const stagingDomain = "staging.onesignal.com";
+  (<any>global).__API_ORIGIN__ = stagingDomain; 
   const config = TestEnvironment.getFakeAppConfig();
   config.subdomain = 'test';
   config.httpUseOneSignalCom = true;
 
   const browser = await TestEnvironment.stubDomEnvironment();
-  browser.changeURL(window, "http://staging-01.onesignal.com");
+  browser.changeURL(window, `http://${stagingDomain}`);
 
   const stagingUrlsOsTcDomain = AltOriginManager.getCanonicalSubscriptionUrls(config, EnvironmentKind.Staging);
-  t.is(stagingUrlsOsTcDomain.length, 2);
-  t.is(stagingUrlsOsTcDomain[0].host, new URL('https://test.staging-01.onesignal.com').host);
-  t.is(stagingUrlsOsTcDomain[1].host, new URL('https://test.os.tc').host);
+  t.is(stagingUrlsOsTcDomain.length, 1);
+  t.is(stagingUrlsOsTcDomain[0].host, new URL(`https://test.${stagingDomain}`).host);
 
+  // staging does not support an alt domain so it should be the same.
   config.httpUseOneSignalCom = false;
-
   const stagingUrls = AltOriginManager.getCanonicalSubscriptionUrls(config, EnvironmentKind.Staging);
   t.is(stagingUrls.length, 1);
-  t.is(stagingUrls[0].host, new URL('https://test.os.tc').host);
+  t.is(stagingUrls[0].host, new URL(`https://test.${stagingDomain}`).host);
 });
 
 test(`should get correct canonical subscription URL for production environment`, async t => {
@@ -50,8 +50,8 @@ test(`should get correct canonical subscription URL for production environment`,
 
   const prodUrlsOsTcDomain = AltOriginManager.getCanonicalSubscriptionUrls(config, EnvironmentKind.Production);
   t.is(prodUrlsOsTcDomain.length, 2);
-  t.is(prodUrlsOsTcDomain[0].host, new URL('https://test.onesignal.com').host);
-  t.is(prodUrlsOsTcDomain[1].host, new URL('https://test.os.tc').host);
+  t.is(prodUrlsOsTcDomain[0].host, new URL('https://test.os.tc').host);
+  t.is(prodUrlsOsTcDomain[1].host, new URL('https://test.onesignal.com').host);
 
   config.httpUseOneSignalCom = false;
   

--- a/test/unit/modules/sdkEnvironment.ts
+++ b/test/unit/modules/sdkEnvironment.ts
@@ -71,6 +71,8 @@ test('API URL should be valid for development environment', async t => {
 });
 
 test('API URL should be valid for staging environment', async t => {
+  const browser = await TestEnvironment.stubDomEnvironment();
+  browser.changeURL(window, "https://localhost");
   const expectedUrl = `https://${window.location.host}/api/v1`;
   t.is(SdkEnvironment.getOneSignalApiUrl(EnvironmentKind.Staging).toString(), expectedUrl);
 });


### PR DESCRIPTION
* Omit os.tc for non-prod envs for iframe
  - Only the dev or staging host can be used for the subdomain
* Refactored a number of methods in AltOriginManager.ts
   - Recommend reviewing commit by commit to see these
* Fixes 2 tests that PR #620 broke
https://travis-ci.org/github/OneSignal/OneSignal-Website-SDK/builds/672001235?utm_source=github_status

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/622)
<!-- Reviewable:end -->
