### PR TITLE
Button color change

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,7 +29,7 @@ Functions:
 
 Typescript:
    - [ ] No Typescript warnings
-   - [ ] Avoid silencing null/undefined warnings by with the explanation point
+   - [ ] Avoid silencing null/undefined warnings with the exclamation point
 
 Other:
    - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`

--- a/src/managers/PermissionManager.ts
+++ b/src/managers/PermissionManager.ts
@@ -1,7 +1,6 @@
 import OneSignalUtils from '../utils/OneSignalUtils';
 import bowser from 'bowser';
 import { InvalidArgumentError, InvalidArgumentReason } from '../errors/InvalidArgumentError';
-import Database from '../services/Database';
 import { NotificationPermission } from '../models/NotificationPermission';
 import SdkEnvironment from '../managers/SdkEnvironment';
 import LocalStorage from '../utils/LocalStorage';

--- a/src/managers/sessionManager/page/SessionManager.ts
+++ b/src/managers/sessionManager/page/SessionManager.ts
@@ -117,7 +117,7 @@ export class SessionManager implements ISessionManager {
         MainHelper.getDeviceId(),
         MainHelper.createDeviceRecord(this.context.appConfig.appId)
       ]);
-  
+
       await this.notifySWToDeactivateSession(deviceId, deviceRecord, SessionOrigin.VisibilityHidden);
       return;
     }

--- a/src/stylesheets/slidedown.scss
+++ b/src/stylesheets/slidedown.scss
@@ -145,7 +145,7 @@ $border-radius: 0.5em;
       /* When the checkbox is checked, add a blue background */
       &:checked ~ .onesignal-checkmark {
         transition: ease 75ms;
-        background-color: #4285f4;
+        background-color: #0078D1;
       }
 
       &:checked ~ .onesignal-checkmark:after {
@@ -296,16 +296,16 @@ $border-radius: 0.5em;
       display: flex;
 
       &.primary {
-        background: #4285f4;
+        background: #0078D1;
         color: white !important;
         transition: linear 75ms;
 
         &:hover {
-          background: darken(#4285f4, 7.5%);
+          background: darken(#0078D1, 7.5%);
         }
 
         &:active {
-          background: darken(#4285f4, 15%);
+          background: darken(#0078D1, 15%);
         }
 
         &.disabled {
@@ -344,14 +344,14 @@ $border-radius: 0.5em;
           We sparingly use an !important tag here because it's important for the user to be able to click "No Thanks".
           Some sites set their own !important tag for text and we don't want that to be able to override ours.
          */
-        color: #4285f4 !important;
+        color: #0078D1 !important;
 
         &:hover {
-          color: darken(#4285f4, 12.5%);
+          color: darken(#0078D1, 12.5%);
         }
 
         &:active {
-          color: darken(#4285f4, 30.5%);
+          color: darken(#0078D1, 30.5%);
         }
       }
     }


### PR DESCRIPTION
# Description
## 1 Line Summary
Change OneSignal blue on slide prompt to a darker alternative for accessibility purposes.

## Details
Users have pointed out that the current blue hex value does not pass AA accessibility tests with white text. We should update the color to fix this for all our users.

Note: Users can control this with CSS but we should provide a default that passes.

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
   - [x] Update the primary button background to #0078D1
   - [x] Update the secondary button text color to #0078D1
   - [x] Hover colors are dark variations of these above colors in CSS so they should fix themselves
   - [ ] Fix this in both the slide prompt AND Shopify slide prompt
      - Needs to be fixed in Shopify

## Tests
### Info
Test not really necessary for this type of change that is purely visual.

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings by with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info
Normal:
<img width="569" alt="Screen Shot 2020-09-02 at 1 30 43 PM" src="https://user-images.githubusercontent.com/11739227/92022189-84256100-ed20-11ea-9071-f77d311b29dc.png">

With hover:
<img width="544" alt="Screen Shot 2020-09-02 at 1 31 26 PM" src="https://user-images.githubusercontent.com/11739227/92022262-9c957b80-ed20-11ea-88f9-3e47269bddf1.png">

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/694)
<!-- Reviewable:end -->
