### PR TITLE
Specify box-sizing type to avoid style conflicts

### DIFF
--- a/src/stylesheets/slidedown.scss
+++ b/src/stylesheets/slidedown.scss
@@ -167,6 +167,7 @@ $border-radius: 0.5em;
     }
 
     .onesignal-checkmark {
+      box-sizing: content-box;
       position: absolute;
       top: 0;
       left: 0;


### PR DESCRIPTION
Motivation: this commit specifies the box-sizing property in order to
mitigate style collisions as seen on [some sites](https://www.insider.com/vaccine-hunters-covid-us-rollout-moderna-pfizer-facebook-2021-3?utm_source=notification&utm_medium=referral).

## Screenshots
`box-sizing: border-box`
![Screen Shot 2021-03-10 at 4 54 08 PM](https://user-images.githubusercontent.com/11739227/110709048-4159af80-81c1-11eb-9e58-9861042875d9.png)

`box-sizing: content-box`
![Screen Shot 2021-03-10 at 4 54 57 PM](https://user-images.githubusercontent.com/11739227/110709188-6f3ef400-81c1-11eb-9291-b97e23afee77.png)

### Checklist
* [x] I have included screenshots/recordings of the intended results or explained why they are not needed

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/763)
<!-- Reviewable:end -->

