### PR TITLE
fix broken icon in bell

### DIFF
--- a/src/bell/Dialog.ts
+++ b/src/bell/Dialog.ts
@@ -61,7 +61,7 @@ export default class Dialog extends AnimatedElement {
 
         let notificationIconHtml = '';
         let imageUrl = getPlatformNotificationIcon(this.notificationIcons);
-        if (imageUrl) {
+        if (imageUrl != 'default-icon') {
           notificationIconHtml = `<div class="push-notification-icon"><img src="${imageUrl}"></div>`
         } else {
           notificationIconHtml = `<div class="push-notification-icon push-notification-icon-default"></div>`


### PR DESCRIPTION
# Description
## 1 Line Summary
Fixes a broken icon in the bell when no custom icon is used.

## Details
The `getPlatformNotificationIcon` will always return an icon path or otherwise will return 'default-icon'. This change fixes a bug where we were incorrectly trying to render the URL "/default-icon" when no icon was specified.

# Systems Affected
* [x] WebSDK

# Validation
Requires validation.

## Tests
### Info
### Checklist
* [ ] All the automated tests pass or I explained why that is not possible
* [ ] I have personally tested this on my machine or explained why that is not possible
* [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:


* [ ] Don't use default export
* [ ] New interfaces are in model files

Functions:


* [ ] Don't use default export
* [ ] All function signatures have return types
* [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:


* [ ] No Typescript warnings
* [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:


* [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
* [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
![](https://user-images.githubusercontent.com/4891/92643947-6fece100-f297-11ea-8f19-de5e1007cd56.png)

### Info
### Checklist
* [x] I have included screenshots/recordings of the intended results or explained why they are not needed

- - -
## Related Tickets
- - -
## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/697)
<!-- Reviewable:end -->

