### PR TITLE
Allow Ava tests to be run directly on .ts files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
   directories:
     - node_modules
 script:
-  - yarn test:noWatch
+  - yarn test:CI
   - yarn build:prod
   - BUILD_ORIGIN=${STAGING_DOMAIN} API=staging API_ORIGIN=${STAGING_DOMAIN} yarn build:staging
   # thanks to https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/

--- a/ava-ci-config.js
+++ b/ava-ci-config.js
@@ -1,0 +1,16 @@
+// Configuration to run transpiled tests which is more performant if running all tests.
+// ava is configured to use ts-node in package.json to make it easy to run one off tests
+//   from a specific .ts file.
+// However ts-node has to reload each time it moves on to the next .ts file making it
+//   ~4x slower overall to run all tests.
+export default {
+  "files": [
+    "build/ts-to-es6/test/unit/**/*.js"
+  ],
+  "source": [
+    "build/ts-to-es6/src/**/*.js"
+  ],
+  "concurrency": 1,
+  "serial": true,
+  "powerAssert": true
+};

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "author": "OneSignal",
   "license": "SEE LICENSE IN LICENSE",
   "devDependencies": {
+    "@ava/typescript": "^1.1.1",
     "@types/body-parser": "latest",
     "@types/chai": "latest",
     "@types/core-js": "latest",
@@ -82,6 +83,7 @@
     "text-encoding": "^0.6.4",
     "timemachine": "^0.3.0",
     "typescript": "^4.1.2",
+    "ts-node": "^9.1.1",
     "tslint": "^5.10.0",
     "tslint-eslint-rules": "^5.2.0",
     "uglifyjs-webpack-plugin": "^1.2.4",
@@ -90,11 +92,17 @@
     "webpack-cli": "^2.0.13"
   },
   "ava": {
+    "extensions": [
+			"ts"
+		],
+		"require": [
+			"ts-node/register/transpile-only"
+		],
     "files": [
-      "build/ts-to-es6/test/unit/**/*.js"
+      "test/unit/**/*.ts"
     ],
     "source": [
-      "build/ts-to-es6/src/**/*.js"
+      "src/**/*.ts"
     ],
     "concurrency": 1,
     "serial": true,

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build:prod": "ENV=production yarn transpile:sources && ENV=production yarn bundle-sw && ENV=production yarn bundle-sdk && ENV=production yarn bundle-page-sdk-es6 && bundlesize && ENV=production build/scripts/publish.sh",
     "test": "ENV=development yarn transpile:tests && yarn run ava --verbose --color --watch",
     "test:noWatch": "ENV=development yarn transpile:tests && ava --verbose --color --watch=false",
+    "test:CI": "ENV=development yarn transpile:tests && ava --config ava-ci-config.js --verbose --color --watch=false",
     "publish": "yarn clean && yarn build:prod && yarn",
     "build:dev-dev": "./build/scripts/build.sh -f development -t development",
     "build:dev-prod": "./build/scripts/build.sh -f development -t production",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "./build/config/tsconfig.json",
   // Options here only apply to IDE, build compile options defined in the build tsconfig.json above.
+  "ts-node": {
+    "compilerOptions": {
+      "module": "commonjs"
+    }
+  },
   "compilerOptions": {
     "strictNullChecks": true,
     "checkJs": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@ava/typescript@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@ava/typescript/-/typescript-1.1.1.tgz#3dcaba3aced8026fdb584d927d809752854dc6e6"
+  integrity sha512-KbLUAe2cWXK63WLK6LnOJonjwEDU/8MNXCOA1ooX/YFZgKRmeAD1kZu+2K0ks5fnOCEcckNQAooyBNGdZUmMQA==
+  dependencies:
+    escape-string-regexp "^2.0.0"
+
 "@babel/code-frame@^7.0.0":
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.1.tgz#d5481c5095daa1c57e16e54c6f9198443afb49ff"
@@ -393,6 +400,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -2285,6 +2297,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
@@ -2644,6 +2661,11 @@ detect-libc@^1.0.2, detect-libc@^1.0.3:
 diff@^3.1.0, diff@^3.2.0, diff@^3.3.1, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.2"
@@ -4939,6 +4961,11 @@ make-dir@^3.0.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 map-age-cleaner@^0.1.3:
   version "0.1.3"
@@ -7447,7 +7474,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.19:
+source-map-support@^0.5.17, source-map-support@^0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -8010,6 +8037,18 @@ tryer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
+ts-node@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
 
 tslib@1.9.0, tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.0"
@@ -8789,3 +8828,8 @@ yeoman-generator@^2.0.3:
     text-table "^0.2.0"
     through2 "^2.0.0"
     yeoman-environment "^2.0.5"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
# Description
Allow Ava tests to be run directly on .ts files instead of requiring transpiled .js files. This means running individual tests much easier and attaching a debugger is now possible.

## Details
* Failed tests now link directly to the .ts file
  * Can now control+click from the terminal to go to source
* Tests can now be run from the VSCode.
  * Using an extension such as testify.
* Running a single test file is about the same speed but it is 4x slower when running the full test suite.
  * A lot of delay before starting each test file.
  * new yarn target `test:CI` to run the old way if needed.
* Followed this guide to add this.
  * https://github.com/avajs/ava/blob/a0791529c18394d92224232cf9d1696426ada505/docs/recipes/typescript.md

## Known Issue
:warning: Running all tests is ~4x slower when using `test:noWatch`.
Use `test:CI` to run the transpiled way if you need to run all tests.
  - Updated travis-CI file to use this method.

* [151302 release build - 66sec](https://travis-ci.com/github/OneSignal/OneSignal-Website-SDK/builds/218392579#L781-L784)
* [This branch with `test:noWatch` - 257 sec](https://travis-ci.com/github/OneSignal/OneSignal-Website-SDK/builds/220028868#L804-L807) 
* [This branch with `test:CI` - 62 sec](https://travis-ci.com/github/OneSignal/OneSignal-Website-SDK/builds/220031058#L782-L785)

# Validation
## Tests
### Info
### Checklist
* [x] All the automated tests pass or I explained why that is not possible
* [x] I have personally tested this on my machine or explained why that is not possible
* [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:


* [x] Don't use default export
* [x] New interfaces are in model files

Functions:


* [x] Don't use default export
* [x] All function signatures have return types
* [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:


* [x] No Typescript warnings
* [x] Avoid silencing null/undefined warnings with the exclamation point

## Screenshots
### Info
Showing running test directly from "Run Test" button on a specific test with VSCode with the Testify extension
![image](https://user-images.githubusercontent.com/645861/111055407-61d87280-842a-11eb-9227-3f1ce97583b9.png)

### Checklist
* [x] I have included screenshots/recordings of the intended results or explained why they are not needed

- - -

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/765)
<!-- Reviewable:end -->
