### PR TITLE
Don't default to document title if no notification title present

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -306,7 +306,6 @@ export default class OneSignal {
         MainHelper.checkAndTriggerNotificationPermissionChanged();
       });
 
-      await InitHelper.initSaveState(document.title);
       await InitHelper.saveInitOptions();
       if (SdkEnvironment.getWindowEnv() === WindowEnvironmentKind.CustomIframe)
         await Event.trigger(OneSignal.EVENTS.SDK_INITIALIZED);

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -265,7 +265,7 @@ export default class InitHelper {
         if (registration && registration.active) {
           await OneSignal.context.serviceWorkerManager.establishServiceWorkerChannel();
         }
-      } catch (e) { 
+      } catch (e) {
         Log.error(e);
       }
     }
@@ -475,7 +475,7 @@ export default class InitHelper {
   public static async initSaveState(overridingPageTitle: string) {
     const appId = await MainHelper.getAppId();
     await Database.put('Ids', { type: 'appId', id: appId });
-    const initialPageTitle = overridingPageTitle || document.title || 'Notification';
+    const initialPageTitle = overridingPageTitle || '';
     await Database.put('Options', { key: 'pageTitle', value: initialPageTitle });
     Log.info(`OneSignal: Set pageTitle to be '${initialPageTitle}'.`);
     const config: AppConfig = OneSignal.config;

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -102,7 +102,6 @@ export class ServiceWorker {
       event.waitUntil(ServiceWorker.onPushSubscriptionChange(event))
     });
 
-
     self.addEventListener('message', (event: ExtendableMessageEvent) => {
       const data: WorkerMessengerMessage = event.data;
       if (!data || !data.command) {
@@ -213,7 +212,7 @@ export class ServiceWorker {
 
         const timestamp = payload.timestamp;
         if (self.clientsStatus.timestamp !== timestamp) { return; }
-        
+
         self.clientsStatus.receivedResponsesCount++;
         if (payload.focused) {
           self.clientsStatus.hasAnyActiveSessions = true;
@@ -357,18 +356,18 @@ export class ServiceWorker {
     if (!hasRequiredParams) {
       return null;
     }
- 
+
     // JSON.stringify() does not include undefined values
     // Our response will not contain those fields here which have undefined values
     const postData = {
-      player_id : deviceId, 
+      player_id : deviceId,
       app_id : appId
     };
-    
+
     Log.debug(`Called %csendConfirmedDelivery(${
       JSON.stringify(notification, null, 4)
     })`, Utils.getConsoleStyle('code'));
-    
+
     return await OneSignalApiBase.put(`notifications/${notification.id}/report_received`, postData);
   }
 
@@ -432,7 +431,7 @@ export class ServiceWorker {
      * if https -> getActiveClients -> check for the first focused
      * unfortunately, not enough for safari, it always returns false for focused state of a client
      * have to workaround it with messaging to the client.
-     * 
+     *
      * if http, also have to workaround with messaging:
      *   SW to iframe -> iframe to page -> page to iframe -> iframe to SW
      */
@@ -602,7 +601,8 @@ export class ServiceWorker {
     Log.debug(`Called %cdisplayNotification(${JSON.stringify(notification, null, 4)}):`, Utils.getConsoleStyle('code'), notification);
 
     // Use the default title if one isn't provided
-    const defaultTitle = await ServiceWorker._getTitle();
+    const defaultTitle = await Database.get("Options", "defaultTitle") || "";
+
     // Use the default icon if one isn't provided
     const defaultIcon = await Database.get('Options', 'defaultIcon');
     // Get option of whether we should leave notification displaying indefinitely
@@ -1091,26 +1091,6 @@ export class ServiceWorker {
         subscriptionState
       );
     }
-  }
-
-  /**
-   * Returns a promise that is fulfilled with either the default title from the database (first priority) or the page title from the database (alternate result).
-   */
-  static _getTitle() {
-    return new Promise(resolve => {
-      Promise.all([Database.get('Options', 'defaultTitle'), Database.get('Options', 'pageTitle')])
-        .then(([defaultTitle, pageTitle]) => {
-          if (defaultTitle !== null) {
-            resolve(defaultTitle);
-          }
-          else if (pageTitle != null) {
-            resolve(pageTitle);
-          }
-          else {
-            resolve('');
-          }
-        });
-    });
   }
 
   /**


### PR DESCRIPTION
# Don't default to document title if no notification title present

### Detailed description

Notification titles used to be required in browsers. We allowed users to not provide a title, but if that happened, we defaulted to the document.title property. This is no longer a required field for notifications, and browsers handle it differently (i.e. Chrome says 'Google Chrome' if no title is present).

This continues to use the default title value if it is provided by the user by calling `OneSignal.setDefaultTitle`.

### Checklist:

- [x] I have personally tested this on my machine or explained why that is not possible
- [x] I have included screenshots/recordings of the intended results


### Jira Ticket(s):
[OS-4666](https://onesignal.atlassian.net/browse/OS-4666)

### Screenshots/Gifs/Video of All Changes:
With no title or default title set:
![no-title](https://user-images.githubusercontent.com/26235016/88229893-5f6ca280-cc26-11ea-94f7-7d2248f6c9b3.gif)

Default title set, then with an actual notification title:
![title](https://user-images.githubusercontent.com/26235016/88229950-73180900-cc26-11ea-82fd-f9a8f75261a0.gif)


### Users Affected:

Estimated number of users this change will impact:

All end users who receive notifications without a set title


### Validation:

- Send notification without a title or default title
  - should see browser default title (i.e. 'Google Chrome' in Chrome)
- Send notification without a title, but after setting a default title (call `OneSignal.setDefaultTitle(<string>)`)
  - should see newly set default title
- Send notification with a title set
  - should see title set on notification

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/674)
<!-- Reviewable:end -->
