### PR TITLE
Outcomes fix

### DIFF
--- a/src/helpers/ServiceWorkerHelper.ts
+++ b/src/helpers/ServiceWorkerHelper.ts
@@ -1,5 +1,5 @@
 import { OneSignalApiSW } from "../OneSignalApiSW";
-import Log from "../libraries/Log";
+import Log from "../libraries/sw/Log";
 import Path from "../models/Path";
 import { Session, initializeNewSession, SessionOrigin, SessionStatus } from "../models/Session";
 import { InvalidStateError, InvalidStateReason } from "../errors/InvalidStateError";

--- a/src/helpers/sw/CancelableTimeout.ts
+++ b/src/helpers/sw/CancelableTimeout.ts
@@ -1,4 +1,4 @@
-import Log from "../../libraries/Log";
+import Log from "../../libraries/sw/Log";
 
 export interface CancelableTimeoutPromise {
   cancel: () => void;

--- a/src/libraries/WorkerMessenger.ts
+++ b/src/libraries/WorkerMessenger.ts
@@ -27,6 +27,7 @@ export enum WorkerMessengerCommand {
   SessionDeactivate = 'os.session.deactivate',
   AreYouVisible = "os.page_focused_request",
   AreYouVisibleResponse = "os.page_focused_response",
+  SetLogging = "os.set_sw_logging",
 }
 
 export interface WorkerMessengerMessage {

--- a/src/libraries/sw/Log.ts
+++ b/src/libraries/sw/Log.ts
@@ -1,0 +1,31 @@
+import { OSServiceWorkerFields } from "../../service-worker/types";
+
+declare var self: ServiceWorkerGlobalScope & OSServiceWorkerFields;
+
+export default class Log {
+  static debug(...args: any[]): void {
+    if (!!self.shouldLog) {
+      console.debug(...args);
+    }
+  }
+  static trace(...args: any[]): void {
+    if (!!self.shouldLog) {
+      console.trace(...args);
+    }
+  }
+  static info(...args: any[]): void {
+    if (!!self.shouldLog) {
+      console.info(...args);
+    }
+  }
+  static warn(...args: any[]): void {
+    if (!!self.shouldLog) {
+      console.warn(...args);
+    }
+  }
+  static error(...args: any[]): void {
+    if (!!self.shouldLog) {
+      console.error(...args);
+    }
+  }
+}

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -17,7 +17,7 @@ import {
   UpsertSessionPayload, DeactivateSessionPayload,
   PageVisibilityRequest, PageVisibilityResponse, SessionStatus
 } from "../models/Session";
-import Log from "../libraries/Log";
+import Log from "../libraries/sw/Log";
 import { ConfigHelper } from "../helpers/ConfigHelper";
 import { OneSignalUtils } from "../utils/OneSignalUtils";
 import { Utils } from "../context/shared/utils/Utils";
@@ -216,6 +216,15 @@ export class ServiceWorker {
         self.clientsStatus.receivedResponsesCount++;
         if (payload.focused) {
           self.clientsStatus.hasAnyActiveSessions = true;
+        }
+      }
+    );
+    ServiceWorker.workerMessenger.on(
+      WorkerMessengerCommand.SetLogging, async (payload: {shouldLog: boolean}) => {
+        if (payload.shouldLog) {
+          self.shouldLog = true;
+        } else {
+          self.shouldLog = undefined;
         }
       }
     );

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -380,8 +380,8 @@ export class ServiceWorker {
       // Test if this window client is the HTTP subdomain iFrame pointing to subdomain.onesignal.com
       if (client.frameType && client.frameType === 'nested') {
         // Subdomain iFrames point to 'https://subdomain.onesignal.com...'
-        if (!Utils.contains(client.url, SdkEnvironment.getOneSignalApiUrl().host) &&
-            !Utils.contains(client.url, '.os.tc')) {
+        if (!Utils.contains(client.url, '.os.tc') &&
+            !Utils.contains(client.url, '.onesignal.com')) {
           continue;
         }
         // Indicates this window client is an HTTP subdomain iFrame

--- a/src/service-worker/types.ts
+++ b/src/service-worker/types.ts
@@ -10,6 +10,7 @@ export interface ClientStatus {
 }
 
 export interface OSServiceWorkerFields { 
+  shouldLog?: boolean;
   debounceSessionTimerId?: number;
   finalizeSessionTimerId?: number;
   clientsStatus?: ClientStatus;


### PR DESCRIPTION
Unfortunately I still was not able to find a reason for not seeing on_focus traffic to go up.

But I fixed one issue for staging where we were not checking correct domain for clients and it resulted in tracking active clients incorrectly. Should not be the case on production as far as I can see but shouldn't hurt either.

ALso added logging for service worker. Controlled by a boolean variable on SW which can be set through inspect of service worker directly, i.e. `self.shouldLog = true`, or via postMessage for browsers that don't allow inspect:
```
navigator.serviceWorker.controller.postMessage({
  command: "os.set_sw_logging",
  payload: {shouldLog: true}
})
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/628)
<!-- Reviewable:end -->
