### PR TITLE
On staging builds, set Travis env vars that used to be passed manually

### DIFF
--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -44,6 +44,12 @@ ENV=${ENV:-"development"}
 API=${API:-"production"}
 HTTPS=${HTTPS:-true}
 
+if [ "$ENV" = "staging" ]; then
+    API="staging"
+    API_ORIGIN=$STAGING_DOMAIN
+    BUILD_ORIGIN=$STAGING_DOMAIN
+fi
+
 echo "BUILD_ORIGIN = ${BUILD_ORIGIN}"
 echo "API_ORIGIN = ${API_ORIGIN}"
 echo "HTTPS = ${HTTPS}"


### PR DESCRIPTION
# Description
On staging builds, set Travis env vars that used to be passed manually

## Details
These environment variables used to be defined in the manual build step
for staging files. Now we use `$ENV=staging` to set `API_ORIGIN` and

`BUILD_ORIGIN` to $STAGING_DOMAIN, which is defined in Travis.

# Systems Affected
* [x] WebSDK
* [ ] Backend
* [ ] Dashboard

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/708)
<!-- Reviewable:end -->

