### PR TITLE
Switch to new slidedown event strings while keeping legacy support

### DIFF
--- a/src/slidedown/Slidedown.ts
+++ b/src/slidedown/Slidedown.ts
@@ -27,12 +27,21 @@ export default class Slidedown {
 
   private categoryOptions: Categories|undefined;
 
-  static get EVENTS() {
+  static get LEGACY_EVENTS() {
     return {
       ALLOW_CLICK: 'popoverAllowClick',
       CANCEL_CLICK: 'popoverCancelClick',
       SHOWN: 'popoverShown',
       CLOSED: 'popoverClosed',
+    };
+  }
+
+  static get EVENTS() {
+    return {
+      ALLOW_CLICK: 'slidedownAllowClick',
+      CANCEL_CLICK: 'slidedownCancelClick',
+      SHOWN: 'slidedownShown',
+      CLOSED: 'slidedownClosed',
     };
   }
 
@@ -98,15 +107,18 @@ export default class Slidedown {
       // Add click event handlers
       this.allowButton.addEventListener('click', this.onSlidedownAllowed.bind(this));
       this.cancelButton.addEventListener('click', this.onSlidedownCanceled.bind(this));
+      Event.trigger(Slidedown.LEGACY_EVENTS.SHOWN);
       Event.trigger(Slidedown.EVENTS.SHOWN);
     }
   }
 
   async onSlidedownAllowed(_: any) {
+    await Event.trigger(Slidedown.LEGACY_EVENTS.ALLOW_CLICK);
     await Event.trigger(Slidedown.EVENTS.ALLOW_CLICK);
   }
 
   onSlidedownCanceled(_: any) {
+    Event.trigger(Slidedown.LEGACY_EVENTS.CANCEL_CLICK);
     Event.trigger(Slidedown.EVENTS.CANCEL_CLICK);
     this.close();
   }
@@ -119,6 +131,7 @@ export default class Slidedown {
           // Uninstall the event listener for animationend
           removeDomElement(`#${SlidedownCssIds.container}`);
           destroyListenerFn();
+          Event.trigger(Slidedown.LEGACY_EVENTS.CLOSED);
           Event.trigger(Slidedown.EVENTS.CLOSED);
       }
     }, true);
@@ -205,6 +218,7 @@ export default class Slidedown {
 
 export function manageNotifyButtonStateWhileSlidedownShows() {
   const notifyButton = OneSignal.notifyButton;
+
   if (notifyButton &&
     notifyButton.options.enable &&
     OneSignal.notifyButton.launcher.state !== 'hidden') {


### PR DESCRIPTION
After switching from the new names ("slidedown" over "popover") back to the old to revert a regression, here we are adding back the new convention while maintaining backwards compatibility.

Old event strings are now on the LEGACY_EVENTS parameter while new event strings are on the EVENTS parameter of the Slidedown object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/679)
<!-- Reviewable:end -->
