### PR TITLE
Correct web push setup documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ This SDK allows your site's visitors to receive push notifications from you. Sen
 
 ## Getting Started
 
-View our [documentation](https://documentation.onesignal.com/docs/web-push-setup) to get started.
+View our [documentation](https://documentation.onesignal.com/docs/web-push-quickstart) to get started.
 
 Please reference the OneSignal SDK on your webpage via our CDN URL (listed in our setup documentation) instead of copying the source into another file. This is because our SDK updates frequently for new features and bug fixes.


### PR DESCRIPTION
The old link leads to `Page not Found` page with common suggestions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/664)
<!-- Reviewable:end -->
