### PR TITLE
Build and publish Staging- files to S3 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
 script:
   - yarn test:noWatch
   - yarn build:prod
+  - yarn build:staging
   # thanks to https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
   - BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - if [ "$BRANCH" = "master" ]; then ./.travis/s3-simple-upload-all.sh build/releases s3://onesignal-build/websdk/$TRAVIS_COMMIT && ./.travis/s3-simple-upload-all.sh build/amp s3://onesignal-build/websdk/$TRAVIS_COMMIT && echo Successfully uploaded Web SDK artifacts for version $TRAVIS_COMMIT; else echo Not uploading artifacts for this build; fi

--- a/build/scripts/publish.sh
+++ b/build/scripts/publish.sh
@@ -26,3 +26,8 @@ cp build/bundles/OneSignalSDKWorker.js.map build/releases/$PREFIX"OneSignalSDKWo
 
 cp build/bundles/OneSignalSDKStyles.css build/releases/$PREFIX"OneSignalSDKStyles.css"
 cp build/bundles/OneSignalSDKStyles.css.map build/releases/$PREFIX"OneSignalSDKStyles.css.map"
+
+if [ "$ENV" = "staging" ]; then
+  sed -i 's/sourceMappingURL=OneSignal/sourceMappingURL=Staging-OneSignal/' build/releases/Staging-*.js
+  sed -i 's/sourceMappingURL=OneSignal/sourceMappingURL=Staging-OneSignal/' build/releases/Staging-*.css
+fi


### PR DESCRIPTION
Staging- files are currently served from rails on staging-01, but we'd
like them to be served by turbine instead, as in prod, and to simplify
URL routing. This change pushes Staging- files to S3, so turbine can
download and serve them.

# Systems Affected
* [x] WebSDK
* [ ] Backend
* [ ] Dashboard

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/706)
<!-- Reviewable:end -->
