### PR TITLE
Remove macOS Chrome force disable requireInteraction, Chrome as fixed the issue

### DIFF
--- a/src/context/shared/utils/Utils.ts
+++ b/src/context/shared/utils/Utils.ts
@@ -161,18 +161,6 @@ export class Utils {
     return parts.slice(skipParts).join(delimiter);
   }
 
-  /**
-   * Checks if a version is number is greater than or equal (AKA at least) to a specific compare
-   *   to version.
-   * Limited to only checking for major and minor version values, patch versions are ignored
-   * @param toCheck - Version we want to check
-   * @param compareTo - Version we want to be at or higher
-   * @returns {string} - Returns true if toCheck >= compareTo
-   */
-  public static isVersionAtLeast(toCheck: string | number, compareTo: number): boolean {
-    return this.parseVersionString(toCheck) >= compareTo;
-  }
-
   public static enforceAppId(appId: string | undefined | null): void {
     if (!appId) {
       throw new Error("App id cannot be empty");

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -689,31 +689,7 @@ export class ServiceWorker {
       vibrate: notification.vibrate
     };
 
-    notificationOptions = ServiceWorker.fixPlatformSpecificDisplayIssues(notificationOptions);
     return self.registration.showNotification(notification.heading, notificationOptions);
-  }
-
-  /**
-   * Fixes display issue with some notification options causing the notification to never show!
-   * This happens when setting requireInteraction = true on the following platforms;
-   *   * macOS 10.15+ - Chrome based browsers
-   *      - https://bugs.chromium.org/p/chromium/issues/detail?id=1007418
-   *   * macOS 10.14+ - Opera
-   *      - https://forums.opera.com/topic/31334/push-notifications-with-requireinteraction-true-do-not-display-on-macos
-   * @param notificationOptions - Value passed to ServiceWorkerRegistration.prototype.showNotification
-   */
-  static fixPlatformSpecificDisplayIssues(notificationOptions: any): any {
-    const clone = { ...notificationOptions };
-    const browser = OneSignalUtils.redetectBrowserUserAgent();
-
-    if (browser.chrome && browser.mac && Utils.isVersionAtLeast(browser.osversion, 10.15)) {
-      clone.requireInteraction = false;
-    }
-    else if (browser.opera && browser.mac && Utils.isVersionAtLeast(browser.osversion, 10.14)) {
-      clone.requireInteraction = false;
-    }
-
-    return clone;
   }
 
   /**

--- a/test/unit/context/sw/ServiceWorker.ts
+++ b/test/unit/context/sw/ServiceWorker.ts
@@ -146,36 +146,6 @@ test('displayNotification - persistNotification - force', async t => {
   t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
 });
 
-test('displayNotification - persistNotification - true - Chrome macOS 10.15', async t => {
-  setUserAgent(BrowserUserAgent.ChromeMac10_15);
-
-  await Database.put('Options', { key: 'persistNotification', value: true });
-
-  const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-  await OSServiceWorker.displayNotification({});
-  t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, false);
-});
-
-test('displayNotification - persistNotification - true - Chrome macOS pre-10.15', async t => {
-  setUserAgent(BrowserUserAgent.ChromeMacSupported);
-
-  await Database.put('Options', { key: 'persistNotification', value: true });
-
-  const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-  await OSServiceWorker.displayNotification({});
-  t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, true);
-});
-
-test('displayNotification - persistNotification - true - Opera macOS 10.14', async t => {
-  setUserAgent(BrowserUserAgent.OperaMac10_14);
-
-  await Database.put('Options', { key: 'persistNotification', value: true });
-
-  const showNotificationSpy = sandbox.spy(self.registration, "showNotification");
-  await OSServiceWorker.displayNotification({});
-  t.is(showNotificationSpy.getCall(0).args[1].requireInteraction, false);
-});
-
 test('displayNotification - persistNotification - false', async t => {
   setUserAgent(BrowserUserAgent.ChromeWindowsSupported);
 


### PR DESCRIPTION
# Description
## 1 Line Summary
Removed force disabling `requireInteraction` for macOS 10.15+ introduced in PR #568 on all Chrome versions. Chrome has fixed the issue.

## Details
# Systems Affected
* [x] WebSDK
* [ ] Backend
* [ ] Dashboard

# Validation
## Tests
### Info
### Checklist
* [x] All the automated tests pass or I explained why that is not possible
* [x] I have personally tested this on my machine or explained why that is not possible
* [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:


* [x] Don't use default export
* [x] New interfaces are in model files

Functions:


* [x] Don't use default export
* [x] All function signatures have return types
* [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:


* [x] No Typescript warnings
* [x] Avoid silencing null/undefined warnings with the exclamation point

Other:


* [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
* [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info
### Checklist
* [x] I have included screenshots/recordings of the intended results or explained why they are not needed
  * https://github.com/OneSignal/OneSignal-Website-SDK/issues/711#issuecomment-782576683

- - -
## Related Tickets
* Fixes #711
* Undoes PR #568

- - -
## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/755)
<!-- Reviewable:end -->

