### PR TITLE
Add awaitOneSignalInitAndSupported to Outcomes Functions

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -846,7 +846,8 @@ export default class OneSignal {
   }
 
   public static async sendOutcome(outcomeName: string, outcomeWeight?: number | undefined): Promise<void> {
-    const config = OneSignal.config!.userConfig.outcomes;
+    await awaitOneSignalInitAndSupported();
+    const config = OneSignal.config?.userConfig.outcomes;
     if (!config) {
       Log.error(`Could not send ${outcomeName}. No outcomes config found.`);
       return;
@@ -872,7 +873,8 @@ export default class OneSignal {
   }
 
   public static async sendUniqueOutcome(outcomeName: string): Promise<void> {
-    const config = OneSignal.config!.userConfig.outcomes;
+    await awaitOneSignalInitAndSupported();
+    const config = OneSignal.config?.userConfig.outcomes;
     if (!config) {
       Log.error(`Could not send ${outcomeName}. No outcomes config found.`);
       return;


### PR DESCRIPTION
# Description
## 1 Line Summary
Adding `awaitOneSignalInitAndSupported` to Outcomes Functions

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/746)
<!-- Reviewable:end -->

