### PR TITLE
Add device_type to notification open endpoint

### DIFF
--- a/test/unit/context/sw/ServiceWorker.ts
+++ b/test/unit/context/sw/ServiceWorker.ts
@@ -214,7 +214,8 @@ test('onNotificationClicked - notification click sends PUT api/v1/notification',
       t.deepEqual(JSON.parse(requestBody), {
         app_id: appConfig.appId,
         opened: true,
-        player_id: playerId
+        player_id: playerId,
+        device_type: 5
       });
       return { success: true };
     });


### PR DESCRIPTION
Include an additional parameter device_type to the request body in onNotificationOpen function of ServiceWorker class https://github.com/OneSignal/OneSignal-Website-SDK/blob/master/src/service-worker/ServiceWorker.ts#L838 .

device_type could be resolved through PushDeviceRecord.prototype.getDeliveryPlatform()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/637)
<!-- Reviewable:end -->
