### PR TITLE
Sandbox env setup improvement for ssl cert

### DIFF
--- a/express_webpack/README.md
+++ b/express_webpack/README.md
@@ -11,9 +11,8 @@
 2. Follow the following instructions (also logged in console)
    - copy `dev-ssl.crt` from container to host with: 
       ```
-      docker cp <containerId>:sdk/express_webpack/certs/dev-ssl.crt .
+      docker cp "$(docker-compose ps -q onesignal-web-sdk-dev)":sdk/express_webpack/certs/dev-ssl.crt .
       ```
-      You can get the container id by running `docker ps`
    - If you're running the container in a VM, get the cert file onto the VM's host (e.g: use `scp`)
    - add cert to keychain (mac OSX): 
       ```


### PR DESCRIPTION
# Description
* Usage of `docker-compose ps -q onesignal-web-sdk-dev` saves a step when copying ssl cert used when setting up the dev sandbox env.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/743)
<!-- Reviewable:end -->

