### PR TITLE
Check require-user-interaction in showDelayedPrompt and change type

### DIFF
--- a/src/managers/PromptsManager.ts
+++ b/src/managers/PromptsManager.ts
@@ -21,6 +21,7 @@ import TestHelper from '../helpers/TestHelper';
 import InitHelper, { RegisterOptions } from '../helpers/InitHelper';
 import { SERVER_CONFIG_DEFAULTS_PROMPT_DELAYS } from '../config/index';
 import { wrapSetTimeoutInPromise } from '../helpers/page/WrapSetTimeoutInPromise';
+import { EnvironmentInfoHelper } from '../context/browser/helpers/EnvironmentInfoHelper';
 
 export interface AutoPromptOptions {
   force?: boolean;
@@ -122,6 +123,11 @@ export class PromptsManager {
     if (typeof timeDelaySeconds !== "number") {
       Log.error("internalShowDelayedPrompt: timeDelay not a number");
       return;
+    }
+
+    const { requiresUserInteraction } = EnvironmentInfoHelper.getEnvironmentInfo();
+    if (requiresUserInteraction && type === DelayedPromptType.Native) {
+      type = DelayedPromptType.Slidedown;
     }
 
     switch(type){


### PR DESCRIPTION
This fixes the public method by checking if the browser requires user-interaction. If so, force the prompt type to be "slidedown"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/631)
<!-- Reviewable:end -->
