### PR TITLE
Use site name as default notification title

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -306,7 +306,7 @@ export default class OneSignal {
         MainHelper.checkAndTriggerNotificationPermissionChanged();
       });
 
-      await InitHelper.initSaveState(document.title);
+      await InitHelper.initSaveState();
       await InitHelper.saveInitOptions();
       if (SdkEnvironment.getWindowEnv() === WindowEnvironmentKind.CustomIframe)
         await Event.trigger(OneSignal.EVENTS.SDK_INITIALIZED);

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -75,8 +75,8 @@ export default class OneSignal {
   }
 
   /**
-   * Sets the default title to display on notifications. Will default to the page's document.title
-   *  if you don't call this.
+   * Sets the default title to display on notifications. Will default to the site name provided
+   * on the dashboard if you don't call this.
    * @remarks Either DB value defaultTitle or pageTitle is used when showing a notification title.
    * @PublicApi
    */

--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -108,6 +108,7 @@ export class ConfigHelper {
     return {
       appId: serverConfig.app_id,
       subdomain,
+      siteName: serverConfig.config.siteInfo.name,
       origin: serverConfig.config.origin,
       httpUseOneSignalCom: serverConfig.config.http_use_onesignal_com,
       cookieSyncEnabled: serverConfig.features.cookie_sync.enable,

--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -319,7 +319,7 @@ export class ConfigHelper {
       pageViews: SERVER_CONFIG_DEFAULTS_PROMPT_DELAYS.pageViews,
       timeDelay: SERVER_CONFIG_DEFAULTS_PROMPT_DELAYS.timeDelay
     };
-    let categories: Categories;
+    let categories: Categories | undefined = undefined;
     if (staticPrompts.slidedown.categories) {
       categories = TagUtils.limitCategoriesToMaxCount(staticPrompts.slidedown.categories, MAX_CATEGORIES);
     }
@@ -336,7 +336,7 @@ export class ConfigHelper {
       actionMessage: staticPrompts.slidedown.actionMessage,
       acceptButtonText: staticPrompts.slidedown.acceptButton,
       cancelButtonText: staticPrompts.slidedown.cancelButton,
-      categories
+      categories,
     };
     return {
       autoPrompt: native.autoPrompt || slidedown.autoPrompt,

--- a/src/helpers/HttpHelper.ts
+++ b/src/helpers/HttpHelper.ts
@@ -5,6 +5,7 @@ import LegacyManager from '../managers/LegacyManager';
 import SdkEnvironment from '../managers/SdkEnvironment';
 import { WindowEnvironmentKind } from '../models/WindowEnvironmentKind';
 import ProxyFrame from '../modules/frames/ProxyFrame';
+import { RemoteFrameOptions } from '../modules/frames/RemoteFrame';
 import SubscriptionModal from '../modules/frames/SubscriptionModal';
 import SubscriptionPopup from '../modules/frames/SubscriptionPopup';
 import { getConsoleStyle } from '../utils';
@@ -12,11 +13,10 @@ import Log from '../libraries/Log';
 
 declare var OneSignal: any;
 
-
 export default class HttpHelper {
 
   // Http only - Only called from iframe's init.js
-  static async initHttp(options) {
+  static async initHttp(options: RemoteFrameOptions) {
     Log.debug(`Called %cinitHttp(${JSON.stringify(options, null, 4)})`, getConsoleStyle('code'));
 
     switch (SdkEnvironment.getWindowEnv()) {

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -471,14 +471,14 @@ export default class InitHelper {
     return Promise.all(opPromises);
   }
 
-  // overridingPageTitle: Only for the HTTP Iframe, pass the page title in from the top frame
-  public static async initSaveState(overridingPageTitle: string) {
+  public static async initSaveState(overridingPageTitle?: string) {
     const appId = await MainHelper.getAppId();
-    await Database.put('Ids', { type: 'appId', id: appId });
-    const initialPageTitle = overridingPageTitle || document.title || 'Notification';
-    await Database.put('Options', { key: 'pageTitle', value: initialPageTitle });
-    Log.info(`OneSignal: Set pageTitle to be '${initialPageTitle}'.`);
     const config: AppConfig = OneSignal.config;
+    await Database.put('Ids', { type: 'appId', id: appId });
+    const pageTitle: string =
+      overridingPageTitle || config.siteName || document.title || 'Notification';
+    await Database.put('Options', { key: 'pageTitle', value: pageTitle });
+    Log.info(`OneSignal: Set pageTitle to be '${pageTitle}'.`);
     await Database.put('Options', { key: 'emailAuthRequired', value: !!config.emailAuthRequired })
   }
 

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -64,6 +64,8 @@ export interface AppConfig {
    */
   receiveReceiptsEnable?: boolean;
   sessionThreshold?: number;
+
+  siteName: string;
 }
 
 export enum ConfigIntegrationKind {

--- a/src/modules/frames/ProxyFrame.ts
+++ b/src/modules/frames/ProxyFrame.ts
@@ -112,7 +112,7 @@ export default class ProxyFrame extends RemoteFrame {
      * stores the last visited full page URL.
      */
     await Database.put('Options', { key: 'lastKnownHostUrl', value: OneSignal.config.pageUrl });
-    await InitHelper.initSaveState(OneSignal.config.pageTitle);
+    await InitHelper.initSaveState();
     await InitHelper.storeInitialValues();
     await InitHelper.saveInitOptions();
 

--- a/src/modules/frames/ProxyFrame.ts
+++ b/src/modules/frames/ProxyFrame.ts
@@ -13,7 +13,7 @@ import {
   UpsertSessionPayload, DeactivateSessionPayload, PageVisibilityResponse
 } from "../../models/Session";
 import { WorkerMessengerCommand } from "../../libraries/WorkerMessenger";
-
+import { AppConfig } from "../../models/AppConfig";
 /**
  * The actual OneSignal proxy frame contents / implementation, that is loaded
  * into the iFrame URL as subdomain.onesignal.com/webPushIFrame or
@@ -87,14 +87,13 @@ export default class ProxyFrame extends RemoteFrame {
   async onProxyFrameInitializing(message: MessengerMessageEvent) {
     Log.info(`(${SdkEnvironment.getWindowEnv().toString()}) The iFrame has just received initOptions from the host page!`);
 
-    OneSignal.config = {
+    const config: AppConfig = {
       ...message.data.hostInitOptions,
       ...OneSignal.config,
-      ...{
       pageUrl: message.data.pageUrl,
-      pageTitle: message.data.pageTitle
-      }
     };
+
+    OneSignal.config = config;
 
     InitHelper.installNativePromptPermissionChangedHook();
 

--- a/src/modules/frames/ProxyFrameHost.ts
+++ b/src/modules/frames/ProxyFrameHost.ts
@@ -126,7 +126,6 @@ export default class ProxyFrameHost implements Disposable {
     this.messenger.message(OneSignal.POSTMAM_COMMANDS.IFRAME_POPUP_INITIALIZE, {
       hostInitOptions: deepCopy(OneSignal.config), // Removes functions and unmessageable objects
       pageUrl: window.location.href,
-      pageTitle: document.title,
     }, (reply: Reply) => {
       if (reply.data === OneSignal.POSTMAM_COMMANDS.REMOTE_OPERATION_COMPLETE) {
         this.loadPromise.resolver();

--- a/src/modules/frames/RemoteFrame.ts
+++ b/src/modules/frames/RemoteFrame.ts
@@ -9,6 +9,23 @@ import ConfigManager from '../../managers/ConfigManager';
 import LocalStorage from '../../utils/LocalStorage';
 import { EnvironmentInfoHelper } from "../../context/browser/helpers/EnvironmentInfoHelper";
 
+/*
+  These options are passed from the Rails app as plain raw untyped values.
+  They have to be converted to the right types.
+*/
+export interface RemoteFrameOptions {
+  appId: string;
+  /* Passed to both the iFrame and popup */
+  subdomainName: string;
+  /* Passed to both the iFrame and popup. Represents Site URL in dashboard config. */
+  origin: string;
+  siteName: string;
+  /* These three flags may be deprecated */
+  continuePressed?: boolean;
+  isPopup?: boolean;
+  isModal?: boolean;
+}
+
 export default class RemoteFrame implements Disposable {
   protected messenger: Postmam;
   protected options: ProxyFrameInitOptions;
@@ -21,26 +38,12 @@ export default class RemoteFrame implements Disposable {
     rejector: Function;
   };
 
-  constructor(initOptions: {
-    /*
-      These options are passed from the Rails app as plain raw untyped values.
-
-      They have to be converted to the right types.
-      */
-    appId: string;
-    /* Passed to both the iFrame and popup */
-    subdomainName: string;
-    /* Passed to both the iFrame and popup. Represents Site URL in dashboard config. */
-    origin: string;
-    /* These three flags may be deprecated */
-    continuePressed: boolean;
-    isPopup: boolean;
-    isModal: boolean;
-  }) {
+  constructor(initOptions: RemoteFrameOptions) {
     this.options = {
       appId: initOptions.appId,
       subdomain: initOptions.subdomainName,
       origin: initOptions.origin,
+      siteName: initOptions.siteName,
       metrics: {
         enable: false,
         mixpanelReportingToken: null

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -399,6 +399,7 @@ export class TestEnvironment {
     return {
       appId,
       subdomain: undefined,
+      siteName: "Fake App",
       httpUseOneSignalCom: false,
       cookieSyncEnabled: true,
       restrictedOriginEnabled: true,


### PR DESCRIPTION
## One Line Summary
Use site name as default notification title

## Details
As described in [this epic](https://onesignal.atlassian.net/browse/OS-4876):

Currently if notification does not have a title specified in the dashboard, the web sdk first attempts to use `defaultTitle` provided via `setDefaultTitle` and then `pageTitle` which is set during OneSignal initialization as `document.title` of the page.

The problem is that if user subscribes for notifications for the whole site while being on some topic specific page, e.g. looking at the page with title `My Site Sports`, all their notifications will have this value used as a site's name going forward.

Solution:
Pass site name to web sdk (actually already happening) and use it in web sdk to save as the page title.
Order of title resolution:
actual notification title if present -> default title (provided via `setDefaultTitle`) -> page title

For http integration had to make this change on the dashboard - https://github.com/OneSignal/OneSignal/pull/4642.

## Screenshots
<img width="327" alt="Screen Shot 2020-08-12 at 5 59 13 PM" src="https://user-images.githubusercontent.com/39500603/90083333-12309d80-dcc7-11ea-9f90-55521c82378f.png">

---

## Related Tickets
https://onesignal.atlassian.net/browse/OS-4950

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/684)
<!-- Reviewable:end -->
