### PR TITLE
Upgrade Typescript to 3.9.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "svgo": "^0.7.2",
     "text-encoding": "^0.6.4",
     "timemachine": "^0.3.0",
-    "typescript": "^2.7.1",
+    "typescript": "^3.9.7",
     "tslint": "^5.10.0",
     "tslint-eslint-rules": "^5.2.0",
     "uglifyjs-webpack-plugin": "^1.2.4",

--- a/src/managers/PermissionManager.ts
+++ b/src/managers/PermissionManager.ts
@@ -103,7 +103,7 @@ export default class PermissionManager {
    * standard.
    */
   private getW3cNotificationPermission(): NotificationPermission {
-    return window.Notification.permission as NotificationPermission;
+    return Notification.permission as NotificationPermission;
   }
 
   /**

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -333,7 +333,7 @@ export class SubscriptionManager {
     */
     if (
       SdkEnvironment.getWindowEnv() !== WindowEnvironmentKind.ServiceWorker &&
-      window.Notification.permission === NotificationPermission.Default
+      Notification.permission === NotificationPermission.Default
     ) {
       await Event.trigger(OneSignal.EVENTS.PERMISSION_PROMPT_DISPLAYED);
       const permission = await SubscriptionManager.requestPresubscribeNotificationPermission();

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -432,7 +432,7 @@ export class ServiceWorker {
      * if https -> getActiveClients -> check for the first focused
      * unfortunately, not enough for safari, it always returns false for focused state of a client
      * have to workaround it with messaging to the client.
-     * 
+     *
      * if http, also have to workaround with messaging:
      *   SW to iframe -> iframe to page -> page to iframe -> iframe to SW
      */

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -381,7 +381,10 @@ export class ServiceWorker {
    * @returns {Promise}
    */
   static async getActiveClients(): Promise<Array<OSWindowClient>> {
-    const windowClients: Client[] = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+    const windowClients: ReadonlyArray<Client> = await self.clients.matchAll({
+      type: 'window',
+      includeUncontrolled: true
+    });
     const activeClients: Array<OSWindowClient> = [];
 
     for (const client of windowClients) {
@@ -437,7 +440,7 @@ export class ServiceWorker {
      *   SW to iframe -> iframe to page -> page to iframe -> iframe to SW
      */
     if (options.isHttps) {
-      const windowClients: Client[] = await self.clients.matchAll(
+      const windowClients: ReadonlyArray<Client> = await self.clients.matchAll(
         { type: "window", includeUncontrolled: false }
       );
 
@@ -457,7 +460,7 @@ export class ServiceWorker {
 
   static async checkIfAnyClientsFocusedAndUpdateSession(
     event: ExtendableMessageEvent,
-    windowClients: Client[],
+    windowClients: ReadonlyArray<Client>,
     sessionInfo: DeactivateSessionPayload
   ): Promise<void> {
     const timestamp = new Date().getTime();

--- a/src/services/DynamicResourceLoader.ts
+++ b/src/services/DynamicResourceLoader.ts
@@ -31,7 +31,7 @@ export class DynamicResourceLoader {
 
   getCache(): DynamicResourceLoaderCache {
     // Cache is private; return a cloned copy just for testing
-    return {...this.cache};
+    return { ...this.cache };
   }
 
   async loadSdkStylesheet(): Promise<ResourceLoadState> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -376,14 +376,10 @@ export function getSdkLoadCount() {
   return (<any>window).__oneSignalSdkLoadCount || 0;
 }
 
-export async function awaitSdkEvent(eventName: string, predicate?: Action<any>) {
+export async function awaitSdkEvent(eventName: string) {
   return await new Promise(resolve => {
     OneSignal.emitter.once(eventName, (event: Event) => {
-      if (predicate) {
-        const predicateResult = predicate(event);
-        if (predicateResult)
-          resolve(event);
-      } else resolve(event);
+      resolve(event);
     });
   });
 }

--- a/test/support/mocks/MockEvent.ts
+++ b/test/support/mocks/MockEvent.ts
@@ -6,6 +6,7 @@ export class MockEvent implements Event {
   readonly bubbles: boolean = true;
   cancelBubble: boolean = false;
   readonly cancelable: boolean = true;
+  readonly composed: boolean = false;
   readonly currentTarget: EventTarget | null = null;
   readonly defaultPrevented: boolean = false;
   readonly eventPhase: number = 0;
@@ -19,6 +20,10 @@ export class MockEvent implements Event {
 
   constructor(typeArg: string, _eventInitDict?: EventInit) {
     this.type = typeArg;
+  }
+
+  composedPath(): EventTarget[] {
+    return [];
   }
 
   deepPath(): EventTarget[] {

--- a/test/support/mocks/MockNotification.ts
+++ b/test/support/mocks/MockNotification.ts
@@ -13,6 +13,7 @@ export default class MockNotification implements Notification {
   readonly silent: boolean;
   readonly timestamp: number;
   readonly lang: string;
+  readonly actions: NotificationAction[];
   readonly badge: string;
   onclick: ((this: Notification, ev: Event) => any) | null;
   onclose: ((this: Notification, ev: Event) => any) | null;
@@ -25,7 +26,7 @@ export default class MockNotification implements Notification {
   constructor(title: string, options?: NotificationOptions) {
     this.title = title;
     this.data = options && options.data;
-
+    this.actions = [];
     this.body = "";
     this.dir = "auto";
     this.icon = "";

--- a/test/support/mocks/MockNotification.ts
+++ b/test/support/mocks/MockNotification.ts
@@ -2,32 +2,46 @@
 // NOTE: permission & requestPermission should be static however this was defined wrong in TS 2.x
 //       This ws later fixed in newer TypeScript versions
 export default class MockNotification implements Notification {
-  readonly body: string | null;
+  readonly body: string;
   readonly data: any;
   readonly dir: NotificationDirection;
-  readonly icon: string | null;
-  readonly lang: string | null;
+  readonly icon: string;
+  readonly image: string;
+  readonly renotify: boolean;
+  readonly requireInteraction: boolean;
+  readonly vibrate: number[];
+  readonly silent: boolean;
+  readonly timestamp: number;
+  readonly lang: string;
+  readonly badge: string;
   onclick: ((this: Notification, ev: Event) => any) | null;
   onclose: ((this: Notification, ev: Event) => any) | null;
   onerror: ((this: Notification, ev: Event) => any) | null;
   onshow: ((this: Notification, ev: Event) => any) | null;
   readonly permission: NotificationPermission;
-  readonly tag: string | null;
+  readonly tag: string;
   readonly title: string;
 
   constructor(title: string, options?: NotificationOptions) {
     this.title = title;
     this.data = options && options.data;
 
-    this.body = null;
+    this.body = "";
     this.dir = "auto";
-    this.icon = null;
-    this.lang = null;
+    this.icon = "";
+    this.image = "";
+    this.badge = "";
+    this.lang = "";
+    this.renotify = false;
+    this.requireInteraction = false;
+    this.silent = false;
+    this.timestamp = 0;
+    this.vibrate = [];
     this.onclick = null;
     this.onclose = null;
     this.onerror = null;
     this.onshow = null;
-    this.tag = null;
+    this.tag = "";
     this.permission = "granted";
   }
 

--- a/test/support/mocks/service-workers/models/MockServiceWorker.ts
+++ b/test/support/mocks/service-workers/models/MockServiceWorker.ts
@@ -22,7 +22,7 @@ export class MockServiceWorker implements ServiceWorker {
     throw new NotImplementedError();
   }
 
-  postMessage(_message: any, _transfer?: any[]): void {
+  postMessage(message: any, transfer: Array<Transferable> | PostMessageOptions): void {
     throw new NotImplementedError();
   }
 

--- a/test/support/mocks/service-workers/models/MockServiceWorkerContainer.ts
+++ b/test/support/mocks/service-workers/models/MockServiceWorkerContainer.ts
@@ -5,7 +5,7 @@ import { MockServiceWorkerRegistration } from "./MockServiceWorkerRegistration";
 export class MockServiceWorkerContainer implements ServiceWorkerContainer {
   controller: ServiceWorker | null;
   oncontrollerchange: ((this: ServiceWorkerContainer, ev: Event) => any) | null;
-  onmessage: ((this: ServiceWorkerContainer, ev: ServiceWorkerMessageEvent) => any) | null;
+  onmessage: ((this: ServiceWorkerContainer, ev: MessageEvent) => any) | null;
   onmessageerror: ((this: ServiceWorkerContainer, ev: MessageEvent) => any) | null;
   readonly ready: Promise<ServiceWorkerRegistration>;
 

--- a/test/support/mocks/service-workers/models/MockServiceWorkerGlobalScope.ts
+++ b/test/support/mocks/service-workers/models/MockServiceWorkerGlobalScope.ts
@@ -56,7 +56,7 @@ export class MockServiceWorkerGlobalScope implements ServiceWorkerGlobalScope {
   queueMicrotask(callback: VoidFunction): void {}
 
   readonly performance: Performance;
-  readonly self: WorkerGlobalScope;
+  readonly self: WorkerGlobalScope & typeof globalThis;
 
   addEventListener<K extends keyof ServiceWorkerGlobalScopeEventMap>(type: K, listener: (this: ServiceWorkerGlobalScope, ev: ServiceWorkerGlobalScopeEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
   addEventListener(type: string, listener: EventListener | EventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/test/support/mocks/service-workers/models/MockServiceWorkerGlobalScope.ts
+++ b/test/support/mocks/service-workers/models/MockServiceWorkerGlobalScope.ts
@@ -23,6 +23,7 @@ export class MockServiceWorkerGlobalScope implements ServiceWorkerGlobalScope {
   readonly console: Console;
   readonly indexedDB: IDBFactory;
   readonly isSecureContext: boolean;
+  readonly origin: string;
   readonly location: WorkerLocation;
   readonly msIndexedDB: IDBFactory;
   readonly navigator: WorkerNavigator = new MockWorkerNavigator(
@@ -33,19 +34,26 @@ export class MockServiceWorkerGlobalScope implements ServiceWorkerGlobalScope {
       "Gecko",
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.167 Safari/537.36"
     );
+  readonly serviceWorker: ServiceWorker;
+  readonly crypto: Crypto;
 
-
+  onlanguagechange: ((this: WorkerGlobalScope, ev: Event) => any) | null = null;
+  onoffline: ((this: WorkerGlobalScope, ev: Event) => any) | null = null;
   onactivate: ((this: ServiceWorkerGlobalScope, ev: ExtendableEvent) => any) | null = null;
   onerror: ((this: WorkerGlobalScope, ev: ErrorEvent) => any) | null = null;
   onfetch: ((this: ServiceWorkerGlobalScope, ev: FetchEvent) => any) | null = null;
   oninstall: ((this: ServiceWorkerGlobalScope, ev: ExtendableEvent) => any) | null = null;
   onmessage: ((this: ServiceWorkerGlobalScope, ev: ExtendableMessageEvent) => any) | null = null;
+  ononline: ((this: WorkerGlobalScope, ev: Event) => any) | null = null;
   onmessageerror: ((this: ServiceWorkerGlobalScope, ev: MessageEvent) => any) | null = null;
   onnotificationclick: ((this: ServiceWorkerGlobalScope, ev: NotificationEvent) => any) | null = null;
   onnotificationclose: ((this: ServiceWorkerGlobalScope, ev: NotificationEvent) => any) | null = null;
+  onrejectionhandled: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null = null;
   onpush: ((this: ServiceWorkerGlobalScope, ev: PushEvent) => any) | null = null;
   onpushsubscriptionchange: ((this: ServiceWorkerGlobalScope, ev: PushSubscriptionChangeEvent) => any) | null = null;
   onsync: ((this: ServiceWorkerGlobalScope, ev: SyncEvent) => any) | null = null;
+  onunhandledrejection: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null = null;
+  queueMicrotask(callback: VoidFunction): void {}
 
   readonly performance: Performance;
   readonly self: WorkerGlobalScope;

--- a/test/support/mocks/service-workers/models/MockServiceWorkerRegistration.ts
+++ b/test/support/mocks/service-workers/models/MockServiceWorkerRegistration.ts
@@ -8,6 +8,8 @@ export class MockServiceWorkerRegistration implements ServiceWorkerRegistration 
   readonly pushManager: PushManager;
   readonly sync: SyncManager;
   readonly waiting: ServiceWorker | null;
+  navigationPreload: NavigationPreloadManager;
+  updateViaCache: ServiceWorkerUpdateViaCache;
 
   constructor() {
     this.active = null;

--- a/test/support/mocks/service-workers/models/MockWorkerNavigator.ts
+++ b/test/support/mocks/service-workers/models/MockWorkerNavigator.ts
@@ -18,6 +18,7 @@ export class MockWorkerNavigator implements WorkerNavigator {
   readonly serviceWorker: ServiceWorkerContainer;
   readonly language: string;
   readonly languages: string[];
+  readonly storage: StorageManager;
 
   sendBeacon(url: string, data?: Blob | Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer | FormData | string | null): boolean {
     return false;

--- a/test/support/mocks/service-workers/models/MockWorkerNavigator.ts
+++ b/test/support/mocks/service-workers/models/MockWorkerNavigator.ts
@@ -5,7 +5,7 @@ export class MockWorkerNavigator implements WorkerNavigator {
     public readonly appVersion: string,
     public readonly platform: string,
     public readonly product: string,
-    public readonly userAgent: string,
+    public readonly userAgent: string
   ) {
   }
 

--- a/test/support/mocks/service-workers/models/MockWorkerNavigator.ts
+++ b/test/support/mocks/service-workers/models/MockWorkerNavigator.ts
@@ -14,6 +14,10 @@ export class MockWorkerNavigator implements WorkerNavigator {
   readonly productSub: string;
   readonly vendor: string;
   readonly vendorSub: string;
+  readonly permissions: Permissions;
+  readonly serviceWorker: ServiceWorkerContainer;
+  readonly language: string;
+  readonly languages: string[];
 
   sendBeacon(url: string, data?: Blob | Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer | FormData | string | null): boolean {
     return false;

--- a/test/support/tester/utils.ts
+++ b/test/support/tester/utils.ts
@@ -14,7 +14,11 @@ export function isNullOrUndefined<T>(value: T | null | undefined): boolean {
   return typeof value === 'undefined' || value === null;
 }
 
-export function stubMessageChannel(t: ExecutionContext) {
+interface StubMessageChannelContext {
+  originalMessageChannel?: MessageChannel;
+}
+
+export function stubMessageChannel(t: ExecutionContext<StubMessageChannelContext>) {
   // Stub MessageChannel
   const fakeClass = class Test { };
   t.context.originalMessageChannel = (global as any).MessageChannel;

--- a/test/unit/managers/AltOriginManager.ts
+++ b/test/unit/managers/AltOriginManager.ts
@@ -1,12 +1,25 @@
 import '../../support/polyfills/polyfills';
-import test from "ava";
+import test, { TestInterface } from "ava";
 import AltOriginManager from '../../../src/managers/AltOriginManager';
 import { EnvironmentKind } from '../../../src/models/EnvironmentKind';
 import sinon from 'sinon';
 import ProxyFrameHost from '../../../src/modules/frames/ProxyFrameHost';
 import { TestEnvironment } from '../../support/sdk/TestEnvironment';
+import { AppConfig } from '../../../src/models/AppConfig';
 
-test(`should get correct canonical subscription URL for development environment`, async t => {
+interface AltOriginContext {
+  appConfig?: AppConfig;
+  subdomainOneSignalHost?: string;
+  subdomainOsTcHost?: string;
+  stubIsSubscribedToOneSignalImpl: () => boolean;
+  stubIsSubscribedToOsTcImpl: () => boolean;
+  stubIsSubscribedToNoneImpl: () => boolean;
+  stubIsSubscribedToBothImpl: () => boolean;
+}
+
+const testWithAltOriginContext = test as TestInterface<AltOriginContext>;
+
+testWithAltOriginContext(`should get correct canonical subscription URL for development environment`, async t => {
   const config = TestEnvironment.getFakeAppConfig();
   config.subdomain = 'test';
   config.httpUseOneSignalCom = true;
@@ -22,7 +35,7 @@ test(`should get correct canonical subscription URL for development environment`
   t.is(devUrls[0].host, new URL('https://test.localhost:3001').host);
 });
 
-test(`should get correct canonical subscription URL for staging environment`, async t => {
+testWithAltOriginContext(`should get correct canonical subscription URL for staging environment`, async t => {
   const stagingDomain = "staging.onesignal.com";
   (<any>global).__API_ORIGIN__ = stagingDomain;
   const config = TestEnvironment.getFakeAppConfig();
@@ -44,7 +57,7 @@ test(`should get correct canonical subscription URL for staging environment`, as
 });
 
 
-test(`should get correct canonical subscription URL when api.staging.onesignal.com is used`, async t => {
+testWithAltOriginContext(`should get correct canonical subscription URL when api.staging.onesignal.com is used`, async t => {
   const stagingDomain = "staging.onesignal.com";
   (<any>global).__API_ORIGIN__ = `api.${stagingDomain}`; 
   const config = TestEnvironment.getFakeAppConfig();
@@ -59,7 +72,7 @@ test(`should get correct canonical subscription URL when api.staging.onesignal.c
   t.is(stagingUrlsOsTcDomain[0].host, new URL(`https://test.${stagingDomain}`).host);
 });
 
-test(`should get correct canonical subscription URL for production environment`, async t => {
+testWithAltOriginContext(`should get correct canonical subscription URL for production environment`, async t => {
   const config = TestEnvironment.getFakeAppConfig();
   config.subdomain = 'test';
   config.httpUseOneSignalCom = true;
@@ -76,8 +89,8 @@ test(`should get correct canonical subscription URL for production environment`,
   t.is(prodUrls[0].host, new URL('https://test.os.tc').host);
 });
 
-test(`should get correct canonical subscription URL for production environment with api. prefix`, async t => {
-  (<any>global).__API_ORIGIN__ = `api.onesignal.com`; 
+testWithAltOriginContext(`should get correct canonical subscription URL for production environment with api. prefix`, async t => {
+  (<any>global).__API_ORIGIN__ = `api.onesignal.com`;
   const config = TestEnvironment.getFakeAppConfig();
   config.subdomain = 'test';
   config.httpUseOneSignalCom = true;
@@ -127,9 +140,11 @@ function setupDiscoverAltOriginTest(t: any) {
   };
 }
 
-test(`should discover alt origin to be subdomain.onesignal.com if user is already subscribed there`, async t => {
+testWithAltOriginContext(`should discover alt origin to be subdomain.onesignal.com if user is already subscribed there`, async t => {
   setupDiscoverAltOriginTest(t);
   const { appConfig } = t.context;
+  if (!appConfig) { return; }
+
   const stubLoad = sinon.stub(ProxyFrameHost.prototype, 'load').resolves(undefined);
   const stubIsSubscribed = sinon.stub(ProxyFrameHost.prototype, 'isSubscribed').callsFake(t.context.stubIsSubscribedToOneSignalImpl);
   const stubRemoveDuplicatedAltOriginSubscription = sinon.stub(AltOriginManager, 'removeDuplicatedAltOriginSubscription').resolves(undefined);
@@ -142,9 +157,11 @@ test(`should discover alt origin to be subdomain.onesignal.com if user is alread
   stubLoad.restore();
 });
 
-test(`should discover alt origin to be subdomain.os.tc if user is not subscribed to onesignal.com but is subscribed to os.tc`, async t => {
+testWithAltOriginContext(`should discover alt origin to be subdomain.os.tc if user is not subscribed to onesignal.com but is subscribed to os.tc`, async t => {
   setupDiscoverAltOriginTest(t);
   const { appConfig } = t.context;
+  if (!appConfig) { return; }
+
   const stubLoad = sinon.stub(ProxyFrameHost.prototype, 'load').resolves(undefined);
   const stubIsSubscribed = sinon.stub(ProxyFrameHost.prototype, 'isSubscribed').callsFake(t.context.stubIsSubscribedToOsTcImpl);
   const stubRemoveDuplicatedAltOriginSubscription = sinon.stub(AltOriginManager, 'removeDuplicatedAltOriginSubscription').resolves(undefined);
@@ -157,9 +174,11 @@ test(`should discover alt origin to be subdomain.os.tc if user is not subscribed
   stubLoad.restore();
 });
 
-test(`should discover alt origin to be subdomain.os.tc if user is not subscribed to either onesignal.com or os.tc`, async t => {
+testWithAltOriginContext(`should discover alt origin to be subdomain.os.tc if user is not subscribed to either onesignal.com or os.tc`, async t => {
   setupDiscoverAltOriginTest(t);
   const { appConfig } = t.context;
+  if (!appConfig) { return; }
+
   const stubLoad = sinon.stub(ProxyFrameHost.prototype, 'load').resolves(undefined);
   const stubIsSubscribed = sinon.stub(ProxyFrameHost.prototype, 'isSubscribed').callsFake(t.context.stubIsSubscribedToNoneImpl);
   const stubRemoveDuplicatedAltOriginSubscription = sinon.stub(AltOriginManager, 'removeDuplicatedAltOriginSubscription').resolves(undefined);
@@ -172,9 +191,11 @@ test(`should discover alt origin to be subdomain.os.tc if user is not subscribed
   stubLoad.restore();
 });
 
-test(`should discover alt origin to be subdomain.os.tc if user is subscribed to both onesignal.com and os.tc`, async t => {
+testWithAltOriginContext(`should discover alt origin to be subdomain.os.tc if user is subscribed to both onesignal.com and os.tc`, async t => {
   setupDiscoverAltOriginTest(t);
   const { appConfig } = t.context;
+  if (!appConfig) { return; }
+
   const stubLoad = sinon.stub(ProxyFrameHost.prototype, 'load').resolves(undefined);
   const stubIsSubscribed = sinon.stub(ProxyFrameHost.prototype, 'isSubscribed').callsFake(t.context.stubIsSubscribedToBothImpl);
   const stubUnsubscribeFromPush = sinon.stub(ProxyFrameHost.prototype, 'unsubscribeFromPush').resolves(undefined);

--- a/test/unit/managers/AltOriginManager.ts
+++ b/test/unit/managers/AltOriginManager.ts
@@ -1,7 +1,7 @@
 import '../../support/polyfills/polyfills';
 import test from "ava";
 import AltOriginManager from '../../../src/managers/AltOriginManager';
-import { EnvironmentKind } from '../../../src/models/EnvironmentKind'
+import { EnvironmentKind } from '../../../src/models/EnvironmentKind';
 import sinon from 'sinon';
 import ProxyFrameHost from '../../../src/modules/frames/ProxyFrameHost';
 import { TestEnvironment } from '../../support/sdk/TestEnvironment';
@@ -24,7 +24,7 @@ test(`should get correct canonical subscription URL for development environment`
 
 test(`should get correct canonical subscription URL for staging environment`, async t => {
   const stagingDomain = "staging.onesignal.com";
-  (<any>global).__API_ORIGIN__ = stagingDomain; 
+  (<any>global).__API_ORIGIN__ = stagingDomain;
   const config = TestEnvironment.getFakeAppConfig();
   config.subdomain = 'test';
   config.httpUseOneSignalCom = true;
@@ -70,7 +70,7 @@ test(`should get correct canonical subscription URL for production environment`,
   t.is(prodUrlsOsTcDomain[1].host, new URL('https://test.onesignal.com').host);
 
   config.httpUseOneSignalCom = false;
-  
+
   const prodUrls = AltOriginManager.getCanonicalSubscriptionUrls(config, EnvironmentKind.Production);
   t.is(prodUrls.length, 1);
   t.is(prodUrls[0].host, new URL('https://test.os.tc').host);
@@ -88,7 +88,7 @@ test(`should get correct canonical subscription URL for production environment w
   t.is(prodUrlsOsTcDomain[1].host, new URL('https://test.onesignal.com').host);
 
   config.httpUseOneSignalCom = false;
-  
+
   const prodUrls = AltOriginManager.getCanonicalSubscriptionUrls(config, EnvironmentKind.Production);
   t.is(prodUrls.length, 1);
   t.is(prodUrls[0].host, new URL('https://test.os.tc').host);
@@ -124,7 +124,7 @@ function setupDiscoverAltOriginTest(t: any) {
       this.url.host === t.context.subdomainOsTcHost) {
       return true;
     } else return false;
-  }
+  };
 }
 
 test(`should discover alt origin to be subdomain.onesignal.com if user is already subscribed there`, async t => {

--- a/test/unit/modules/loadSdkStyles.ts
+++ b/test/unit/modules/loadSdkStyles.ts
@@ -1,12 +1,21 @@
 import "../../support/polyfills/polyfills";
-import test from "ava";
+import anyTest, { TestInterface } from "ava";
 import { TestEnvironment, HttpHttpsEnvironment, TestEnvironmentConfig } from "../../support/sdk/TestEnvironment";
 import OneSignal from "../../../src/OneSignal";
-import sinon from 'sinon';
+import sinon, { SinonStub } from 'sinon';
 import Bell from "../../../src/bell/Bell";
 import { InvalidStateError, InvalidStateReason } from "../../../src/errors/InvalidStateError";
 import MockLauncher from "../../support/mocks/MockLauncher";
 import { DynamicResourceLoader, ResourceType, ResourceLoadState } from '../../../src/services/DynamicResourceLoader';
+import { AppConfig } from '../../../src/models/AppConfig';
+
+interface LoadSdkContext {
+  appConfig: AppConfig;
+  loadSdkStylesheet: SinonStub;
+  load: Function;
+}
+
+const test = anyTest as TestInterface<LoadSdkContext>;
 
 test.beforeEach(t => {
   const appConfig = TestEnvironment.getFakeAppConfig();

--- a/test/unit/modules/mergedLegacyConfig.ts
+++ b/test/unit/modules/mergedLegacyConfig.ts
@@ -1,10 +1,15 @@
 import '../../support/polyfills/polyfills';
-import test from 'ava';
-import InitHelper from '../../../src/helpers/InitHelper';
-import { AppConfig, ServerAppConfig, ConfigIntegrationKind } from '../../../src/models/AppConfig';
+import anyTest, { TestInterface } from 'ava';
+import { ConfigIntegrationKind, ServerAppConfig } from '../../../src/models/AppConfig';
 import { TestEnvironment, HttpHttpsEnvironment } from '../../support/sdk/TestEnvironment';
 import OneSignal from '../../../src/OneSignal';
 import ConfigManager from '../../../src/managers/ConfigManager';
+
+interface ConfigContext {
+  overrideServerConfig: ServerAppConfig;
+}
+
+const test = anyTest as TestInterface<ConfigContext>;
 
 test.beforeEach(t => {
   t.context.overrideServerConfig = TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom);

--- a/test/unit/modules/postmam.ts
+++ b/test/unit/modules/postmam.ts
@@ -1,17 +1,17 @@
 import '../../support/polyfills/polyfills';
-import test from 'ava';
+import anyTest, { TestInterface } from 'ava';
 import { TestEnvironment, HttpHttpsEnvironment } from '../../support/sdk/TestEnvironment';
-import OneSignal from '../../../src/OneSignal';
-import MainHelper from '../../../src/helpers/MainHelper';
-import sinon from 'sinon';
-import SubscriptionHelper from '../../../src/helpers/SubscriptionHelper';
-import { SubscriptionManager } from '../../../src/managers/SubscriptionManager';
-import { AppConfig } from '../../../src/models/AppConfig';
-
-import Context from '../../../src/models/Context';
-import { PageViewManager } from '../../../src/managers/PageViewManager';
 import Postmam from '../../../src/Postmam';
-import { contains } from '../../../src/utils';
+
+interface PostmamContext{
+  originalMessageChannel: MessageChannel;
+  expectedSafeHttpOrigins: string[];
+  expectedSafeHttpsOrigins: string[];
+  expectedSafeHttpOriginsForIrregularSubdomains: string[];
+  expectedSafeHttpOriginsForReallyIrregularSubdomains: string[];
+}
+
+const test = anyTest as TestInterface<PostmamContext>;
 
 test.beforeEach(async t => {
   await TestEnvironment.initialize({

--- a/test/unit/public-sdk-apis/sendTags.ts
+++ b/test/unit/public-sdk-apis/sendTags.ts
@@ -14,34 +14,34 @@ const DEVICE_ID = "55b9bc29-5f07-48b9-b85d-7e6efe2396fb";
 
 test.beforeEach(t => {
   t.context.simpleTags = {
-    'string': 'This is a string.',
-    'number': 123456789,
+    string: 'This is a string.',
+    number: 123456789,
   };
 
   t.context.sentTags = {
-    'null': null,
-    'undefined': undefined,
-    'true': true,
-    'false': false,
-    'string': 'This is a string.',
-    'number': 123456789,
-    'decimal': 123456789.987654321,
+    null: null,
+    undefined: undefined,
+    true: true,
+    false: false,
+    string: 'This is a string.',
+    number: 123456789,
+    decimal: 123456789.987654321,
     'array.empty': [],
     'array.one': [1],
     'array.multi': [1, 2, 3],
     'array.nested': [0, [1], [[2]]],
     'object.empty': {},
-    'object.one': JSON.stringify({key: 'value'}),
-    'object.multi': JSON.stringify({a: 1, b: 2, c: 3}),
-    'object.nested': JSON.stringify({a0: 1, b0: {a1: 1, b1: 1}, c0: {a1: 1, b1: {a2: 1, b2: {a3: 1}}}})
+    'object.one': JSON.stringify({ key: 'value' } ) ,
+    'object.multi': JSON.stringify({ a: 1, b: 2, c: 3 }),
+    'object.nested': JSON.stringify({ a0: 1, b0: { a1: 1, b1: 1 }, c0: { a1: 1, b1: { a2: 1, b2: { a3: 1 } } } })
   };
 
   t.context.expectedTags = {
-    "number": "123456789",
-    "true": "true",
-    "false": "false",
-    "string": "This is a string.",
-    "decimal": "123456789.98765433",
+    number: "123456789",
+    true: "true",
+    false: "false",
+    string: "This is a string.",
+    decimal: "123456789.98765433",
     "array.one": "[1]",
     "array.multi": "[1, 2, 3]",
     "array.nested": "[0, [1], [[2]]]",
@@ -52,7 +52,8 @@ test.beforeEach(t => {
 
   t.context.expectedTagsUnsent = ['null', 'undefined', 'array.empty', 'object.empty'];
 
-  t.context.tagsToCheckDeepEqual = Object.keys(t.context.sentTags).filter(x => t.context.expectedTagsUnsent.concat(['string', 'false']).indexOf(x) < 0);
+  t.context.tagsToCheckDeepEqual = Object.keys(t.context.sentTags)
+    .filter(x => t.context.expectedTagsUnsent.concat(['string', 'false']).indexOf(x) < 0);
 });
 
 async function expectPushRecordTagUpdateRequest(
@@ -71,7 +72,7 @@ async function expectPushRecordTagUpdateRequest(
           identifier_auth_hash: identifierAuthHash ? identifierAuthHash : undefined,
         })
       );
-      return { "success":true };
+      return { success : true };
     });
 }
 

--- a/test/unit/public-sdk-apis/sendTags.ts
+++ b/test/unit/public-sdk-apis/sendTags.ts
@@ -1,5 +1,5 @@
 import "../../support/polyfills/polyfills";
-import test, { ExecutionContext } from "ava";
+import anyTest, { ExecutionContext, TestInterface } from "ava";
 import { TestEnvironment } from '../../support/sdk/TestEnvironment';
 import OneSignal from '../../../src/OneSignal';
 import nock from 'nock';
@@ -11,6 +11,16 @@ const EMAIL_ID = "dafb31e3-19a5-473c-b319-62082bd696fb";
 const EMAIL = "test@example.com";
 const EMAIL_AUTH_HASH = "email-auth-hash";
 const DEVICE_ID = "55b9bc29-5f07-48b9-b85d-7e6efe2396fb";
+
+interface SendTagsContext {
+  simpleTags: Object;
+  sentTags  : Object;
+  expectedTags: Object;
+  expectedTagsUnsent: string[];
+  tagsToCheckDeepEqual: Object;
+}
+
+const test = anyTest as TestInterface<SendTagsContext>;
 
 test.beforeEach(t => {
   t.context.simpleTags = {
@@ -57,7 +67,7 @@ test.beforeEach(t => {
 });
 
 async function expectPushRecordTagUpdateRequest(
-  t: ExecutionContext,
+  t: ExecutionContext<SendTagsContext>,
   pushDevicePlayerId: string,
   identifierAuthHash: string | undefined,
 ) {

--- a/typings/globals/missing.d.ts
+++ b/typings/globals/missing.d.ts
@@ -46,6 +46,7 @@ interface Client {
 
 // Notification.requestPermission - Added in TypeScript 3.0.0
 interface Notification {
+  readonly permission: NotificationPermission;
   requestPermission(callback?: NotificationPermissionCallback): Promise<NotificationPermission>;
 }
 
@@ -69,7 +70,6 @@ interface SafariRemoteNotification {
 }
 
 interface Window {
-  // TODO: "Notification" should be used over "window.Notification". Do so when updating to TS 3
   Notification: Notification;
   safari: {
     pushNotification: SafariRemoteNotification

--- a/yarn.lock
+++ b/yarn.lock
@@ -8110,9 +8110,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.7.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.1.tgz#6160e4f8f195d5ba81d4876f9c0cc1fbc0820624"
+typescript@^3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 typeson-registry@^1.0.0-alpha.20:
   version "1.0.0-alpha.28"


### PR DESCRIPTION
# Description
## 1 Line Summary
Upgrades Typescript version to 3.9.7

# Systems Affected
* [x] WebSDK
* [ ] Backend
* [ ] Dashboard

# Validation
## Tests
All tests pass

### Info
Fixed Unit Tests that broke due to Typescript changes

### Checklist
* [x] All the automated tests pass or I explained why that is not possible
* [x] I have personally tested this on my machine or explained why that is not possible
* [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:

* [x] Don't use default export
* [x] New interfaces are in model files
  * New interfaces are unique to each individual testing file

Functions:

* [x] Don't use default export
* [x] All function signatures have return types
* [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:

* [x] No Typescript warnings
* [x] Avoid silencing null/undefined warnings with the exclamation point

Other:

* [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
* [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info
No relevant screenshots necessary

### Checklist
* [x] I have included screenshots/recordings of the intended results or explained why they are not needed
* 
* 
* 

## Related Tickets
- - -
## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/727)
<!-- Reviewable:end -->

