### PR TITLE
Explicitly set BUILD_ORIGIN and API_ORIGIN env in staging build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 script:
   - yarn test:noWatch
   - yarn build:prod
-  - yarn build:staging
+  - BUILD_ORIGIN=${STAGING_DOMAIN} API=staging API_ORIGIN=${STAGING_DOMAIN} yarn build:staging
   # thanks to https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
   - BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - if [ "$BRANCH" = "master" ]; then ./.travis/s3-simple-upload-all.sh build/releases s3://onesignal-build/websdk/$TRAVIS_COMMIT && ./.travis/s3-simple-upload-all.sh build/amp s3://onesignal-build/websdk/$TRAVIS_COMMIT && echo Successfully uploaded Web SDK artifacts for version $TRAVIS_COMMIT; else echo Not uploading artifacts for this build; fi


### PR DESCRIPTION
## Details
Since https://github.com/OneSignal/OneSignal-Website-SDK/pull/708 didn't seem to populate these correctly in the build.

# Systems Affected
* [x] WebSDK
* [ ] Backend
* [ ] Dashboard

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/709)
<!-- Reviewable:end -->

