### PR TITLE
Category Slidedown Testing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 
       # docker for Ubuntu VM
       # network_mode: "host"
-      
+
       # docker for mac
       ports:
           - published: 4001

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -485,6 +485,11 @@ export default class OneSignal {
       tags: tags
     });
     executeCallback(callback, tags);
+
+    /* for testing only */
+    Event.trigger(OneSignal.EVENTS.TEST_TAGS_SENT);
+    /* for testing only */
+
     return tags;
   }
 
@@ -1070,6 +1075,7 @@ export default class OneSignal {
     TEST_WOULD_DISPLAY: 'testWouldDisplay',
     POPUP_WINDOW_TIMEOUT: 'popupWindowTimeout',
     SESSION_STARTED: "os.sessionStarted",
+    TEST_TAGS_SENT: 'testTagsSent'
   };
 }
 

--- a/src/OneSignalApiShared.ts
+++ b/src/OneSignalApiShared.ts
@@ -18,7 +18,7 @@ export default class OneSignalApiShared {
   static updatePlayer(appId: string, playerId: string, options?: Object) {
     Utils.enforceAppId(appId);
     Utils.enforcePlayerId(playerId);
-    return OneSignalApiBase.put(`players/${playerId}`, {app_id: appId, ...options});
+    return OneSignalApiBase.put(`players/${playerId}`, { app_id: appId, ...options });
   }
 
   static sendNotification(appId: string, playerIds: Array<string>, titles, contents, url, icon, data, buttons) {

--- a/src/managers/PromptsManager.ts
+++ b/src/managers/PromptsManager.ts
@@ -224,7 +224,7 @@ export class PromptsManager {
 
   public async internalShowCategorySlidedown(options?: AutoPromptOptions): Promise<void> {
     const promptOptions = await this.context.appConfig.userConfig.promptOptions;
-    const isUsingSlidedownOptions = promptOptions && promptOptions.slidedown && promptOptions.slidedown;
+    const isUsingSlidedownOptions = promptOptions && promptOptions.slidedown;
     const isUsingCategoryOptions = isUsingSlidedownOptions && promptOptions!.slidedown!.categories;
     const categoryOptions = promptOptions!.slidedown!.categories;
 

--- a/src/slidedown/Slidedown.ts
+++ b/src/slidedown/Slidedown.ts
@@ -22,6 +22,16 @@ export default class Slidedown {
   private isInSaveState: boolean;
   public isShowingFailureMessage: boolean;
 
+  // identifiers and style classes
+  public static readonly onesignalSlidedownContainerClass = "onesignal-slidedown-container";
+  public static readonly onesignalResetClass = "onesignal-reset";
+  public static readonly onesignalSlidedownDialogClass = "onesignal-slidedown-dialog";
+  public static readonly onesignalSavingLoadingIndicatorHolderClass = "onesignal-saving-loading-indicator-holder";
+  public static readonly onesignalSlidedownAllowButtonClass = "onesignal-slidedown-allow-button";
+  public static readonly onesignalSlidedownCancelButtonClass = "onesignal-slidedown-cancel-button";
+  public static readonly slidedownBody = "slidedown-body";
+  public static readonly slidedownFooter = "slidedown-footer";
+
   static get EVENTS() {
     return {
       ALLOW_CLICK: 'slidedownAllowClick',
@@ -61,8 +71,8 @@ export default class Slidedown {
       this.notificationIcons = icons;
 
       // Remove any existing container
-      if (this.container.className.includes("onesignal-slidedown-container")) {
-          removeDomElement('#onesignal-slidedown-container');
+      if (this.container.className.includes(Slidedown.onesignalSlidedownContainerClass)) {
+          removeDomElement(`#${Slidedown.onesignalSlidedownContainerClass}`);
       }
       const positiveButtonText = isInUpdateMode ?
         this.options.positiveUpdateButton : this.options.acceptButtonText;
@@ -81,10 +91,10 @@ export default class Slidedown {
 
       // Insert the container
       addDomElement('body', 'beforeend',
-          '<div id="onesignal-slidedown-container" class="onesignal-slidedown-container onesignal-reset"></div>');
+          `<div id="${Slidedown.onesignalSlidedownContainerClass}" class="${Slidedown.onesignalSlidedownContainerClass} ${Slidedown.onesignalResetClass}"></div>`);
       // Insert the dialog
       addDomElement(this.container, 'beforeend',
-          `<div id="onesignal-slidedown-dialog" class="onesignal-slidedown-dialog">${dialogHtml}</div>`);
+          `<div id="${Slidedown.onesignalSlidedownDialogClass}" class="${Slidedown.onesignalSlidedownDialogClass}">${dialogHtml}</div>`);
 
       // Add dynamic button width by class
       // Need this due to saving state (with loading indicator) which may be different size as text
@@ -122,7 +132,7 @@ export default class Slidedown {
       if (event.target === this.dialog &&
           (event.animationName === 'slideDownExit' || event.animationName === 'slideUpExit')) {
           // Uninstall the event listener for animationend
-          removeDomElement('#onesignal-slidedown-container');
+          removeDomElement(`#${Slidedown.onesignalSlidedownContainerClass}`);
           destroyListenerFn();
           Event.trigger(Slidedown.EVENTS.CLOSED);
       }
@@ -134,7 +144,7 @@ export default class Slidedown {
    */
   toggleSaveState() {
     if (!this.isInSaveState) {
-      this.allowButton.innerHTML = `Saving...<div id="saving-loading-indicator-holder" class="saving-loading-indicator-holder"></div>`;
+      this.allowButton.innerHTML = `Saving...<div id="${Slidedown.onesignalSavingLoadingIndicatorHolderClass}" class="${Slidedown.onesignalSavingLoadingIndicatorHolderClass}"></div>`;
       addDomElement(this.savingLoadingIndicatorHolder, 'beforeend', getLoadingIndicatorWithColor("#FFFFFF"));
       (<HTMLButtonElement>this.allowButton).disabled = true;
       addCssClass(this.allowButton, 'disabled');
@@ -142,7 +152,7 @@ export default class Slidedown {
     } else {
       // positiveUpdateButton should be defined as written in MainHelper.getSlidedownPermissionMessageOptions
       this.allowButton.innerHTML = this.options.positiveUpdateButton!;
-      removeDomElement('#saving-loading-indicator-holder');
+      removeDomElement(`#${Slidedown.onesignalSavingLoadingIndicatorHolderClass}`);
       (<HTMLButtonElement>this.allowButton).disabled = false;
       removeCssClass(this.allowButton, 'disabled');
       removeCssClass(this.allowButton, 'onesignal-saving-state-button');
@@ -165,23 +175,23 @@ export default class Slidedown {
   }
 
   get container() {
-    return getDomElementOrStub('#onesignal-slidedown-container');
+    return getDomElementOrStub(`#${Slidedown.onesignalSlidedownContainerClass}`);
   }
 
   get dialog() {
-    return getDomElementOrStub('#onesignal-slidedown-dialog');
+    return getDomElementOrStub(`#${Slidedown.onesignalSlidedownDialogClass}`);
   }
 
   get allowButton() {
-    return getDomElementOrStub('#onesignal-slidedown-allow-button');
+    return getDomElementOrStub(`#${Slidedown.onesignalSlidedownAllowButtonClass}`);
   }
 
   get cancelButton() {
-    return getDomElementOrStub('#onesignal-slidedown-cancel-button');
+    return getDomElementOrStub(`#${Slidedown.onesignalSlidedownCancelButtonClass}`);
   }
 
   get savingLoadingIndicatorHolder() {
-    return getDomElementOrStub('#saving-loading-indicator-holder');
+    return getDomElementOrStub(`#${Slidedown.onesignalSavingLoadingIndicatorHolderClass}`);
   }
 
   get slidedownFooter() {

--- a/src/slidedown/Slidedown.ts
+++ b/src/slidedown/Slidedown.ts
@@ -9,12 +9,12 @@ import {
   once,
   removeDomElement,
   removeCssClass,
-  getDomElementOrStub } from '../utils';
+  getDomElementOrStub, 
+  sanitizeHtmlAndDoubleQuotes} from '../utils';
 import { SlidedownPermissionMessageOptions } from '../models/Prompts';
 import { SERVER_CONFIG_DEFAULTS_SLIDEDOWN } from '../config';
 import getLoadingIndicatorWithColor from './LoadingIndicator';
 import getDialogHTML from './DialogHTML';
-import sanitizeHtml from 'sanitize-html';
 
 export default class Slidedown {
   public options: SlidedownPermissionMessageOptions;
@@ -36,14 +36,14 @@ export default class Slidedown {
         options = MainHelper.getSlidedownPermissionMessageOptions(OneSignal.config.userConfig.promptOptions);
     }
     this.options = options;
-    this.options.actionMessage = sanitizeHtml(options.actionMessage.substring(0, 90));
-    this.options.acceptButtonText = sanitizeHtml(options.acceptButtonText.substring(0, 16));
-    this.options.cancelButtonText = sanitizeHtml(options.cancelButtonText.substring(0, 16));
+    this.options.actionMessage = sanitizeHtmlAndDoubleQuotes(options.actionMessage.substring(0, 90));
+    this.options.acceptButtonText = sanitizeHtmlAndDoubleQuotes(options.acceptButtonText.substring(0, 16));
+    this.options.cancelButtonText = sanitizeHtmlAndDoubleQuotes(options.cancelButtonText.substring(0, 16));
     this.options.positiveUpdateButton = options.positiveUpdateButton ?
-      sanitizeHtml(options.positiveUpdateButton).substring(0, 16):
+      sanitizeHtmlAndDoubleQuotes(options.positiveUpdateButton.substring(0, 16)):
       SERVER_CONFIG_DEFAULTS_SLIDEDOWN.categoryDefaults.positiveUpdateButton;
     this.options.negativeUpdateButton = options.negativeUpdateButton ?
-      sanitizeHtml(options.negativeUpdateButton).substring(0, 16) :
+      sanitizeHtmlAndDoubleQuotes(options.negativeUpdateButton.substring(0, 16)) :
       SERVER_CONFIG_DEFAULTS_SLIDEDOWN.categoryDefaults.negativeUpdateButton;
     this.options.updateMessage = !!options.updateMessage ? sanitizeHtml(options.updateMessage).substring(0, 90) :
       SERVER_CONFIG_DEFAULTS_SLIDEDOWN.categoryDefaults.updateMessage;

--- a/src/slidedown/Slidedown.ts
+++ b/src/slidedown/Slidedown.ts
@@ -9,7 +9,7 @@ import {
   once,
   removeDomElement,
   removeCssClass,
-  getDomElementOrStub, 
+  getDomElementOrStub,
   sanitizeHtmlAndDoubleQuotes} from '../utils';
 import { SlidedownPermissionMessageOptions } from '../models/Prompts';
 import { SERVER_CONFIG_DEFAULTS_SLIDEDOWN } from '../config';
@@ -55,7 +55,8 @@ export default class Slidedown {
     this.options.negativeUpdateButton = options.negativeUpdateButton ?
       sanitizeHtmlAndDoubleQuotes(options.negativeUpdateButton.substring(0, 16)) :
       SERVER_CONFIG_DEFAULTS_SLIDEDOWN.categoryDefaults.negativeUpdateButton;
-    this.options.updateMessage = !!options.updateMessage ? sanitizeHtml(options.updateMessage).substring(0, 90) :
+    this.options.updateMessage = !!options.updateMessage ?
+      sanitizeHtmlAndDoubleQuotes(options.updateMessage).substring(0, 90) :
       SERVER_CONFIG_DEFAULTS_SLIDEDOWN.categoryDefaults.updateMessage;
 
     this.notificationIcons = null;

--- a/src/slidedown/TaggingContainer.ts
+++ b/src/slidedown/TaggingContainer.ts
@@ -5,12 +5,18 @@ import {
     addCssClass,
     removeCssClass,
     getDomElementOrStub,
-    getAllDomElementsOrStub, 
+    getAllDomElementsOrStub,
     sanitizeHtmlAndDoubleQuotes} from '../utils';
 import getLoadingIndicatorWithColor from './LoadingIndicator';
 
 export default class TaggingContainer {
     private html: string = "";
+
+    /* for testing only */
+    public TESTING = {
+        getCheckedTagCategories: this._getCheckedTagCategories
+    };
+    /* for testing only */
 
     public mount(remoteTagCategories: Array<TagCategory>, existingPlayerTags?: TagsObject): void {
         this.generateHTML(remoteTagCategories, existingPlayerTags);
@@ -39,14 +45,16 @@ export default class TaggingContainer {
     }
 
     /**
-     * Finds intersection between remoteTagCategories (from config) and existingPlayerTags (from `getTags`)
+     * Returns checked TagCategory[] using unchecked remoteTagCategories (from config)
+     * and existingPlayerTags (from `getTags`)
      * @param  {TagCategory[]} remoteTagCategories
      * @param  {TagsObject} existingPlayerTags?
      */
-    private getCheckedTagCategories(remoteTagCategories: TagCategory[], existingPlayerTags?: TagsObject)
+    private _getCheckedTagCategories(remoteTagCategories: TagCategory[], existingPlayerTags?: TagsObject)
         : TagCategory[] {
+            const remoteTagCategoriesCopy: TagCategory[] = JSON.parse(JSON.stringify(remoteTagCategories));
             return !!existingPlayerTags ?
-                remoteTagCategories.map(elem => {
+                remoteTagCategoriesCopy.map(elem => {
                     const existingTagValue = <boolean>existingPlayerTags[elem.tag];
                     elem.checked = existingTagValue;
                     return elem;
@@ -54,7 +62,7 @@ export default class TaggingContainer {
     }
 
     private generateHTML(remoteTagCategories: TagCategory[], existingPlayerTags?: TagsObject): void {
-        const checkedTagCategories = this.getCheckedTagCategories(remoteTagCategories, existingPlayerTags);
+        const checkedTagCategories = this._getCheckedTagCategories(remoteTagCategories, existingPlayerTags);
         const firstColumnArr = checkedTagCategories.filter(elem => checkedTagCategories.indexOf(elem) % 2 === 0);
         const secondColumnArr = checkedTagCategories.filter(elem => checkedTagCategories.indexOf(elem) % 2);
         let innerHtml = `<div class="tagging-container-col">`;
@@ -93,6 +101,8 @@ export default class TaggingContainer {
             target.setAttribute("checked", isChecked.toString());
         }
     }
+
+    // static
 
     static getValuesFromTaggingContainer(): TagsObject {
         const selector = "#slidedown-body > div.tagging-container > div > label > input[type=checkbox]";

--- a/src/slidedown/TaggingContainer.ts
+++ b/src/slidedown/TaggingContainer.ts
@@ -40,10 +40,6 @@ export default class TaggingContainer {
         addCssClass("#onesignal-slidedown-allow-button", 'disabled');
     }
 
-    public getHtml(): string {
-        return this.html;
-    }
-
     /**
      * Returns checked TagCategory[] using unchecked remoteTagCategories (from config)
      * and existingPlayerTags (from `getTags`)

--- a/src/slidedown/TaggingContainer.ts
+++ b/src/slidedown/TaggingContainer.ts
@@ -5,9 +5,9 @@ import {
     addCssClass,
     removeCssClass,
     getDomElementOrStub,
-    getAllDomElementsOrStub } from '../utils';
+    getAllDomElementsOrStub, 
+    sanitizeHtmlAndDoubleQuotes} from '../utils';
 import getLoadingIndicatorWithColor from './LoadingIndicator';
-import sanitizeHtml from 'sanitize-html';
 
 export default class TaggingContainer {
     private html: string = "";
@@ -33,6 +33,11 @@ export default class TaggingContainer {
         (<HTMLButtonElement>allowButton).disabled = true;
         addCssClass("#onesignal-slidedown-allow-button", 'disabled');
     }
+
+    public getHtml(): string {
+        return this.html;
+    }
+
     /**
      * Finds intersection between remoteTagCategories (from config) and existingPlayerTags (from `getTags`)
      * @param  {TagCategory[]} remoteTagCategories
@@ -69,12 +74,12 @@ export default class TaggingContainer {
 
     private getCategoryLabelHtml(tagCategory: TagCategory): string {
         const { label } = tagCategory;
-        return `<label class="onesignal-category-label" title="${sanitizeHtml(label)}">
-        <span class="onesignal-category-label-text">${sanitizeHtml(label)}</span>
-        <input type="checkbox" value="${sanitizeHtml(tagCategory.tag)}"
-            ${tagCategory.checked ? `checked="${sanitizeHtml(tagCategory.checked)}` : ``}">
-        <span class="onesignal-checkmark"></span></label>
-        <div style="clear:both"></div>`;
+        return `<label class="onesignal-category-label" title="${sanitizeHtmlAndDoubleQuotes(label)}">`+
+        `<span class="onesignal-category-label-text">${sanitizeHtmlAndDoubleQuotes(label)}</span>`+
+        `<input type="checkbox" value="${sanitizeHtmlAndDoubleQuotes(tagCategory.tag)}"`+
+            `${tagCategory.checked ? `checked="${sanitizeHtmlAndDoubleQuotes(`${tagCategory.checked}`)}"` : ''}>`+
+        `<span class="onesignal-checkmark"></span></label>`+
+        `<div style="clear:both"></div>`;
     }
 
     private get taggingContainer(){

--- a/src/slidedown/TaggingContainer.ts
+++ b/src/slidedown/TaggingContainer.ts
@@ -33,15 +33,23 @@ export default class TaggingContainer {
         (<HTMLButtonElement>allowButton).disabled = true;
         addCssClass("#onesignal-slidedown-allow-button", 'disabled');
     }
+    /**
+     * Finds intersection between remoteTagCategories (from config) and existingPlayerTags (from `getTags`)
+     * @param  {TagCategory[]} remoteTagCategories
+     * @param  {TagsObject} existingPlayerTags?
+     */
+    private getCheckedTagCategories(remoteTagCategories: TagCategory[], existingPlayerTags?: TagsObject)
+        : TagCategory[] {
+            return !!existingPlayerTags ?
+                remoteTagCategories.map(elem => {
+                    const existingTagValue = <boolean>existingPlayerTags[elem.tag];
+                    elem.checked = existingTagValue;
+                    return elem;
+                }) : remoteTagCategories;
+    }
 
     private generateHTML(remoteTagCategories: TagCategory[], existingPlayerTags?: TagsObject): void {
-        const checkedTagCategories = !!existingPlayerTags ?
-            remoteTagCategories.map(elem => {
-                const existingTagValue = <boolean>existingPlayerTags[elem.tag];
-                elem.checked = existingTagValue;
-                return elem;
-            })
-            : remoteTagCategories;
+        const checkedTagCategories = this.getCheckedTagCategories(remoteTagCategories, existingPlayerTags);
         const firstColumnArr = checkedTagCategories.filter(elem => checkedTagCategories.indexOf(elem) % 2 === 0);
         const secondColumnArr = checkedTagCategories.filter(elem => checkedTagCategories.indexOf(elem) % 2);
         let innerHtml = `<div class="tagging-container-col">`;

--- a/src/stylesheets/slidedown.scss
+++ b/src/stylesheets/slidedown.scss
@@ -212,7 +212,7 @@ $border-radius: 0.5em;
     }
   }
 
-  .saving-loading-indicator-holder {
+  .onesignal-saving-loading-indicator-holder {
     display: flex;
   }
 
@@ -340,7 +340,7 @@ $border-radius: 0.5em;
         }
       }
 
-      &.saving-loading-indicator-holder {
+      &.onesignal-saving-loading-indicator-holder {
         display: flex;
       }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -431,5 +431,5 @@ export function getAllDomElementsOrStub(selector: string): NodeList {
 }
 
 export function sanitizeHtmlAndDoubleQuotes(input: string) {
-  return sanitizeHtml(input).replace(/['"]+/g, '').replace(/[\s]+$/g, '');
+  return sanitizeHtml(input).replace(/["]+/g, '').replace(/[\s]+$/g, '');
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import { PermissionUtils } from './utils/PermissionUtils';
 import { BrowserUtils } from './utils/BrowserUtils';
 import { Utils } from "./context/shared/utils/Utils";
 import bowser from 'bowser';
+import sanitizeHtml from 'sanitize-html';
 
 export function isArray(variable: any) {
   return Object.prototype.toString.call(variable) === '[object Array]';
@@ -427,4 +428,8 @@ export function getAllDomElementsOrStub(selector: string): NodeList {
     return new NodeList();
   }
   return foundElementList;
+}
+
+export function sanitizeHtmlAndDoubleQuotes(input: string) {
+  return sanitizeHtml(input).replace(/['"]+/g, '').replace(/[\s]+$/g, '');
 }

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -30,7 +30,12 @@ import { EnvironmentInfo } from  '../../../src/context/browser/models/Environmen
 import { EnvironmentInfoHelper } from '../../../src/context/browser/helpers/EnvironmentInfoHelper';
 import Slidedown from '../../../src/slidedown/Slidedown';
 import { ExecutionContext } from 'ava';
-import { InitTestHelper, mockWebPushAnalytics, stubMessageChannel, mockIframeMessaging, mockGetIcon } from '../tester/utils';
+import {
+  InitTestHelper,
+  mockWebPushAnalytics,
+  stubMessageChannel,
+  mockIframeMessaging,
+  mockGetIcon } from '../tester/utils';
 import OneSignalApiBase from '../../../src/OneSignalApiBase';
 import { SessionManager } from '../../../src/managers/sessionManager/page/SessionManager';
 import TagManager from '../../../src/managers/tagManager/page/TagManager';

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -28,6 +28,7 @@ import deepmerge = require("deepmerge");
 import { RecursivePartial } from '../../../src/context/shared/utils/Utils';
 import { EnvironmentInfo } from  '../../../src/context/browser/models/EnvironmentInfo';
 import { EnvironmentInfoHelper } from '../../../src/context/browser/helpers/EnvironmentInfoHelper';
+import Slidedown from '../../../src/slidedown/Slidedown';
 
 // NodeJS.Global
 declare var global: any;
@@ -188,8 +189,10 @@ export class TestEnvironment {
   }
 
   static async stubDomEnvironment(config?: TestEnvironmentConfig) {
-    if (!config)
+    if (!config) {
       config = {};
+    }
+
     let url: string | undefined = undefined;
     let isSecureContext: boolean | undefined = undefined;
     if (config.httpOrHttps == HttpHttpsEnvironment.Http) {
@@ -209,7 +212,12 @@ export class TestEnvironment {
       <div class="${CustomLink.containerClass}"></div>\
       <div class="${CustomLink.containerClass}"></div>\
       <button class="${CustomLink.subscribeClass}"></button>\
-      </head><body></body></html>`;
+      </head><body>\
+        <div id="${Slidedown.slidedownBody}"></div>\
+        <div id="${Slidedown.slidedownFooter}">\
+        <button id="onesignal-slidedown-allow-button"></button>\
+        <button id="onesignal-slidedown-cancel-button"></button>\
+        </div></body></html>`;
     }
 
     var windowDef = await new Promise<Window>((resolve, reject) => {
@@ -241,6 +249,7 @@ export class TestEnvironment {
     (windowDef as any).TextEncoder = TextEncoder;
     (windowDef as any).TextDecoder = TextDecoder;
     (windowDef as any).isSecureContext = isSecureContext;
+    (windowDef as any).location = url;
 
     if (config.stubSetTimeout) {
       (windowDef as any).setTimeout = async (callback: Function, timeDelay: number) => {
@@ -255,7 +264,7 @@ export class TestEnvironment {
 
     TestEnvironment.addCustomEventPolyfill(windowDef);
 
-    let topWindow = config.initializeAsIframe ? {
+    const topWindow = config.initializeAsIframe ? {
       location: {
         get origin() {
           throw new Error("SecurityError: Permission denied to access property 'origin' on cross-origin object");
@@ -364,7 +373,7 @@ export class TestEnvironment {
   }
 
   static mockInternalOneSignal(config?: TestEnvironmentConfig) {
-    config = config || { 
+    config = config || {
       httpOrHttps: HttpHttpsEnvironment.Https,
       integration: ConfigIntegrationKind.Custom,
     };

--- a/test/support/tester/EventsTestHelper.ts
+++ b/test/support/tester/EventsTestHelper.ts
@@ -1,0 +1,33 @@
+import Slidedown from "../../../src/slidedown/Slidedown";
+import { SubscriptionManager } from '../../../src/managers/SubscriptionManager';
+import OneSignalEvent from "../../../src/Event";
+import { SinonSandbox } from 'sinon';
+import { stubServiceWorkerInstallation } from "../../support/tester/sinonSandboxUtils";
+
+export default class EventsTestHelper {
+    private readonly sinonSandbox: SinonSandbox;
+
+    constructor(sinonSandbox: SinonSandbox) {
+        this.sinonSandbox = sinonSandbox;
+    }
+
+    public simulateSlidedownAllowAfterShown() {
+    OneSignal.on(Slidedown.EVENTS.SHOWN, () => {
+        OneSignalEvent.trigger(Slidedown.EVENTS.ALLOW_CLICK);
+    });
+    }
+
+    public simulateSlidedownDismissAfterShown() {
+    OneSignal.on(Slidedown.EVENTS.SHOWN, () => {
+        OneSignalEvent.trigger(Slidedown.EVENTS.CANCEL_CLICK);
+    });
+    }
+
+    public simulateNativeAllowAfterShown() {
+    OneSignal.emitter.on(OneSignal.EVENTS.PERMISSION_PROMPT_DISPLAYED, () => {
+        this.sinonSandbox.stub(SubscriptionManager.prototype, "getSubscriptionState")
+        .resolves({ subscribed: true, isOptedOut: false });
+        stubServiceWorkerInstallation(this.sinonSandbox);
+    });
+    }
+}

--- a/test/support/tester/utils.ts
+++ b/test/support/tester/utils.ts
@@ -49,6 +49,14 @@ export function mockWebPushAnalytics() {
     }).persist(true);
 }
 
+export function mockGetIcon() {
+  nock('https://onesignal.com')
+    .get(/.*icon$/)
+    .reply(200, (_uri: string, _requestBody: string) => {
+      return { success: true };
+    });
+}
+
 export class InitTestHelper {
   private readonly sinonSandbox: SinonSandbox;
 

--- a/test/unit/managers/PromptsManager.ts
+++ b/test/unit/managers/PromptsManager.ts
@@ -1,4 +1,3 @@
-
 import test from "ava";
 import sinon, { SinonSandbox } from "sinon";
 import { TestEnvironment } from '../../support/sdk/TestEnvironment';
@@ -10,6 +9,7 @@ import InitHelper from '../../../src/helpers/InitHelper';
 import { PromptsManager } from '../../../src/managers/PromptsManager';
 import { PageViewManager } from '../../../src/managers/PageViewManager';
 import Slidedown from '../../../src/slidedown/Slidedown';
+import { DynamicResourceLoader, ResourceLoadState } from '../../../src/services/DynamicResourceLoader';
 
 const sinonSandbox: SinonSandbox = sinon.sandbox.create();
 
@@ -48,6 +48,9 @@ test('category options are configured, not in update mode, check remote tag fetc
     await initializeConfigWithCategories();
     const tagFetchSpy = sinonSandbox.stub(TagManager, "downloadTags").resolves({});
     sinonSandbox.stub(PageViewManager.prototype, "getLocalPageViewCount").returns(1);
+    sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(false);
+    sinonSandbox.stub(PromptsManager.prototype as any, "checkIfAutoPromptShouldBeShown").resolves(true);
+    sinonSandbox.stub(DynamicResourceLoader.prototype, "loadSdkStylesheet").resolves(ResourceLoadState.Loaded);
     const slidedownSpy = sinonSandbox.spy(PromptsManager.prototype, "internalShowSlidedownPrompt");
     const createSpy = sinonSandbox.spy(Slidedown.prototype, "create");
     await InitHelper.sessionInit();

--- a/test/unit/managers/PromptsManager.ts
+++ b/test/unit/managers/PromptsManager.ts
@@ -1,0 +1,88 @@
+
+import test from "ava";
+import sinon, { SinonSandbox } from "sinon";
+import { TestEnvironment } from '../../support/sdk/TestEnvironment';
+import Log from '../../../src/libraries/Log';
+import TaggingContainer from '../../../src/slidedown/TaggingContainer';
+import MainHelper from '../../../src/helpers/MainHelper';
+import TagManager from '../../../src/managers/tagManager/page/TagManager';
+import InitHelper from '../../../src/helpers/InitHelper';
+import { PromptsManager } from '../../../src/managers/PromptsManager';
+import { PageViewManager } from '../../../src/managers/PageViewManager';
+import Slidedown from '../../../src/slidedown/Slidedown';
+
+const sinonSandbox: SinonSandbox = sinon.sandbox.create();
+
+test.afterEach(() => {
+    sinonSandbox.restore();
+    OneSignal._initCalled = false;
+    OneSignal.__initAlreadyCalled = false;
+    OneSignal._sessionInitAlreadyRunning = false;
+});
+
+test('if category options are not configured, check that an error was logged', async t => {
+    await TestEnvironment.initialize();
+    TestEnvironment.mockInternalOneSignal();
+    const logSpy = sinonSandbox.stub(Log, "error");
+    await OneSignal.showCategorySlidedown();
+    t.true(logSpy.calledOnce);
+});
+
+test('category options are configured, in update mode, check 1) tagging container loaded 2) remote tag fetch',
+    async t => {
+        await initializeConfigWithCategories();
+        sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(true);
+        sinonSandbox.stub(MainHelper, "getNotificationIcons");
+
+        const tagFetchSpy = sinonSandbox.stub(TagManager, "downloadTags").resolves({});
+        const loadSpy = sinonSandbox.spy(TaggingContainer.prototype, "load");
+
+        await OneSignal.showCategorySlidedown();
+
+        t.true(loadSpy.calledOnce);
+        t.true(tagFetchSpy.calledOnce);
+});
+
+
+test('category options are configured, not in update mode, check remote tag fetch not made', async t => {
+    await initializeConfigWithCategories();
+    const tagFetchSpy = sinonSandbox.stub(TagManager, "downloadTags").resolves({});
+    sinonSandbox.stub(PageViewManager.prototype, "getLocalPageViewCount").returns(1);
+    const autoPromptSpy = sinonSandbox.spy(PromptsManager.prototype, "internalShowAutoPrompt");
+    const delayedPromptSpy = sinonSandbox.spy(PromptsManager.prototype, "internalShowDelayedPrompt");
+    const slidedownSpy = sinonSandbox.spy(PromptsManager.prototype, "internalShowSlidedownPrompt");
+    const createSpy = sinonSandbox.spy(Slidedown.prototype, "create");
+    await InitHelper.sessionInit();
+
+    t.true(!tagFetchSpy.called);
+    t.true(autoPromptSpy.calledOnce);
+    t.true(delayedPromptSpy.calledOnce);
+    t.true(slidedownSpy.calledOnce);
+    t.true(createSpy.called);
+});
+
+async function initializeConfigWithCategories() {
+    const config = {
+        userConfig: {
+            promptOptions: {
+                autoPrompt: true,
+                slidedown: {
+                    enabled: true,
+                    actionMessage: "",
+                    acceptButtonText: "",
+                    cancelButtonText: "",
+                    categories: {
+                        tags: [
+                            {
+                                tag: "Tag",
+                                label: "Label"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    };
+    await TestEnvironment.initialize();
+    TestEnvironment.mockInternalOneSignal(config);
+}

--- a/test/unit/managers/PromptsManager.ts
+++ b/test/unit/managers/PromptsManager.ts
@@ -48,15 +48,11 @@ test('category options are configured, not in update mode, check remote tag fetc
     await initializeConfigWithCategories();
     const tagFetchSpy = sinonSandbox.stub(TagManager, "downloadTags").resolves({});
     sinonSandbox.stub(PageViewManager.prototype, "getLocalPageViewCount").returns(1);
-    const autoPromptSpy = sinonSandbox.spy(PromptsManager.prototype, "internalShowAutoPrompt");
-    const delayedPromptSpy = sinonSandbox.spy(PromptsManager.prototype, "internalShowDelayedPrompt");
     const slidedownSpy = sinonSandbox.spy(PromptsManager.prototype, "internalShowSlidedownPrompt");
     const createSpy = sinonSandbox.spy(Slidedown.prototype, "create");
     await InitHelper.sessionInit();
 
     t.true(!tagFetchSpy.called);
-    t.true(autoPromptSpy.calledOnce);
-    t.true(delayedPromptSpy.calledOnce);
     t.true(slidedownSpy.calledOnce);
     t.true(createSpy.called);
 });

--- a/test/unit/managers/TagManager.ts
+++ b/test/unit/managers/TagManager.ts
@@ -1,0 +1,31 @@
+import test from "ava";
+import sinon, { SinonSandbox } from "sinon";
+import { TestEnvironment } from '../../support/sdk/TestEnvironment';
+import OneSignalApi from '../../../src/OneSignalApi';
+import TagManager from '../../../src/managers/tagManager/page/TagManager';
+
+const sinonSandbox: SinonSandbox = sinon.sandbox.create();
+
+test.beforeEach(async () => {
+    await TestEnvironment.initialize();
+    TestEnvironment.mockInternalOneSignal();
+});
+
+test.afterEach(() => {
+    sinonSandbox.restore();
+});
+
+test('calling `syncTags` results in remote tag update with sendTags', async t => {
+    const mockTags = { tag1: 1, tag2: 2 };
+    const sendTagsSpy = sinonSandbox.stub(OneSignal, "sendTags").resolves();
+    OneSignal.context.tagManager.storeTagValuesToUpdate(mockTags);
+    await OneSignal.context.tagManager.syncTags();
+    t.is(sendTagsSpy.callCount, 1);
+    t.true(sendTagsSpy.getCall(0).calledWith(mockTags));
+});
+
+test('`downloadTags` results in remote getTags call', async t => {
+    const getTagsSpy = sinonSandbox.stub(OneSignal, "getTags").resolves({});
+    await TagManager.downloadTags();
+    t.is(getTagsSpy.callCount, 1);
+});

--- a/test/unit/managers/TagManager.ts
+++ b/test/unit/managers/TagManager.ts
@@ -1,8 +1,10 @@
 import test from "ava";
 import sinon, { SinonSandbox } from "sinon";
-import { TestEnvironment } from '../../support/sdk/TestEnvironment';
-import OneSignalApi from '../../../src/OneSignalApi';
+import { TestEnvironment, TestEnvironmentConfig, HttpHttpsEnvironment } from '../../support/sdk/TestEnvironment';
 import TagManager from '../../../src/managers/tagManager/page/TagManager';
+import { ConfigIntegrationKind } from '../../../src/models/AppConfig';
+import Random from '../../support/tester/Random';
+import EventsTestHelper from '../../support/tester/EventsTestHelper';
 
 const sinonSandbox: SinonSandbox = sinon.sandbox.create();
 
@@ -29,3 +31,42 @@ test('`downloadTags` results in remote getTags call', async t => {
     await TagManager.downloadTags();
     t.is(getTagsSpy.callCount, 1);
 });
+
+test('subscribing through category slidedown accept button calls syncTags', async t => {
+    const testConfig: TestEnvironmentConfig = {
+      httpOrHttps: HttpHttpsEnvironment.Https,
+      integration: ConfigIntegrationKind.Custom,
+      pushIdentifier: 'granted',
+      stubSetTimeout: true
+    };
+
+    const appId = Random.getRandomUuid();
+    const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t);
+    const eventsHelper = new EventsTestHelper(sinonSandbox);
+    eventsHelper.simulateSlidedownAllowAfterShown();
+    eventsHelper.simulateNativeAllowAfterShown();
+
+    const accepted = new Promise(resolve => {
+      OneSignal.on(OneSignal.EVENTS.TEST_TAGS_SENT, () => {
+        t.is(stubs.syncTagsSpy.callCount, 1);
+        resolve();
+      });
+    });
+
+    const initPromise = OneSignal.init({
+      appId,
+      promptOptions: {
+        slidedown: {
+          enabled: true,
+          autoPrompt: true,
+          categories : {
+              tags : [{ tag: "tag", label: "Tag" }]
+          }
+        }
+      },
+      autoResubscribe: false,
+    });
+    await initPromise;
+    await accepted;
+});
+

--- a/test/unit/modules/subscriptionHelper.ts
+++ b/test/unit/modules/subscriptionHelper.ts
@@ -19,7 +19,7 @@ test.beforeEach(async () => {
 
 test.afterEach(() => {
   sinonSandbox.restore();
-})
+});
 
 test('should not resubscribe user on subsequent page views if the user is already subscribed', async t => {
   sinonSandbox.stub(LocalStorage, 'getIsPushNotificationsEnabled').returns("true");
@@ -34,7 +34,7 @@ test('should subscribe user on subsequent page views if the user is not subscrib
   sinonSandbox.stub(OneSignal, 'isPushNotificationsEnabled').resolves(false);
   sinonSandbox.stub(PageViewManager.prototype, 'getPageViewCount').returns(2);
   sinonSandbox.stub(SubscriptionManager.prototype, 'registerSubscription').resolves();
-  
+
   const subscribeStub = sinonSandbox.stub(SubscriptionManager.prototype, 'subscribe').resolves(null);
   await SubscriptionHelper.registerForPush();
   t.true(subscribeStub.called);

--- a/test/unit/prompts/Slidedown.ts
+++ b/test/unit/prompts/Slidedown.ts
@@ -148,7 +148,7 @@ test('slidedown: uses edge by default', async t => {
 /**
  * samsung test
  */
-test('slidedown: uses samsung browser by default', async t => {
+test('slidedown: uses samsung browser by default, icon url defined', async t => {
   setUserAgent(BrowserUserAgent.SamsungBrowserSupported);
   const slidedown = new Slidedown(options);
 
@@ -161,17 +161,17 @@ test('slidedown: uses samsung browser by default', async t => {
 /**
  * default catch tests
  */
-test('slidedown: uses samsung browser by default', async t => {
+test('slidedown: uses samsung browser by default, icon undefined', async t => {
   setUserAgent(BrowserUserAgent.SamsungBrowserSupported);
   const slidedown = new Slidedown(options);
 
-  slidedown.notificationIcons = undefined;
+  slidedown.notificationIcons = null;
   const icon = slidedown.getPlatformNotificationIcon();
 
   t.is(icon, "default-icon");
 });
 
-test('slidedown: uses samsung browser by default', async t => {
+test('slidedown: uses samsung browser by default, icon empty', async t => {
   setUserAgent(BrowserUserAgent.SamsungBrowserSupported);
   const slidedown = new Slidedown(options);
 

--- a/test/unit/prompts/Slidedown.ts
+++ b/test/unit/prompts/Slidedown.ts
@@ -69,7 +69,7 @@ test('slidedown: uses chrome by default on windows', async t => {
   t.is(icon, "http://url.com");
 });
 
-test('slidedown: uses chrome by default on windows', async t => {
+test('slidedown: uses chrome by default on Android', async t => {
   setUserAgent(BrowserUserAgent.ChromeAndroidSupported);
   const slidedown = new Slidedown(options);
 

--- a/test/unit/prompts/Slidedown.ts
+++ b/test/unit/prompts/Slidedown.ts
@@ -33,7 +33,7 @@ test('slidedown: uses chrome by default on mac', async t => {
   setUserAgent(BrowserUserAgent.ChromeMacSupported);
   const slidedown = new Slidedown(options);
 
-  slidedown.notificationIcons = {chrome: "http://url.com"};
+  slidedown.notificationIcons = { chrome: "http://url.com" };
   const icon = slidedown.getPlatformNotificationIcon();
 
   t.is(icon, "http://url.com");
@@ -43,7 +43,7 @@ test('slidedown: uses chrome by default on tablet', async t => {
   setUserAgent(BrowserUserAgent.ChromeTabletSupported);
   const slidedown = new Slidedown(options);
 
-  slidedown.notificationIcons = {chrome: "http://url.com"};
+  slidedown.notificationIcons = { chrome: "http://url.com" };
   const icon = slidedown.getPlatformNotificationIcon();
 
   t.is(icon, "http://url.com");
@@ -53,7 +53,7 @@ test('slidedown: uses chrome by default on linux', async t => {
   setUserAgent(BrowserUserAgent.ChromeLinuxSupported);
   const slidedown = new Slidedown(options);
 
-  slidedown.notificationIcons = {chrome: "http://url.com"};
+  slidedown.notificationIcons = { chrome: "http://url.com" };
   const icon = slidedown.getPlatformNotificationIcon();
 
   t.is(icon, "http://url.com");
@@ -63,7 +63,7 @@ test('slidedown: uses chrome by default on windows', async t => {
   setUserAgent(BrowserUserAgent.ChromeWindowsSupported);
   const slidedown = new Slidedown(options);
 
-  slidedown.notificationIcons = {chrome: "http://url.com"};
+  slidedown.notificationIcons = { chrome: "http://url.com" };
   const icon = slidedown.getPlatformNotificationIcon();
 
   t.is(icon, "http://url.com");
@@ -73,7 +73,7 @@ test('slidedown: uses chrome by default on windows', async t => {
   setUserAgent(BrowserUserAgent.ChromeAndroidSupported);
   const slidedown = new Slidedown(options);
 
-  slidedown.notificationIcons = {chrome: "http://url.com"};
+  slidedown.notificationIcons = { chrome: "http://url.com" };
   const icon = slidedown.getPlatformNotificationIcon();
 
   t.is(icon, "http://url.com");
@@ -86,7 +86,7 @@ test('slidedown: uses firefox by default on mobile', async t => {
   setUserAgent(BrowserUserAgent.FirefoxMobileSupported);
   const slidedown = new Slidedown(options);
 
-  slidedown.notificationIcons = {firefox: "http://url.com"};
+  slidedown.notificationIcons = { firefox: "http://url.com" };
   const icon = slidedown.getPlatformNotificationIcon();
 
   t.is(icon, "http://url.com");
@@ -96,7 +96,7 @@ test('slidedown: uses firefox by default on tablet', async t => {
   setUserAgent(BrowserUserAgent.FirefoxTabletSupported);
   const slidedown = new Slidedown(options);
 
-  slidedown.notificationIcons = {firefox: "http://url.com"};
+  slidedown.notificationIcons = { firefox: "http://url.com" };
   const icon = slidedown.getPlatformNotificationIcon();
 
   t.is(icon, "http://url.com");
@@ -106,7 +106,7 @@ test('slidedown: uses firefox by default on windows', async t => {
   setUserAgent(BrowserUserAgent.FirefoxWindowsSupported);
   const slidedown = new Slidedown(options);
 
-  slidedown.notificationIcons = {firefox: "http://url.com"};
+  slidedown.notificationIcons = { firefox: "http://url.com" };
   const icon = slidedown.getPlatformNotificationIcon();
 
   t.is(icon, "http://url.com");
@@ -116,7 +116,7 @@ test('slidedown: uses firefox by default on mac', async t => {
   setUserAgent(BrowserUserAgent.FirefoxMacSupported);
   const slidedown = new Slidedown(options);
 
-  slidedown.notificationIcons = {firefox: "http://url.com"};
+  slidedown.notificationIcons = { firefox: "http://url.com" };
   const icon = slidedown.getPlatformNotificationIcon();
 
   t.is(icon, "http://url.com");
@@ -126,7 +126,7 @@ test('slidedown: uses firefox by default on linux', async t => {
   setUserAgent(BrowserUserAgent.FirefoxLinuxSupported);
   const slidedown = new Slidedown(options);
 
-  slidedown.notificationIcons = {firefox: "http://url.com"};
+  slidedown.notificationIcons = { firefox: "http://url.com" };
   const icon = slidedown.getPlatformNotificationIcon();
 
   t.is(icon, "http://url.com");
@@ -139,7 +139,7 @@ test('slidedown: uses edge by default', async t => {
   setUserAgent(BrowserUserAgent.EdgeSupported);
   const slidedown = new Slidedown(options);
 
-  slidedown.notificationIcons = {chrome: "http://url.com"};
+  slidedown.notificationIcons = { chrome: "http://url.com" };
   const icon = slidedown.getPlatformNotificationIcon();
 
   t.is(icon, "http://url.com");
@@ -152,7 +152,7 @@ test('slidedown: uses samsung browser by default', async t => {
   setUserAgent(BrowserUserAgent.SamsungBrowserSupported);
   const slidedown = new Slidedown(options);
 
-  slidedown.notificationIcons = {chrome: "http://url.com"};
+  slidedown.notificationIcons = { chrome: "http://url.com" };
   const icon = slidedown.getPlatformNotificationIcon();
 
   t.is(icon, "http://url.com");

--- a/test/unit/prompts/TaggingContainer.ts
+++ b/test/unit/prompts/TaggingContainer.ts
@@ -1,0 +1,44 @@
+import test from 'ava';
+import TaggingContainer from '../../../src/slidedown/TaggingContainer';
+import sinon, { SinonSandbox } from 'sinon';
+import { TestEnvironment, HttpHttpsEnvironment, BrowserUserAgent } from '../../support/sdk/TestEnvironment';
+import { setUserAgent } from '../../support/tester/browser';
+import Slidedown from '../../../src/slidedown/Slidedown';
+import { ConfigIntegrationKind } from '../../../src/models/AppConfig';
+
+const sandbox: SinonSandbox = sinon.sandbox.create();
+
+test.beforeEach(async () => {
+  (global as any).BrowserUserAgent = BrowserUserAgent;
+  (global as any).location = "https://localhost:4001";
+  const userConfig = await TestEnvironment.getFakeMergedConfig({});
+  const options = {
+    httpOrHttps: HttpHttpsEnvironment.Https,
+    initOptions: userConfig,
+    addPrompts: true
+  };
+  await TestEnvironment.stubDomEnvironment(options);
+  await TestEnvironment.initialize(options);
+});
+
+test.afterEach(function () {
+  sandbox.restore();
+});
+
+test('check sanitization is working correctly', t => {
+    setUserAgent(BrowserUserAgent.ChromeMacSupported);
+    OneSignal.slidedown = new Slidedown();
+    const tagCategoryList = [{
+        tag: "tag1\"<script> // injected code </script> \"\"",
+        label: "Tag 1\"<script> // injected code </script> \"",
+    }];
+    const taggingContainer = new TaggingContainer();
+    taggingContainer.mount(tagCategoryList);
+    const generatedHtml = taggingContainer.getHtml();
+    t.is(generatedHtml, `<div class="tagging-container"><div class="tagging-container-col">`+
+    `<label class="onesignal-category-label" title="Tag 1">`+
+    `<span class="onesignal-category-label-text">Tag 1</span>`+
+    `<input type="checkbox" value="tag1">`+
+    `<span class="onesignal-checkmark"></span></label>`+
+    `<div style="clear:both"></div></div><div class="tagging-container-col"></div></div>`);
+});

--- a/test/unit/prompts/TaggingContainer.ts
+++ b/test/unit/prompts/TaggingContainer.ts
@@ -4,7 +4,6 @@ import sinon, { SinonSandbox } from 'sinon';
 import { TestEnvironment, HttpHttpsEnvironment, BrowserUserAgent } from '../../support/sdk/TestEnvironment';
 import { setUserAgent } from '../../support/tester/browser';
 import Slidedown from '../../../src/slidedown/Slidedown';
-import { ConfigIntegrationKind } from '../../../src/models/AppConfig';
 import { TagCategory, TagsObject } from 'src/models/Tags';
 import _ from "lodash";
 import { getDomElementOrStub } from '../../../src/utils';

--- a/test/unit/prompts/TaggingContainer.ts
+++ b/test/unit/prompts/TaggingContainer.ts
@@ -5,12 +5,14 @@ import { TestEnvironment, HttpHttpsEnvironment, BrowserUserAgent } from '../../s
 import { setUserAgent } from '../../support/tester/browser';
 import Slidedown from '../../../src/slidedown/Slidedown';
 import { ConfigIntegrationKind } from '../../../src/models/AppConfig';
+import { TagCategory, TagsObject } from 'src/models/Tags';
+import _ from "lodash";
 
 const sandbox: SinonSandbox = sinon.sandbox.create();
 
 test.beforeEach(async () => {
   (global as any).BrowserUserAgent = BrowserUserAgent;
-  (global as any).location = "https://localhost:4001";
+  (global as any).location = new URL("https://localhost:4001");
   const userConfig = await TestEnvironment.getFakeMergedConfig({});
   const options = {
     httpOrHttps: HttpHttpsEnvironment.Https,
@@ -41,4 +43,23 @@ test('check sanitization is working correctly', t => {
     `<input type="checkbox" value="tag1">`+
     `<span class="onesignal-checkmark"></span></label>`+
     `<div style="clear:both"></div></div><div class="tagging-container-col"></div></div>`);
+});
+
+test('check that correct TagCategory object is returned after applying remote player tags', t => {
+  setUserAgent(BrowserUserAgent.ChromeMacSupported);
+  const tagCateogryList: TagCategory[] = [
+    { tag: "a", label: "A" },
+    { tag: "b", label: "B" },
+    { tag: "c", label: "C" },
+  ];
+
+  const targetIntersection = JSON.parse(JSON.stringify(tagCateogryList));
+  targetIntersection[0].checked = true;
+  targetIntersection[1].checked = false;
+  targetIntersection[2].checked = true;
+
+  const tagsObject: TagsObject = { a: true, b: false, c: true };
+
+  const intersection = new TaggingContainer().TESTING.getCheckedTagCategories(tagCateogryList, tagsObject);
+  t.true(_.isEqual(intersection, targetIntersection));
 });

--- a/test/unit/prompts/TaggingContainer.ts
+++ b/test/unit/prompts/TaggingContainer.ts
@@ -7,6 +7,7 @@ import Slidedown from '../../../src/slidedown/Slidedown';
 import { ConfigIntegrationKind } from '../../../src/models/AppConfig';
 import { TagCategory, TagsObject } from 'src/models/Tags';
 import _ from "lodash";
+import { getDomElementOrStub } from '../../../src/utils';
 
 const sandbox: SinonSandbox = sinon.sandbox.create();
 
@@ -36,13 +37,9 @@ test('check sanitization is working correctly', t => {
     }];
     const taggingContainer = new TaggingContainer();
     taggingContainer.mount(tagCategoryList);
-    const generatedHtml = taggingContainer.getHtml();
-    t.is(generatedHtml, `<div class="tagging-container"><div class="tagging-container-col">`+
-    `<label class="onesignal-category-label" title="Tag 1">`+
-    `<span class="onesignal-category-label-text">Tag 1</span>`+
-    `<input type="checkbox" value="tag1">`+
-    `<span class="onesignal-checkmark"></span></label>`+
-    `<div style="clear:both"></div></div><div class="tagging-container-col"></div></div>`);
+    const labelElement = getDomElementOrStub(".onesignal-category-label");
+    t.is(labelElement.innerHTML, `<span class="onesignal-category-label-text">Tag 1</span>`+
+      `<input type="checkbox" value="tag1"><span class="onesignal-checkmark"></span>`);
 });
 
 test('check that correct TagCategory object is returned after applying remote player tags', t => {

--- a/test/unit/public-sdk-apis/onSession.ts
+++ b/test/unit/public-sdk-apis/onSession.ts
@@ -61,7 +61,7 @@ test.afterEach(function (_t: ExecutionContext) {
  * 3. user subscribed
  *     + 1. expiring subscription -> player update
  *     + 2. not-expiring subscription and first page view -> on session
- *       3. second page view -> no requests - TODO 
+ *       3. second page view -> no requests - TODO
  */
 
 test.serial(`HTTPS: User not subscribed and not opted out => first page view => slidedown's autoPrompt is on =>
@@ -72,7 +72,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
       pushIdentifier: 'granted',
       stubSetTimeout: true
     };
-    const stubs = await beforeTest(testConfig, t);
+    const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t);
     const eventsHelper = new EventsTestHelper(sinonSandbox);
     eventsHelper.simulateSlidedownAllowAfterShown();
     eventsHelper.simulateNativeAllowAfterShown();
@@ -119,7 +119,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
     stubSetTimeout: true
   };
 
-  const stubs = await beforeTest(testConfig, t);
+  const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t);
   const eventsHelper = new EventsTestHelper(sinonSandbox);
   eventsHelper.simulateSlidedownDismissAfterShown();
 
@@ -157,7 +157,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
       permission: NotificationPermission.Granted
     };
 
-    const stubs = await beforeTest(testConfig, t);
+    const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t);
     stubServiceWorkerInstallation(sinonSandbox);
 
     const initializePromise = new Promise(resolve => {
@@ -201,7 +201,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
       integration: ConfigIntegrationKind.Custom,
       permission: NotificationPermission.Default
     };
-    const stubs = await beforeTest(testConfig, t);
+    const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t);
     const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
     const initializePromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
@@ -234,7 +234,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
       pushIdentifier: 'granted',
       permission: NotificationPermission.Granted
     };
-    const stubs = await beforeTest(testConfig, t);
+    const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t);
     const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
 
     const initializePromise = new Promise(resolve => {
@@ -265,7 +265,7 @@ test.serial(`HTTPS: User opted out => first page view => onSession flag is on =>
 
     const serverAppConfig = TestEnvironment.getFakeServerAppConfig(testConfig.integration!);
     serverAppConfig.features.enable_on_session = true;
-    const stubs = await beforeTest(testConfig, t, serverAppConfig);
+    const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t, serverAppConfig);
     await markUserAsOptedOut(sinonSandbox, playerId);
 
     const initializePromise = new Promise(resolve => {
@@ -301,7 +301,7 @@ test.serial(`HTTPS: User opted out => first page view => onSession flag is off =
 
   const serverAppConfig = TestEnvironment.getFakeServerAppConfig(testConfig.integration!);
   serverAppConfig.features.enable_on_session = false;
-  const stubs = await beforeTest(testConfig, t, serverAppConfig);
+  const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t, serverAppConfig);
   const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
   await markUserAsOptedOut(sinonSandbox, playerId);
 
@@ -339,7 +339,7 @@ test.serial(`HTTPS: User opted out => second page view => onSession flag is on =
 
   const serverAppConfig = TestEnvironment.getFakeServerAppConfig(testConfig.integration!);
   serverAppConfig.features.enable_on_session = true;
-  const stubs = await beforeTest(testConfig, t, serverAppConfig);
+  const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t, serverAppConfig);
   const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
   await markUserAsOptedOut(sinonSandbox, playerId);
 
@@ -376,7 +376,7 @@ test.serial(`HTTPS: User subscribed => first page view => expiring subscription 
     pushIdentifier: 'granted'
   };
 
-  const stubs = await beforeTest(testConfig, t);
+  const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t);
 
   // Using spy instead of stub here is intended. Spy does callThrough, i.e. executes underlying function, by default
   //  while stub prevents the actual execution.
@@ -418,7 +418,7 @@ test.serial(`HTTPS: User subscribed => first page view => sends on session`, asy
     pushIdentifier: 'granted'
   };
 
-  const stubs = await beforeTest(testConfig, t);
+  const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t);
   await markUserAsSubscribed(sinonSandbox, playerId);
   stubServiceWorkerInstallation(sinonSandbox);
 
@@ -453,7 +453,7 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => s
       pushIdentifier: 'granted',
       stubSetTimeout: true
     };
-    const stubs = await beforeTest(testConfig, t);
+    const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t);
 
     const eventsHelper = new EventsTestHelper(sinonSandbox);
     eventsHelper.simulateSlidedownAllowAfterShown();
@@ -501,7 +501,7 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => s
     stubSetTimeout: true
   };
 
-  const stubs = await beforeTest(testConfig, t);
+  const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t);
   new EventsTestHelper(sinonSandbox).simulateSlidedownDismissAfterShown();
 
   const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
@@ -539,7 +539,7 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => a
       permission: NotificationPermission.Granted
     };
 
-    const stubs = await beforeTest(testConfig, t);
+    const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t);
     stubServiceWorkerInstallation(sinonSandbox);
 
     const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
@@ -569,7 +569,7 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => a
       integration: ConfigIntegrationKind.Custom,
       permission: NotificationPermission.Default
     };
-    const stubs = await beforeTest(testConfig, t);
+    const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t);
     const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
     const initializePromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
@@ -601,7 +601,7 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => n
       pushIdentifier: 'granted',
       permission: NotificationPermission.Granted
     };
-    const stubs = await beforeTest(testConfig, t);
+    const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t);
     const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
 
     const initializePromise = new Promise(resolve => {
@@ -632,7 +632,7 @@ test.serial(`HTTP: User opted out => first page view => onSession flag is on => 
 
     const serverAppConfig = TestEnvironment.getFakeServerAppConfig(testConfig.integration!, false);
     serverAppConfig.features.enable_on_session = true;
-    const stubs = await beforeTest(testConfig, t, serverAppConfig);
+    const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t, serverAppConfig);
     await markUserAsOptedOut(sinonSandbox, playerId);
 
     const initializePromise = new Promise(resolve => {
@@ -668,7 +668,7 @@ test.serial(`HTTP: User opted out => first page view => onSession flag is off =>
 
   const serverAppConfig = TestEnvironment.getFakeServerAppConfig(testConfig.integration!, false);
   serverAppConfig.features.enable_on_session = false;
-  const stubs = await beforeTest(testConfig, t, serverAppConfig);
+  const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t, serverAppConfig);
   const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
   await markUserAsOptedOut(sinonSandbox, playerId);
 
@@ -706,7 +706,7 @@ test.serial(`HTTP: User opted out => second page view => onSession flag is on =>
 
   const serverAppConfig = TestEnvironment.getFakeServerAppConfig(testConfig.integration!, false);
   serverAppConfig.features.enable_on_session = true;
-  const stubs = await beforeTest(testConfig, t, serverAppConfig);
+  const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t, serverAppConfig);
   const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
   await markUserAsOptedOut(sinonSandbox, playerId);
 
@@ -743,7 +743,7 @@ test.serial(`HTTP: User subscribed => first page view => expiring subscription =
     pushIdentifier: 'granted'
   };
 
-  const stubs = await beforeTest(testConfig, t);
+  const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t);
   sinonSandbox.stub(InitHelper, "registerSubscriptionInProxyFrame").resolves(createSubscription());
 
   await markUserAsSubscribedOnHttp(sinonSandbox, playerId, true);
@@ -781,7 +781,7 @@ test.serial(`HTTP: User subscribed => first page view => sends on session`, asyn
     pushIdentifier: 'granted'
   };
 
-  const stubs = await beforeTest(testConfig, t);
+  const stubs = await TestEnvironment.setupOneSignalWithStubs(sinonSandbox, testConfig, t);
   await markUserAsSubscribedOnHttp(sinonSandbox, playerId);
   stubServiceWorkerInstallation(sinonSandbox);
 
@@ -809,38 +809,6 @@ test.serial(`HTTP: User subscribed => first page view => sends on session`, asyn
 });
 
 /** Helper methods */
-async function beforeTest(
-  testConfig: TestEnvironmentConfig,
-  t: ExecutionContext,
-  customServerAppConfig?: ServerAppConfig
-) {
-  await TestEnvironment.initialize(testConfig);
-  initTestHelper.mockBasicInitEnv(testConfig, customServerAppConfig);
-  OneSignal.initialized = false;
-  OneSignal.__doNotShowWelcomeNotification = true;
-
-  sinonSandbox.stub(window.Notification, "permission").value(testConfig.permission || "default");
-
-  const createPlayerPostStub = sinonSandbox.stub(OneSignalApiBase, "post")
-    .resolves({ success: true, id: playerId });
-  const onSessionStub = sinonSandbox.stub(SessionManager.prototype, "upsertSession").resolves();
-  // const onSessionStub = sinonSandbox.stub(OneSignal.context.sessionManager, "upsertSession").resolves();
-
-  sinonSandbox.stub(DynamicResourceLoader.prototype, "loadSdkStylesheet").resolves(ResourceLoadState.Loaded);
-  sinonSandbox.stub(ServiceWorkerManager.prototype, "installWorker").resolves();
-  nock('https://onesignal.com')
-    .get(/.*icon$/)
-    .reply(200, (_uri: string, _requestBody: string) => {
-      return { success: true };
-    });
-
-  if (testConfig.httpOrHttps === HttpHttpsEnvironment.Http) {
-    stubMessageChannel(t);
-    mockIframeMessaging(sinonSandbox);
-  }
-  return { createPlayerPostStub, onSessionStub };
-}
-
 async function inspectPushRecordCreationRequest(t: ExecutionContext, requestStub: SinonStub) {
   // For player#create device record is already serialized. Checking serialized structure.
   const anyValues = [

--- a/test/unit/public-sdk-apis/onSession.ts
+++ b/test/unit/public-sdk-apis/onSession.ts
@@ -11,8 +11,6 @@ import OneSignalApiBase from "../../../src/OneSignalApiBase";
 import {
   stubMessageChannel, mockIframeMessaging, mockWebPushAnalytics, InitTestHelper
 } from '../../support/tester/utils';
-import Slidedown from "../../../src/slidedown/Slidedown";
-import OneSignalEvent from "../../../src/Event";
 import { DynamicResourceLoader, ResourceLoadState } from "../../../src/services/DynamicResourceLoader";
 import { ServiceWorkerManager } from "../../../src/managers/ServiceWorkerManager";
 import { NotificationPermission } from "../../../src/models/NotificationPermission";
@@ -23,10 +21,10 @@ import { SubscriptionManager } from "../../../src/managers/SubscriptionManager";
 import InitHelper from "../../../src/helpers/InitHelper";
 import {
   markUserAsOptedOut, markUserAsSubscribed, markUserAsSubscribedOnHttp,
-  stubServiceWorkerInstallation, 
+  stubServiceWorkerInstallation
 } from "../../support/tester/sinonSandboxUtils";
 import { createSubscription } from "../../support/tester/utils";
-import { PromptsManager } from '../../../src/managers/PromptsManager';
+import EventsTestHelper from '../../support/tester/EventsTestHelper';
 
 
 const sinonSandbox: SinonSandbox = sinon.sandbox.create();
@@ -75,10 +73,11 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
       stubSetTimeout: true
     };
     const stubs = await beforeTest(testConfig, t);
-    simulateSlidedownAllowAfterShown();
-    simulateNativeAllowAfterShown();
+    const eventsHelper = new EventsTestHelper(sinonSandbox);
+    eventsHelper.simulateSlidedownAllowAfterShown();
+    eventsHelper.simulateNativeAllowAfterShown();
 
-    const initializePromise = new Promise((resolve) => {
+    const initializePromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
         t.is(stubs.createPlayerPostStub.callCount, 0);
         t.is(stubs.onSessionStub.callCount, 0);
@@ -86,7 +85,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
       });
     });
 
-    const subscriptionPromise = new Promise((resolve) => {
+    const subscriptionPromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.SUBSCRIPTION_CHANGED, () => {
         t.is(stubs.onSessionStub.callCount, 1);
         t.is(stubs.createPlayerPostStub.callCount, 1);
@@ -121,11 +120,12 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
   };
 
   const stubs = await beforeTest(testConfig, t);
-  simulateSlidedownDismissAfterShown();
+  const eventsHelper = new EventsTestHelper(sinonSandbox);
+  eventsHelper.simulateSlidedownDismissAfterShown();
 
   const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
 
-  const initializePromise = new Promise((resolve) => {
+  const initializePromise = new Promise(resolve => {
     OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
       t.is(stubs.onSessionStub.callCount, 0);
       t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -160,7 +160,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
     const stubs = await beforeTest(testConfig, t);
     stubServiceWorkerInstallation(sinonSandbox);
 
-    const initializePromise = new Promise((resolve) => {
+    const initializePromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
         t.is(stubs.onSessionStub.callCount, 1);
         t.is(stubs.createPlayerPostStub.callCount, 1);
@@ -169,7 +169,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
       });
     });
 
-    const registrationPromise = new Promise((resolve) => {
+    const registrationPromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.REGISTERED, () => {
         t.is(stubs.onSessionStub.callCount, 1);
         t.is(stubs.createPlayerPostStub.callCount, 1);
@@ -177,7 +177,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
       });
     });
 
-    const subscriptionPromise = new Promise((resolve) => {
+    const subscriptionPromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.SUBSCRIPTION_CHANGED, () => {
         resolve();
       });
@@ -203,7 +203,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
     };
     const stubs = await beforeTest(testConfig, t);
     const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
-    const initializePromise = new Promise((resolve) => {
+    const initializePromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
         t.is(stubs.onSessionStub.callCount, 0);
         t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -237,7 +237,7 @@ test.serial(`HTTPS: User not subscribed and not opted out => first page view => 
     const stubs = await beforeTest(testConfig, t);
     const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
 
-    const initializePromise = new Promise((resolve) => {
+    const initializePromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
         t.is(stubs.onSessionStub.callCount, 0);
         t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -268,7 +268,7 @@ test.serial(`HTTPS: User opted out => first page view => onSession flag is on =>
     const stubs = await beforeTest(testConfig, t, serverAppConfig);
     await markUserAsOptedOut(sinonSandbox, playerId);
 
-    const initializePromise = new Promise((resolve) => {
+    const initializePromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
         t.is(stubs.onSessionStub.callCount, 1);
         t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -305,7 +305,7 @@ test.serial(`HTTPS: User opted out => first page view => onSession flag is off =
   const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
   await markUserAsOptedOut(sinonSandbox, playerId);
 
-  const initializePromise = new Promise((resolve) => {
+  const initializePromise = new Promise(resolve => {
     OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
       t.is(stubs.onSessionStub.callCount, 0);
       t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -345,7 +345,7 @@ test.serial(`HTTPS: User opted out => second page view => onSession flag is on =
 
   sinonSandbox.stub(PageViewManager.prototype, "getPageViewCount").resolves(2);
 
-  const initializePromise = new Promise((resolve) => {
+  const initializePromise = new Promise(resolve => {
     OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
       t.is(stubs.onSessionStub.callCount, 0);
       t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -385,7 +385,7 @@ test.serial(`HTTPS: User subscribed => first page view => expiring subscription 
   await markUserAsSubscribed(sinonSandbox, playerId, true);
   stubServiceWorkerInstallation(sinonSandbox);
 
-  const initializePromise = new Promise((resolve) => {
+  const initializePromise = new Promise(resolve => {
     OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
       // sends player update which actually calls on_session if this is the first call we're performing.
       t.is(playerUpdateStub.callCount, 1);
@@ -422,7 +422,7 @@ test.serial(`HTTPS: User subscribed => first page view => sends on session`, asy
   await markUserAsSubscribed(sinonSandbox, playerId);
   stubServiceWorkerInstallation(sinonSandbox);
 
-  const initializePromise = new Promise((resolve) => {
+  const initializePromise = new Promise(resolve => {
     OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
       t.is(stubs.onSessionStub.callCount, 1);
       t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -455,10 +455,11 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => s
     };
     const stubs = await beforeTest(testConfig, t);
 
-    simulateSlidedownAllowAfterShown();
-    simulateNativeAllowAfterShown();
+    const eventsHelper = new EventsTestHelper(sinonSandbox);
+    eventsHelper.simulateSlidedownAllowAfterShown();
+    eventsHelper.simulateNativeAllowAfterShown();
 
-    const initializePromise = new Promise((resolve) => {
+    const initializePromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
         t.is(stubs.onSessionStub.callCount, 0);
         t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -466,7 +467,7 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => s
       });
     });
 
-    const subscriptionPromise = new Promise((resolve) => {
+    const subscriptionPromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.SUBSCRIPTION_CHANGED, () => {
         t.is(stubs.onSessionStub.callCount, 1);
         t.is(stubs.createPlayerPostStub.callCount, 1);
@@ -501,11 +502,11 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => s
   };
 
   const stubs = await beforeTest(testConfig, t);
-  simulateSlidedownDismissAfterShown();
+  new EventsTestHelper(sinonSandbox).simulateSlidedownDismissAfterShown();
 
   const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
 
-  const initializePromise = new Promise((resolve) => {
+  const initializePromise = new Promise(resolve => {
     OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
       t.is(stubs.onSessionStub.callCount, 0);
       t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -543,7 +544,7 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => a
 
     const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
 
-    const initializePromise = new Promise((resolve) => {
+    const initializePromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
         t.is(stubs.onSessionStub.callCount, 0);
         t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -570,7 +571,7 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => a
     };
     const stubs = await beforeTest(testConfig, t);
     const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
-    const initializePromise = new Promise((resolve) => {
+    const initializePromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
         t.is(stubs.onSessionStub.callCount, 0);
         t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -603,7 +604,7 @@ test.serial(`HTTP: User not subscribed and not opted out => first page view => n
     const stubs = await beforeTest(testConfig, t);
     const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
 
-    const initializePromise = new Promise((resolve) => {
+    const initializePromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
         t.is(stubs.onSessionStub.callCount, 0);
         t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -634,7 +635,7 @@ test.serial(`HTTP: User opted out => first page view => onSession flag is on => 
     const stubs = await beforeTest(testConfig, t, serverAppConfig);
     await markUserAsOptedOut(sinonSandbox, playerId);
 
-    const initializePromise = new Promise((resolve) => {
+    const initializePromise = new Promise(resolve => {
       OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
         t.is(stubs.onSessionStub.callCount, 1);
         t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -671,7 +672,7 @@ test.serial(`HTTP: User opted out => first page view => onSession flag is off =>
   const subscribeSpy = sinonSandbox.spy(SubscriptionManager.prototype, "subscribe");
   await markUserAsOptedOut(sinonSandbox, playerId);
 
-  const initializePromise = new Promise((resolve) => {
+  const initializePromise = new Promise(resolve => {
     OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
       t.is(stubs.onSessionStub.callCount, 0);
       t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -711,7 +712,7 @@ test.serial(`HTTP: User opted out => second page view => onSession flag is on =>
 
   sinonSandbox.stub(PageViewManager.prototype, "getPageViewCount").resolves(2);
 
-  const initializePromise = new Promise((resolve) => {
+  const initializePromise = new Promise(resolve => {
     OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
       t.is(stubs.onSessionStub.callCount, 0);
       t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -748,7 +749,7 @@ test.serial(`HTTP: User subscribed => first page view => expiring subscription =
   await markUserAsSubscribedOnHttp(sinonSandbox, playerId, true);
   stubServiceWorkerInstallation(sinonSandbox);
 
-  const initializePromise = new Promise((resolve) => {
+  const initializePromise = new Promise(resolve => {
     OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
       // t.is(registerStub.callCount, 1);
       t.is(stubs.onSessionStub.callCount, 0);
@@ -784,7 +785,7 @@ test.serial(`HTTP: User subscribed => first page view => sends on session`, asyn
   await markUserAsSubscribedOnHttp(sinonSandbox, playerId);
   stubServiceWorkerInstallation(sinonSandbox);
 
-  const initializePromise = new Promise((resolve) => {
+  const initializePromise = new Promise(resolve => {
     OneSignal.on(OneSignal.EVENTS.SDK_INITIALIZED_PUBLIC, () => {
       t.is(stubs.onSessionStub.callCount, 1);
       t.is(stubs.createPlayerPostStub.callCount, 0);
@@ -821,7 +822,7 @@ async function beforeTest(
   sinonSandbox.stub(window.Notification, "permission").value(testConfig.permission || "default");
 
   const createPlayerPostStub = sinonSandbox.stub(OneSignalApiBase, "post")
-    .resolves({success: true, id: playerId});
+    .resolves({ success: true, id: playerId });
   const onSessionStub = sinonSandbox.stub(SessionManager.prototype, "upsertSession").resolves();
   // const onSessionStub = sinonSandbox.stub(OneSignal.context.sessionManager, "upsertSession").resolves();
 
@@ -839,28 +840,6 @@ async function beforeTest(
   }
   return { createPlayerPostStub, onSessionStub };
 }
-
-function simulateSlidedownAllowAfterShown() {
-  OneSignal.on(Slidedown.EVENTS.SHOWN, () => {
-    OneSignalEvent.trigger(Slidedown.EVENTS.ALLOW_CLICK);
-  });
-}
-
-function simulateSlidedownDismissAfterShown() {
-  OneSignal.on(Slidedown.EVENTS.SHOWN, () => {
-    OneSignalEvent.trigger(Slidedown.EVENTS.CANCEL_CLICK);
-  });
-}
-
-function simulateNativeAllowAfterShown() {
-  OneSignal.emitter.on(OneSignal.EVENTS.PERMISSION_PROMPT_DISPLAYED, () => {
-    sinonSandbox.stub(SubscriptionManager.prototype, "getSubscriptionState")
-      .resolves({subscribed: true, isOptedOut: false});
-    stubServiceWorkerInstallation(sinonSandbox);
-  });
-}
-
-
 
 async function inspectPushRecordCreationRequest(t: ExecutionContext, requestStub: SinonStub) {
   // For player#create device record is already serialized. Checking serialized structure.

--- a/test/unit/utils/TagUtils.ts
+++ b/test/unit/utils/TagUtils.ts
@@ -1,0 +1,36 @@
+import test from "ava";
+import TagUtils from '../../../src/utils/TagUtils';
+import _ from "lodash";
+import sinon, { SinonSandbox } from "sinon";
+import { TestEnvironment } from '../../support/sdk/TestEnvironment';
+import OneSignalApiBase from '../../../src/OneSignalApiBase';
+import Database from '../../../src/services/Database';
+
+const sinonSandbox: SinonSandbox = sinon.sandbox.create();
+
+test.beforeEach(async () => {
+    await TestEnvironment.initialize({ stubSetTimeout: true });
+    TestEnvironment.mockInternalOneSignal();
+});
+
+test.afterEach(() => {
+    sinonSandbox.restore();
+});
+
+test('check conversion from tag number values to booleans', t => {
+    const converted = TagUtils.convertTagNumberValuesToBooleans({ tag1: "1", tag2: "0" });
+    t.true(_.isEqual(converted, { tag1: true, tag2: false }));
+});
+
+test('check conversion from tag boolean values to numbers', t => {
+    const converted = TagUtils.convertTagBooleanValuesToNumbers({ tag1: false, tag2: true });
+    t.true(_.isEqual(converted, { tag1: 0, tag2: 1 }));
+});
+
+test('check tagHelperWithRetries makes correct number of tries', async t => {
+    const getTagsSpy = sinonSandbox.spy(OneSignal, "getTags");
+    sinonSandbox.stub(OneSignalApiBase, "get").rejects();
+    sinonSandbox.stub(Database, "getSubscription");
+    await TagUtils.tagHelperWithRetries(OneSignal.getTags, 100, 3);
+    t.is(getTagsSpy.callCount, 4);
+});

--- a/test/unit/utils/utils.ts
+++ b/test/unit/utils/utils.ts
@@ -1,4 +1,4 @@
-import '../support/polyfills/polyfills';
+import '../../support/polyfills/polyfills';
 import test from "ava";
 import { timeoutPromise } from "../../../src/utils";
 import TimeoutError from '../../../src/errors/TimeoutError';

--- a/test/unit/utils/utils.ts
+++ b/test/unit/utils/utils.ts
@@ -1,7 +1,7 @@
 import '../support/polyfills/polyfills';
 import test from "ava";
-import { timeoutPromise } from "../../src/utils";
-import TimeoutError from '../../src/errors/TimeoutError';
+import { timeoutPromise } from "../../../src/utils";
+import TimeoutError from '../../../src/errors/TimeoutError';
 
 
 test(`timeoutPromise should reject after the specified amount of time`, async t => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2703,6 +2703,14 @@ doctrine@0.7.2:
     esutils "^1.1.6"
     isarray "0.0.1"
 
+dom-serializer@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
+  integrity sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
+  dependencies:
+    domelementtype "^2.0.1"
+    entities "^2.0.0"
+
 dom-storage@^2.0.2:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/dom-storage/-/dom-storage-2.1.0.tgz#00fb868bc9201357ea243c7bcfd3304c1e34ea39"
@@ -2711,12 +2719,33 @@ domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
 
+domelementtype@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
+  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
+
 domexception@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
   integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
   dependencies:
     webidl-conversions "^4.0.2"
+
+domhandler@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.0.0.tgz#51cd13efca31da95bbb0c5bee3a48300e333b3e9"
+  integrity sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==
+  dependencies:
+    domelementtype "^2.0.1"
+
+domutils@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.1.0.tgz#7ade3201af43703fde154952e3a868eb4b635f16"
+  integrity sha512-CD9M0Dm1iaHfQ1R/TI+z3/JWp/pgub0j4jIQKH89ARR4ATAV2nbaOQS5XxU9maJP5jHaPdDDQSEHuE2UmpUTKg==
+  dependencies:
+    dom-serializer "^0.2.1"
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
 
 dot-prop@^5.2.0:
   version "5.2.0"
@@ -2839,6 +2868,11 @@ enhanced-resolve@^4.0.0:
     graceful-fs "^4.1.2"
     memory-fs "^0.4.0"
     tapable "^1.0.0"
+
+entities@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 equal-length@^1.0.0:
   version "1.0.1"
@@ -3928,6 +3962,16 @@ html-encoding-sniffer@^1.0.1:
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
     whatwg-encoding "^1.0.1"
+
+htmlparser2@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.1.0.tgz#9a4ef161f2e4625ebf7dfbe6c0a2f52d18a59e78"
+  integrity sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+    domutils "^2.0.0"
+    entities "^2.0.0"
 
 http-cache-semantics@3.8.1:
   version "3.8.1"
@@ -6531,6 +6575,15 @@ postcss@^6.0.0, postcss@^6.0.1:
     source-map "^0.6.1"
     supports-color "^5.3.0"
 
+postcss@^7.0.27:
+  version "7.0.32"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.32.tgz#4310d6ee347053da3433db2be492883d62cec59d"
+  integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
 prebuild-install@^5.3.2:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-5.3.3.tgz#ef4052baac60d465f5ba6bf003c9c1de79b9da8e"
@@ -7262,6 +7315,18 @@ samsam@1.x, samsam@^1.1.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.3.0.tgz#8d1d9350e25622da30de3e44ba692b5221ab7c50"
 
+sanitize-html@^1.26.0:
+  version "1.27.0"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.27.0.tgz#42104a2d59f1a48b616b5165ad5349824861e580"
+  integrity sha512-U1btucGeYVpg0GoK43jPpe/bDCV4cBOGuxzv5NBd0bOjyZdMKY0n98S/vNlO1wVwre0VCj8H3hbzE7gD2+RjKA==
+  dependencies:
+    chalk "^2.4.1"
+    htmlparser2 "^4.1.0"
+    lodash "^4.17.15"
+    postcss "^7.0.27"
+    srcset "^2.0.1"
+    xtend "^4.0.1"
+
 sass-graph@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/sass-graph/-/sass-graph-2.2.4.tgz#13fbd63cd1caf0908b9fd93476ad43a51d1e0b49"
@@ -7637,6 +7702,11 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
+srcset@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/srcset/-/srcset-2.0.1.tgz#8f842d357487eb797f413d9c309de7a5149df5ac"
+  integrity sha512-00kZI87TdRKwt+P8jj8UZxbfp7mK2ufxcIMWvhAOZNJTRROimpHeruWrGvCZneiuVDLqdyHefVp748ECTnyUBQ==
+
 sshpk@^1.7.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.14.1.tgz#130f5975eddad963f1d56f92b9ac6c51fa9f83eb"
@@ -7873,6 +7943,13 @@ supports-color@^4.0.0:
 supports-color@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
+  dependencies:
+    has-flag "^3.0.0"
+
+supports-color@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
+  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
 
@@ -8744,6 +8821,11 @@ xml-name-validator@^2.0.1:
 xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+xtend@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
# Description
Testing for Category Slidedown. Includes some refactoring and other tweaks.

# Unit Testing
### PromptsManager.ts
- 'if category options are not configured, check that an error was logged'
- 'category options are configured, in update mode, check 1) tagging container loaded 2) remote tag fetch'
- 'category options are configured, not in update mode, check remote tag fetch not made'

### TagManager.ts
- 'calling `syncTags` results in remote tag update with sendTags'
- '`downloadTags` results in remote getTags call'
- 'subscribing through category slidedown accept button calls syncTags'

### TaggingContainer.ts
- 'check sanitization is working correctly'
- 'check that correct TagCategory object is returned after applying remote player tags'

### TagUtils.ts
- 'check conversion from tag number values to booleans'
- 'check conversion from tag boolean values to numbers'
- 'check tagHelperWithRetries makes correct number of tries'

# Refactoring
- Renamed unit tests to prevent duplicates
- `setupOneSignalWithStubs()` helper replaces `beforeTest()`


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/659)
<!-- Reviewable:end -->
