### PR TITLE
Make Slidedown button string max length consistant with Category Slidedown

### DIFF
--- a/src/slidedown/Slidedown.ts
+++ b/src/slidedown/Slidedown.ts
@@ -43,8 +43,8 @@ export default class Slidedown {
     this.options = options;
     this.categoryOptions = options.categories;
     this.options.actionMessage = options.actionMessage.substring(0, 90);
-    this.options.acceptButtonText = options.acceptButtonText.substring(0, 15);
-    this.options.cancelButtonText = options.cancelButtonText.substring(0, 15);
+    this.options.acceptButtonText = options.acceptButtonText.substring(0, 16);
+    this.options.cancelButtonText = options.cancelButtonText.substring(0, 16);
     this.notificationIcons = null;
     this.isShowingFailureState = false;
 


### PR DESCRIPTION
We should be consistant with the max string length for buttons in the regular slidedown as well as the Category Slidedown

- change from 15 to 16

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/680)
<!-- Reviewable:end -->
