### PR TITLE
Revert string values for slidedown events

### DIFF
--- a/src/slidedown/Slidedown.ts
+++ b/src/slidedown/Slidedown.ts
@@ -29,10 +29,10 @@ export default class Slidedown {
 
   static get EVENTS() {
     return {
-      ALLOW_CLICK: 'slidedownAllowClick',
-      CANCEL_CLICK: 'slidedownCancelClick',
-      SHOWN: 'slidedownShown',
-      CLOSED: 'slidedownClosed',
+      ALLOW_CLICK: 'popoverAllowClick',
+      CANCEL_CLICK: 'popoverCancelClick',
+      SHOWN: 'popoverShown',
+      CLOSED: 'popoverClosed',
     };
   }
 


### PR DESCRIPTION
Slidedown -> popover rename should not have changed actual string values as it is not backwards compatible.

Reverting to old values for now. Ideally should update to emit both new and old event and have deprecation path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/675)
<!-- Reviewable:end -->
