### PR TITLE
HTTP Fix Controller is Undefined

### DIFF
--- a/src/context/browser/helpers/EnvironmentInfoHelper.ts
+++ b/src/context/browser/helpers/EnvironmentInfoHelper.ts
@@ -19,8 +19,9 @@ export class EnvironmentInfoHelper {
             isUsingSubscriptionWorkaround: this.isUsingSubscriptionWorkaround(),
             isBrowserAndSupportsServiceWorkers: this.supportsServiceWorkers(),
             requiresUserInteraction: this.requiresUserInteraction(),
-            osVersion: this.getOsVersion()
-        }
+            osVersion: this.getOsVersion(),
+            canTalkToServiceWorker: this.canTalkToServiceWorker()
+        };
     }
 
     private static getBrowser(): Browser {
@@ -75,5 +76,9 @@ export class EnvironmentInfoHelper {
 
     private static getOsVersion(): string|number {
         return bowser.osversion;
+    }
+
+    private static canTalkToServiceWorker(): boolean {
+        return window.isSecureContext;
     }
 }

--- a/src/context/browser/helpers/EnvironmentInfoHelper.ts
+++ b/src/context/browser/helpers/EnvironmentInfoHelper.ts
@@ -79,6 +79,6 @@ export class EnvironmentInfoHelper {
     }
 
     private static canTalkToServiceWorker(): boolean {
-        return window.isSecureContext;
+        return !!window.isSecureContext;
     }
 }

--- a/src/context/browser/models/EnvironmentInfo.ts
+++ b/src/context/browser/models/EnvironmentInfo.ts
@@ -9,4 +9,5 @@ export interface EnvironmentInfo {
     isBrowserAndSupportsServiceWorkers: boolean;
     requiresUserInteraction: boolean;
     osVersion: string|number;
+    canTalkToServiceWorker: boolean;
 }

--- a/src/managers/PermissionManager.ts
+++ b/src/managers/PermissionManager.ts
@@ -76,8 +76,15 @@ export default class PermissionManager {
     // Is this web push setup using subdomain.os.tc or subdomain.onesignal.com?
     if (OneSignalUtils.isUsingSubscriptionWorkaround())
       return await this.getOneSignalSubdomainNotificationPermission(safariWebId);
-    else
+    else {
+      const reportedPermission: NotificationPermission = this.getW3cNotificationPermission();
+
+      if (await this.isPermissionEnvironmentAmbiguous(reportedPermission)) {
+        return await this.getInterpretedAmbiguousPermission(reportedPermission);
+      }
+
       return this.getW3cNotificationPermission();
+    }
   }
 
   /**

--- a/src/managers/sessionManager/page/SessionManager.ts
+++ b/src/managers/sessionManager/page/SessionManager.ts
@@ -41,7 +41,8 @@ export class SessionManager implements ISessionManager {
     ) {
       Log.debug("Notify SW to upsert session");
       await this.context.workerMessenger.unicast(WorkerMessengerCommand.SessionUpsert, payload);
-    } else if (this.context.environmentInfo.isUsingSubscriptionWorkaround) {
+    } else if (this.context.environmentInfo.canTalkToServiceWorker &&
+        this.context.environmentInfo.isUsingSubscriptionWorkaround) {
       Log.debug("Notify iframe to notify SW to upsert session");
       await OneSignal.proxyFrameHost.runCommand(OneSignal.POSTMAM_COMMANDS.SESSION_UPSERT, payload);
     } else { // http w/o our iframe
@@ -72,7 +73,8 @@ export class SessionManager implements ISessionManager {
     ) {
       Log.debug("Notify SW to deactivate session");
       await this.context.workerMessenger.unicast(WorkerMessengerCommand.SessionDeactivate, payload);
-    } else if (this.context.environmentInfo.isUsingSubscriptionWorkaround) {
+    } else if (this.context.environmentInfo.canTalkToServiceWorker &&
+        this.context.environmentInfo.isUsingSubscriptionWorkaround) {
       Log.debug("Notify SW to deactivate session");
       await OneSignal.proxyFrameHost.runCommand(OneSignal.POSTMAM_COMMANDS.SESSION_DEACTIVATE, payload);
     } else { // http w/o our iframe

--- a/src/managers/sessionManager/page/SessionManager.ts
+++ b/src/managers/sessionManager/page/SessionManager.ts
@@ -193,7 +193,12 @@ export class SessionManager implements ISessionManager {
       this.context.environmentInfo.isBrowserAndSupportsServiceWorkers ||
       this.context.environmentInfo.isUsingSubscriptionWorkaround
     ) {
-      this.setupSessionEventListeners();
+      if (!this.context.environmentInfo.canTalkToServiceWorker) {
+        this.onSessionSent = sessionOrigin === SessionOrigin.PlayerCreate;
+        OneSignal.emitter.emit(OneSignal.EVENTS.SESSION_STARTED);
+      } else {
+        this.setupSessionEventListeners();
+      }
     } else if (
       !this.context.environmentInfo.isBrowserAndSupportsServiceWorkers &&
       !this.context.environmentInfo.isUsingSubscriptionWorkaround

--- a/src/managers/sessionManager/page/SessionManager.ts
+++ b/src/managers/sessionManager/page/SessionManager.ts
@@ -218,7 +218,12 @@ export class SessionManager implements ISessionManager {
       !this.context.environmentInfo.isBrowserAndSupportsServiceWorkers &&
       !this.context.environmentInfo.isUsingSubscriptionWorkaround
     ) {
-      Log.debug("Not setting session event listeners. No SW possible.");
+      Log.debug("Not setting session event listeners. No service worker possible.");
+      return;
+    }
+
+    if (!this.context.environmentInfo.canTalkToServiceWorker) {
+      Log.debug("Not setting session event listeners. Can't talk to ServiceWorker due being hosted on an HTTP page.");
       return;
     }
 


### PR DESCRIPTION
# Description
## 1 Line Summary
Fixes issue on HTTP sites introduced during Outcomes release where access to the service worker from an HTTP site isn't available

## Details
This fix addresses issue where `WorkerMessenger.js:118 Uncaught (in promise) TypeError: Cannot read property 'controller' of undefined` is thrown on HTTP sites. The reason this fails is because `isSecureContext` is `false` in the iframe context due to ancestry rules. In other words, the iframe is not considered secure because it is a child of the host (page) which is insecure (http) and so can't establish the messaging channel. From MDN:

`For example, even for a document delivered over TLS within an <iframe>, its context is not considered secure if it has an ancestor that was not also delivered over TLS.`
([source](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts))

To resolve, we switch to use `getInterpretedAmbiguousPermission` which is a workaround to Chrome 62+'s permission ambiguity for "denied" permissions, we assume the permission is "default" until we actually record the permission being "denied" or "granted". This allows our best-effort approach to subscribe new users, and upon subscribing, if we discover the actual permission to be denied, we record this for next time.

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings by with the explanation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/683)
<!-- Reviewable:end -->
