### PR TITLE
Update ServiceWorker if its href or scope changes

### DIFF
--- a/src/helpers/ServiceWorkerHelper.ts
+++ b/src/helpers/ServiceWorkerHelper.ts
@@ -12,6 +12,7 @@ import { OutcomesConfig } from "../models/Outcomes";
 import OutcomesHelper from './shared/OutcomesHelper';
 import { cancelableTimeout, CancelableTimeoutPromise } from './sw/CancelableTimeout';
 import { OSServiceWorkerFields } from "../service-worker/types";
+import Utils from "../context/shared/utils/Utils";
 
 declare var self: ServiceWorkerGlobalScope & OSServiceWorkerFields;
 
@@ -34,6 +35,14 @@ export default class ServiceWorkerHelper {
       workerFullPath = config.workerAPath.getFullPath();
 
     return ServiceWorkerHelper.appendServiceWorkerParams(workerFullPath, appId);
+  }
+
+  public static getPossibleServiceWorkerHrefs(
+    config: ServiceWorkerManagerConfig,
+    appId: string
+    ): string[] {
+    const workerFullPaths = [config.workerAPath.getFullPath(), config.workerBPath.getFullPath()];
+    return workerFullPaths.map((href) => ServiceWorkerHelper.appendServiceWorkerParams(href, appId));
   }
 
   private static appendServiceWorkerParams(workerFullPath: string, appId: string): string {

--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -136,34 +136,38 @@ export class ServiceWorkerManager {
   }
 
   private async shouldInstallWorker(): Promise<boolean> {
+    // 1. Does the browser support ServiceWorkers?
     if (!Environment.supportsServiceWorkers())
       return false;
 
+    // 2. Is OneSignal initialized?
     if (!OneSignal.config)
       return false;
 
+    // 3. Will the service worker be installed on os.tc instead of the current domain?
     if (OneSignal.config.subdomain) {
       // No, if configured to use our subdomain (AKA HTTP setup) AND this is on their page (HTTP or HTTPS).
       // But since safari does not need subscription workaround, installing SW for session tracking.
       if (
-        OneSignal.environmentInfo.browserType !== "safari" && 
+        OneSignal.environmentInfo.browserType !== "safari" &&
           SdkEnvironment.getWindowEnv() === WindowEnvironmentKind.Host
       ) {
         return false;
       }
     }
 
+    // 4. Is a OneSignal ServiceWorker not installed now?, if not and
+    //   notification permissions are enabled we should install.
+    //   This prevents an unnecessary install which saves bandwidth
     const workerState = await this.getActiveState();
-    // If there isn't a SW or it isn't OneSignal's only install our SW if notification permissions are enabled
-    // This prevents an unnessary install which saves bandwidth
     if (workerState === ServiceWorkerActiveState.None || workerState === ServiceWorkerActiveState.ThirdParty) {
       const permission = await OneSignal.context.permissionManager.getNotificationPermission(
         OneSignal.config!.safariWebId
       );
-
       return permission === "granted";
     }
 
+    // 5. We have a OneSignal ServiceWorker installed, is there an update?
     return this.workerNeedsUpdate();
   }
 

--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -366,15 +366,16 @@ export class ServiceWorkerManager {
       Log.info(`[Service Worker Installation] 3rd party service worker detected.`);
     }
 
-    const workerFullPath = ServiceWorkerHelper.getServiceWorkerHref(workerState, this.config);
-    const installUrlQueryParams = Utils.encodeHashAsUriComponent({
-      appId: this.context.appConfig.appId
-    });
-    const fullWorkerPath = `${workerFullPath}?${installUrlQueryParams}`;
+    const workerHref = ServiceWorkerHelper.getAlternatingServiceWorkerHref(
+      workerState,
+      this.config,
+      this.context.appConfig.appId
+    );
+
     const scope = `${OneSignalUtils.getBaseUrl()}${this.config.registrationOptions.scope}`;
-    Log.info(`[Service Worker Installation] Installing service worker ${fullWorkerPath} ${scope}.`);
+    Log.info(`[Service Worker Installation] Installing service worker ${workerHref} ${scope}.`);
     try {
-      await navigator.serviceWorker.register(fullWorkerPath, { scope });
+      await navigator.serviceWorker.register(workerHref, { scope });
     } catch (error) {
       Log.error(`[Service Worker Installation] Installing service worker failed ${error}`);
       // Try accessing the service worker path directly to find out what the problem is and report it to OneSignal api.
@@ -385,7 +386,7 @@ export class ServiceWorkerManager {
       if (env === WindowEnvironmentKind.OneSignalSubscriptionPopup)
         throw error;
 
-      const response = await fetch(fullWorkerPath);
+      const response = await fetch(workerHref);
       if (response.status === 403 || response.status === 404)
         throw new ServiceWorkerRegistrationError(response.status, response.statusText);
 

--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -160,11 +160,16 @@ export class ServiceWorkerManager {
     // If not and notification permissions are enabled we should install.
     // This prevents an unnecessary install of the OneSignal worker which saves bandwidth
     const workerState = await this.getActiveState();
+    Log.debug("[shouldInstallWorker] workerState", workerState);
     if (workerState === ServiceWorkerActiveState.None || workerState === ServiceWorkerActiveState.ThirdParty) {
       const permission = await OneSignal.context.permissionManager.getNotificationPermission(
         OneSignal.config!.safariWebId
       );
-      return permission === "granted";
+      const notificationsEnabled = permission === "granted";
+      if (notificationsEnabled) {
+        Log.info("[shouldInstallWorker] Notification Permissions enabled, will install ServiceWorker");
+      }
+      return notificationsEnabled;
     }
 
     // 5. We have a OneSignal ServiceWorker installed, but did the path or scope of the ServiceWorker change?
@@ -304,6 +309,7 @@ export class ServiceWorkerManager {
   }
 
   public async establishServiceWorkerChannel() {
+    Log.debug('establishServiceWorkerChannel');
     const workerMessenger = this.context.workerMessenger;
     workerMessenger.off();
 

--- a/test/support/mocks/service-workers/models/MockServiceWorkerContainer.ts
+++ b/test/support/mocks/service-workers/models/MockServiceWorkerContainer.ts
@@ -22,10 +22,10 @@ export abstract class MockServiceWorkerContainer implements ServiceWorkerContain
   onmessageerror: ((this: ServiceWorkerContainer, ev: MessageEvent) => any) | null;
 
   private dispatchEventUtil: DispatchEventUtil = new DispatchEventUtil();
-  public serviceWorkerRegistration: ServiceWorkerRegistration | null;
+  private serviceWorkerRegistrations: Map<string, ServiceWorkerRegistration>;
 
   constructor() {
-    this.serviceWorkerRegistration = null;
+    this.serviceWorkerRegistrations = new Map();
     this._controller = null;
     this.onmessage = null;
     this.onmessageerror = null;
@@ -40,17 +40,15 @@ export abstract class MockServiceWorkerContainer implements ServiceWorkerContain
     return this.dispatchEventUtil.dispatchEvent(evt);
   }
 
-  async getRegistration(_clientURL?: string): Promise<ServiceWorkerRegistration | undefined> {
-    return this.serviceWorkerRegistration || undefined;
+  async getRegistration(clientURL?: string): Promise<ServiceWorkerRegistration | undefined> {
+    return this.serviceWorkerRegistrations.get(clientURL || "/");
   }
 
   async getRegistrations(): Promise<ServiceWorkerRegistration[]> {
-    if (this.serviceWorkerRegistration)
-      return [this.serviceWorkerRegistration];
-    return [];
+    return Array.from(this.serviceWorkerRegistrations.values());
   }
 
-  async register(scriptURL: string, _options?: RegistrationOptions): Promise<ServiceWorkerRegistration> {
+  async register(scriptURL: string, options?: RegistrationOptions): Promise<ServiceWorkerRegistration> {
     if (scriptURL.startsWith('/')) {
       const fakeScriptUrl = new URL(window.location.toString());
       scriptURL = fakeScriptUrl.origin + scriptURL;
@@ -59,14 +57,31 @@ export abstract class MockServiceWorkerContainer implements ServiceWorkerContain
     const mockSw = new MockServiceWorker();
     mockSw.scriptURL = scriptURL;
     mockSw.state = 'activated';
- 
+
     this._controller = mockSw;
 
     const swReg = new MockServiceWorkerRegistration();
     swReg.active = this._controller;
-    this.serviceWorkerRegistration = swReg;
 
-    return this.serviceWorkerRegistration;
+    const scope = MockServiceWorkerContainer.getScopeAsPathname(options);
+    this.serviceWorkerRegistrations.set(scope, swReg);
+
+    return swReg;
+  }
+
+  // RegistrationOptions.scope could be falsely or a string in a URL or pathname format.
+  // This will always give us a pathname, defaulting to "/" if falsely.
+  private static getScopeAsPathname(options?: RegistrationOptions): string {
+    if (!options?.scope) {
+      return "/";
+    }
+
+    try {
+      return new URL(options.scope).pathname;
+    } catch(_e) {
+      // Not a valid URL, assuming it's a path
+      return options.scope;
+    }
   }
 
   removeEventListener<K extends keyof ServiceWorkerContainerEventMap>(type: K, listener: (this: ServiceWorkerContainer, ev: ServiceWorkerContainerEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -77,6 +92,10 @@ export abstract class MockServiceWorkerContainer implements ServiceWorkerContain
   }
 
   startMessages(): void {
+  }
+
+  mockUnregister(scope: string) {
+    this.serviceWorkerRegistrations.delete(scope);
   }
 
 }

--- a/test/support/mocks/service-workers/models/MockServiceWorkerContainer.ts
+++ b/test/support/mocks/service-workers/models/MockServiceWorkerContainer.ts
@@ -41,7 +41,23 @@ export abstract class MockServiceWorkerContainer implements ServiceWorkerContain
   }
 
   async getRegistration(clientURL?: string): Promise<ServiceWorkerRegistration | undefined> {
-    return this.serviceWorkerRegistrations.get(clientURL || "/");
+    const scope = clientURL || "/";
+
+    // 1. If we find an exact path match
+    let registration = this.serviceWorkerRegistrations.get(scope);
+    if (registration) {
+      return registration;
+    }
+
+    // 2. Match any SW's that are at a higher scope than the one we are querying for as they are under it's control.
+    // WARNING: This mock implementation does not consider which one is correct if more than one applies the scope.
+    this.serviceWorkerRegistrations.forEach((value, key) => {
+      if (scope.startsWith(key)) {
+        registration = value;
+      }
+    });
+
+    return registration;
   }
 
   async getRegistrations(): Promise<ServiceWorkerRegistration[]> {

--- a/test/support/mocks/service-workers/models/MockServiceWorkerRegistration.ts
+++ b/test/support/mocks/service-workers/models/MockServiceWorkerRegistration.ts
@@ -48,7 +48,7 @@ export class MockServiceWorkerRegistration implements ServiceWorkerRegistration 
 
   async unregister(): Promise<boolean> {
     const container = navigator.serviceWorker as MockServiceWorkerContainer;
-    container.serviceWorkerRegistration = null;
+    container.mockUnregister(new URL(this.scope).pathname);
     this.active = null;
     return true;
   }

--- a/test/unit/meta/mockServiceWorker.ts
+++ b/test/unit/meta/mockServiceWorker.ts
@@ -48,12 +48,20 @@ test('mock service worker registration should return the registered worker', asy
   t.deepEqual(registrations, [registration]);
 });
 
+test('mock service worker getRegistrations should return multiple registered workers', async t => {
+  const expectedRegistrations = [] as ServiceWorkerRegistration[];
+  expectedRegistrations.push(await navigator.serviceWorker.register('/workerA.js', { scope: '/' }));
+  expectedRegistrations.push(await navigator.serviceWorker.register('/workerB.js', { scope: '/mypath/' }));
+
+  const registrations = await navigator.serviceWorker.getRegistrations();
+  t.deepEqual(registrations, expectedRegistrations);
+});
 
 test('mock service worker unregistration should return no registered workers', async t => {
   await navigator.serviceWorker.register('/worker.js', { scope: '/' });
 
   const initialRegistration = await navigator.serviceWorker.getRegistration();
-  await initialRegistration.unregister();
+  await initialRegistration!.unregister();
 
   const postUnsubscribeRegistration = await navigator.serviceWorker.getRegistration();
   t.is(postUnsubscribeRegistration, undefined);

--- a/test/unit/meta/mockServiceWorker.ts
+++ b/test/unit/meta/mockServiceWorker.ts
@@ -57,6 +57,19 @@ test('mock service worker getRegistrations should return multiple registered wor
   t.deepEqual(registrations, expectedRegistrations);
 });
 
+test('mock service worker getRegistration should return higher path worker', async t => {
+  const expected = await navigator.serviceWorker.register('/workerA.js', { scope: '/' });
+  const actual = await navigator.serviceWorker.getRegistration("/some/scope/");
+  t.deepEqual(actual, expected);
+});
+
+test('mock service worker getRegistration should return specific path if a higher path worker exists too', async t => {
+  const expected = await navigator.serviceWorker.register('/workerB.js', { scope: '/mypath/' });
+  await navigator.serviceWorker.register('/workerA.js', { scope: '/' });
+  const actual = await navigator.serviceWorker.getRegistration("/mypath/");
+  t.deepEqual(actual, expected);
+});
+
 test('mock service worker unregistration should return no registered workers', async t => {
   await navigator.serviceWorker.register('/worker.js', { scope: '/' });
 


### PR DESCRIPTION
# Description
## 1 Line Summary
Update ServiceWorker if its href or scope changes. Allows a seamless transition for those who take advantage of the ["Remove ServiceWorker Page Control Requirement"](https://github.com/OneSignal/OneSignal-Website-SDK/pull/745) changes.

## Details
# Systems Affected
* [x] WebSDK
* [ ] Backend
* [ ] Dashboard

# Validation
## Tests
**Tested the following scenario:**


1. Subscribed for push with default OneSignal ServiceWorker settings.
   - OneSignalSDKWorker.js on the root scope
2. Closed site
3. Changed scope by setting `OneSignal.SERVICE_WORKER_PARAM` to `/push/onesignal/`
4. Also someone may add their own service work in the same deploy
    - Added a call to `navigator.serviceWorker.register("pwa-sw.js");` to replace OneSignal at the root scope.
5. Opened site, observed both ServiceWorkers installed at different scopes.
6. Sent a push and observed it displayed correctly.

Tested on Edge and Firefox on Windows 10.

### Info
### Checklist
* [x] All the automated tests pass or I explained why that is not possible
* [x] I have personally tested this on my machine or explained why that is not possible
* [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:


* [x] Don't use default export
* [x] New interfaces are in model files

Functions:


* [x] Don't use default export
* [x] All function signatures have return types
* [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:


* [x] No Typescript warnings
* [x] Avoid silencing null/undefined warnings with the exclamation point

Other:


* [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
* [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

# Info
## Browser behavior
### Question if two different SW files have `self.addEventListener('push'` which one gets the event?
Every `ServiceWorkerRegistration` instance has its own subscription endpoint. So the answer is simply which one you sent the push to..

## Checklist
* [x] First time setup
* [x] Site was on root scope, changes to a non-root scope such as `/push/onesignal/`
* [x] Site has a root worked with both their SW `importScripts` and ours, want to migrate to OneSignal being under it own scope.
* [x] Ensure pushes display, and don't display twice.
* [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

- - -
## Related Tickets
PR #745
- - -
## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/747)
<!-- Reviewable:end -->

