### PR TITLE
Update Error Button Color and default text

### DIFF
--- a/src/slidedown/Slidedown.ts
+++ b/src/slidedown/Slidedown.ts
@@ -54,7 +54,12 @@ export default class Slidedown {
         this.errorButton          = Utils.getValueOrDefault(this.options.text.positiveUpdateButton,
           SERVER_CONFIG_DEFAULTS_SLIDEDOWN.errorButton);
         break;
-      // TO DO: other cases: sms, email, smsAndEmail
+      case DelayedPromptType.Sms:
+      case DelayedPromptType.Email:
+      case DelayedPromptType.SmsAndEmail:
+        this.errorButton = Utils.getValueOrDefault(this.options.text.acceptButton,
+          SERVER_CONFIG_DEFAULTS_SLIDEDOWN.errorButton);
+        break;
       default:
         break;
     }

--- a/src/stylesheets/slidedown.scss
+++ b/src/stylesheets/slidedown.scss
@@ -321,7 +321,7 @@ $border-radius: 0.5em;
 
         &.onesignal-error-state-button {
           padding: 0.75em 1em;
-          background: #E54A4D;
+          background: #0078d1;
           transition: linear 75ms;
           align-items: center;
 


### PR DESCRIPTION
# Description
## 1 Line Summary
Includes changes to the slidedown error button related to its color and default text.

## Details
1. Changes the background color for the button to the same blue as the regular button per discussion.
1. Changes the default text to the regular accept button text for slidedown types: `sms`, `email`, and `smsAndEmail`

# Systems Affected
* [ ] WebSDK
* [ ] Backend
* [ ] Dashboard

## Screenshots
![Screen Shot 2021-03-09 at 7 06 09 PM](https://user-images.githubusercontent.com/11739227/110560432-963aee80-810b-11eb-990b-5d30e14836c4.png)

### Checklist
* [x] I have included screenshots/recordings of the intended results or explained why they are not needed

- - -
## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/762)
<!-- Reviewable:end -->

