### PR TITLE
fix(urls): tiny urls fixed for init errors

### DIFF
--- a/src/errors/SdkInitError.ts
+++ b/src/errors/SdkInitError.ts
@@ -24,10 +24,10 @@ export class SdkInitError extends OneSignalError {
         break;
       case SdkInitErrorKind.AppNotConfiguredForWebPush:
         errorMessage = `OneSignal: This app ID does not have any web platforms enabled. Double check your app` +
-        ` ID, or see step 1 on our setup guide (https://documentation.onesignal.com/docs/web-push-quickstart).`;
+        ` ID, or see step 1 on our setup guide (https://tinyurl.com/2x5jzk83).`;
         break;
       case SdkInitErrorKind.MissingSubdomain:
-        errorMessage = `Non-HTTPS pages require the subdomainName parameter within the label set within the OneSignal Web configuration (https://documentation.onesignal.com/docs/web-push-sdk#initialization).`;
+        errorMessage = `Non-HTTPS pages require the subdomainName parameter within the label set within the OneSignal Web configuration (https://tinyurl.com/ry39x7mk).`;
         break;
       case SdkInitErrorKind.WrongSiteUrl:
         if (extra && extra.siteUrl) {

--- a/src/errors/SdkInitError.ts
+++ b/src/errors/SdkInitError.ts
@@ -24,11 +24,10 @@ export class SdkInitError extends OneSignalError {
         break;
       case SdkInitErrorKind.AppNotConfiguredForWebPush:
         errorMessage = `OneSignal: This app ID does not have any web platforms enabled. Double check your app` +
-        ` ID, or see step 1 on our setup guide (https://goo.gl/01h7fZ).`;
+        ` ID, or see step 1 on our setup guide ( https://documentation.onesignal.com/docs/web-push-typical-setup).`;
         break;
       case SdkInitErrorKind.MissingSubdomain:
-        errorMessage = `OneSignal: Non-HTTPS pages require a subdomain of OneSignal to be chosen on ` +
-        `your dashboard. See step 1.4 on our setup guide (https://goo.gl/xip6JB).`;
+        errorMessage = `Non-HTTPS pages require the subdomainName parameter within the label set within the OneSignal Web configuration (https://documentation.onesignal.com/docs/web-push-sdk#initialization).`;
         break;
       case SdkInitErrorKind.WrongSiteUrl:
         if (extra && extra.siteUrl) {

--- a/src/errors/SdkInitError.ts
+++ b/src/errors/SdkInitError.ts
@@ -24,7 +24,7 @@ export class SdkInitError extends OneSignalError {
         break;
       case SdkInitErrorKind.AppNotConfiguredForWebPush:
         errorMessage = `OneSignal: This app ID does not have any web platforms enabled. Double check your app` +
-        ` ID, or see step 1 on our setup guide ( https://documentation.onesignal.com/docs/web-push-typical-setup).`;
+        ` ID, or see step 1 on our setup guide (https://documentation.onesignal.com/docs/web-push-quickstart).`;
         break;
       case SdkInitErrorKind.MissingSubdomain:
         errorMessage = `Non-HTTPS pages require the subdomainName parameter within the label set within the OneSignal Web configuration (https://documentation.onesignal.com/docs/web-push-sdk#initialization).`;


### PR DESCRIPTION
# Description
## 1 Line Summary
## Details
 Based on the ticket Web SDK was being tested locally and user ran into an error, which points to a URL https://goo.gl/xip6JB that no longer exists. As you can see I modified 2 links instead of one because both of the links were down.

# Systems Affected
* [ ] WebSDK
* [ ] Backend
* [ ] Dashboard

# Validation
## Tests
### Info
### Checklist
* [ ] All the automated tests pass or I explained why that is not possible
* [ ] I have personally tested this on my machine or explained why that is not possible
* [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:


* [ ] Don't use default export
* [ ] New interfaces are in model files

Functions:


* [ ] Don't use default export
* [ ] All function signatures have return types
* [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:


* [ ] No Typescript warnings
* [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:


* [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
* [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info
### Checklist
* [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

- - -
## Related Tickets
## https://app.asana.com/0/1193807006058450/1199616780744182/f
## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/767)
<!-- Reviewable:end -->

