### PR TITLE
fix installWorker() annoying error message

### DIFF
--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -17,6 +17,7 @@ import ServiceWorkerHelper, { ServiceWorkerActiveState, ServiceWorkerManagerConf
 import { ContextSWInterface } from '../models/ContextSW';
 import { Utils } from "../context/shared/utils/Utils";
 import { PageVisibilityRequest, PageVisibilityResponse } from "../models/Session";
+import { once } from '../utils';
 
 export class ServiceWorkerManager {
   private context: ContextSWInterface;
@@ -314,16 +315,18 @@ export class ServiceWorkerManager {
       }
       else {
         Log.debug("installWorker - Awaiting on navigator.serviceWorker's 'controllerchange' event");
-        navigator.serviceWorker.addEventListener('controllerchange', async e => {
+        once(navigator.serviceWorker, 'controllerchange', async (e, removeListener) => {
           const postInstallWorkerState = await this.getActiveState();
           if (postInstallWorkerState !== preInstallWorkerState &&
             postInstallWorkerState !== ServiceWorkerActiveState.Installing) {
+
+            removeListener();
             resolve();
           }
           else {
             Log.error("installWorker - SW's 'controllerchange' fired but no state change!");
           }
-        });
+        }, true);
       }
     });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -331,7 +331,7 @@ export function substringAfter(string: string, search: string) {
   return string.substr(string.indexOf(search) + search.length);
 }
 
-export function once(targetSelectorOrElement: string | string[] | Element | Document, event: string, task: Function, manualDestroy=false) {
+export function once(targetSelectorOrElement: string | string[] | Element | Document | ServiceWorkerContainer, event: string, task: Function, manualDestroy=false) {
   if (!event) {
     Log.error('Cannot call on() with no event: ', event);
   }
@@ -353,7 +353,7 @@ export function once(targetSelectorOrElement: string | string[] | Element | Docu
     var taskWrapper = (function () {
       var internalTaskFunction = function (e: Event) {
         var destroyEventListener = function() {
-          (targetSelectorOrElement as Element | Document).removeEventListener(e.type, taskWrapper);
+          (targetSelectorOrElement as Element | Document | ServiceWorkerContainer).removeEventListener(e.type, taskWrapper);
         };
         if (!manualDestroy) {
           destroyEventListener();
@@ -362,7 +362,7 @@ export function once(targetSelectorOrElement: string | string[] | Element | Docu
       };
       return internalTaskFunction;
     })();
-    (targetSelectorOrElement as Element | Document).addEventListener(event, taskWrapper);
+    (targetSelectorOrElement as Element | Document | ServiceWorkerContainer).addEventListener(event, taskWrapper);
   }
   else
     throw new Error(`${targetSelectorOrElement} must be a CSS selector string or DOM Element object.`);


### PR DESCRIPTION
we have a lot of `"installWorker - SW's 'controllerchange' fired but no state change!"` errors in our error tracking system. i discovered that this happened during worker update. it updates successfully, but prints error. this happens due event listener doesn't removed and `this.installAlternatingWorker()` below will trigger this listener again, but we don't need it because promise has already been resolved

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/643)
<!-- Reviewable:end -->

