### PR TITLE
Fixed sandbox web sdk script src

### DIFF
--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -3,7 +3,7 @@
 <!-- Some sites use this HTML base tag to change the origin for all relative links.
     Ensure OneSignal SDK correctly handles this. -->
 <base href="https://www.example.com/">
-<script src="/sdks/Dev-OneSignalSDK.js" async=""></script>
+<script src="https://localhost:4001/sdks/Dev-OneSignalSDK.js" async=""></script>
 <script>
     const SERVICE_WORKER_PATH = "push/onesignal/";
 


### PR DESCRIPTION
Fixed a 404 error with the web sdk with the sandbox due to an addition of a `<base>` from PR "Fix SW scope handling of base html tag" #754.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/764)
<!-- Reviewable:end -->

