### PR TITLE
Updated setEmail() and setExternalUserId() call to include external_user_id

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -105,6 +105,7 @@ export default class OneSignal {
 
     const appConfig = await Database.getAppConfig();
     const { deviceId } = await Database.getSubscription();
+    const externalUserId = await Database.getExternalUserId();
     const existingEmailProfile = await Database.getEmailProfile();
 
     if (appConfig.emailAuthRequired && !(options && options.emailAuthHash)) {
@@ -117,19 +118,26 @@ export default class OneSignal {
     }
 
     const isExistingEmailSaved = !!existingEmailProfile.emailId;
+    var sanitizedExternalUserId: string | undefined;
+    if(externalUserId == null){
+      sanitizedExternalUserId = undefined
+    }
+
     if (isExistingEmailSaved && appConfig.emailAuthRequired) {
       // If we already have a saved email player ID, make a PUT call to update the existing email record
       newEmailProfile.emailId = await OneSignalApi.updateEmailRecord(
         appConfig,
         newEmailProfile,
-        deviceId
+        deviceId,
+        sanitizedExternalUserId
       );
     } else {
       // Otherwise, make a POST call to create a new email record
       newEmailProfile.emailId = await OneSignalApi.createEmailRecord(
         appConfig,
         newEmailProfile,
-        deviceId
+        deviceId,
+        sanitizedExternalUserId
       );
     }
 

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -118,7 +118,7 @@ export default class OneSignal {
     }
 
     const isExistingEmailSaved = !!existingEmailProfile.emailId;
-    var sanitizedExternalUserId: string | undefined;
+    let sanitizedExternalUserId: string | undefined;
     if(externalUserId == null){
       sanitizedExternalUserId = undefined
     }

--- a/src/OneSignalApi.ts
+++ b/src/OneSignalApi.ts
@@ -51,17 +51,19 @@ export default class OneSignalApi {
   static async createEmailRecord(
     appConfig: AppConfig,
     emailProfile: EmailProfile,
-    pushDeviceRecordId?: string
+    pushDeviceRecordId?: string,
+    externalUserId?: string,
   ): Promise<string | null> {
-    return await OneSignalApiShared.createEmailRecord(appConfig, emailProfile, pushDeviceRecordId);
+    return await OneSignalApiShared.createEmailRecord(appConfig, emailProfile, pushDeviceRecordId, externalUserId);
   }
 
   static async updateEmailRecord(
     appConfig: AppConfig,
     emailProfile: EmailProfile,
-    pushDeviceRecordId?: string
+    pushDeviceRecordId?: string,
+    externalUserId?: string,
   ): Promise<string | null> {
-    return await OneSignalApiShared.updateEmailRecord(appConfig, emailProfile, pushDeviceRecordId);
+    return await OneSignalApiShared.updateEmailRecord(appConfig, emailProfile, pushDeviceRecordId, externalUserId);
   }
 
   static async logoutEmail(appConfig: AppConfig, emailProfile: EmailProfile, deviceId: string): Promise<boolean> {

--- a/src/OneSignalApiShared.ts
+++ b/src/OneSignalApiShared.ts
@@ -56,11 +56,12 @@ export default class OneSignalApiShared {
   static async createEmailRecord(
     appConfig: AppConfig,
     emailProfile: EmailProfile,
-    pushDeviceRecordId?: string
+    pushDeviceRecordId?: string,
+    externalUserId?: string
   ): Promise<string | null> {
     Utils.enforceAppId(appConfig.appId);
     const emailRecord = new EmailDeviceRecord(emailProfile.emailAddress, emailProfile.emailAuthHash,
-      pushDeviceRecordId);
+      pushDeviceRecordId, externalUserId);
     emailRecord.appId = appConfig.appId;
     const response = await OneSignalApiBase.post(`players`, emailRecord.serialize());
     if (response && response.success) {
@@ -73,12 +74,13 @@ export default class OneSignalApiShared {
   static async updateEmailRecord(
     appConfig: AppConfig,
     emailProfile: EmailProfile,
-    pushDeviceRecordId?: string
+    pushDeviceRecordId?: string,
+    externalUserId?: string
   ): Promise<string | null> {
     Utils.enforceAppId(appConfig.appId);
     Utils.enforcePlayerId(emailProfile.emailId);
     const emailRecord = new EmailDeviceRecord(emailProfile.emailAddress, emailProfile.emailAuthHash,
-      pushDeviceRecordId);
+      pushDeviceRecordId, externalUserId);
     emailRecord.appId = appConfig.appId;
     const response = await OneSignalApiBase.put(`players/${emailProfile.emailId}`, emailRecord.serialize());
     if (response && response.success) {

--- a/src/models/DeviceRecord.ts
+++ b/src/models/DeviceRecord.ts
@@ -24,7 +24,6 @@ export interface FlattenedDeviceRecord {
  *
  * This is used when creating or modifying push and email records.
  */
- */
 export abstract class DeviceRecord implements Serializable {
   public deliveryPlatform: DeliveryPlatformKind;
   public language: string;

--- a/src/models/DeviceRecord.ts
+++ b/src/models/DeviceRecord.ts
@@ -24,6 +24,7 @@ export interface FlattenedDeviceRecord {
  *
  * This is used when creating or modifying push and email records.
  */
+ */
 export abstract class DeviceRecord implements Serializable {
   public deliveryPlatform: DeliveryPlatformKind;
   public language: string;

--- a/src/models/EmailDeviceRecord.ts
+++ b/src/models/EmailDeviceRecord.ts
@@ -13,6 +13,7 @@ export class EmailDeviceRecord extends DeviceRecord {
     public email?: string,
     public emailAuthHash?: string,
     public pushDeviceRecordId?: string,
+    public externalUserId ?: string
   ) {
     super();
     this.deliveryPlatform = DeliveryPlatformKind.Email;
@@ -29,6 +30,9 @@ export class EmailDeviceRecord extends DeviceRecord {
     }
     if (this.pushDeviceRecordId) {
       serializedBundle.device_player_id = this.pushDeviceRecordId;
+    }
+    if (this.externalUserId) {
+      serializedBundle.external_user_id = this.externalUserId;
     }
 
     return serializedBundle;


### PR DESCRIPTION
…e checking for external user id

# Description
## Updated setEmail() and setExternalUserId() calls to make sure that they are updating the external_user_id in the email record.
## Details
# Systems Affected
* [x] WebSDK
* [ ] Backend
* [ ] Dashboard

# Validation
## Tests
### Info
### Checklist
* [x] All the automated tests pass or I explained why that is not possible
* [x] I have personally tested this on my machine or explained why that is not possible
* [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:


* [x] Don't use default export
* [x] New interfaces are in model files

Functions:


* [x] Don't use default export
* [x] All function signatures have return types
* [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:


* [x] No Typescript warnings
* [x] Avoid silencing null/undefined warnings with the exclamation point

Other:


* [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
* [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info
### Checklist
* [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

- - -
## Related Tickets
- - -
## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/713)
<!-- Reviewable:end -->

