### PR TITLE
Load International Telephone Input Resources

### DIFF
--- a/src/slidedown/InternationalTelephoneInput.ts
+++ b/src/slidedown/InternationalTelephoneInput.ts
@@ -1,0 +1,11 @@
+export enum ItiScriptURLs {
+    Stylesheet = "https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.12/css/intlTelInput.min.css",
+    Main       = "https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.12/js/intlTelInput.min.js",
+    Utils      = "https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.12/js/utils.js"
+}
+
+export enum ItiScriptURLHashes {
+    Stylesheet  = "sha512-yye/u0ehQsrVrfSd6biT17t39Rg9kNc+vENcCXZuMz2a+LWFGvXUnYuWUW6pbfYj1jcBb/C39UZw2ciQvwDDvg==",
+    Main        = "sha512-OnkjbJ4TwPpgSmjXACCb5J4cJwi880VRe+vWpPDlr8M38/L3slN5uUAeOeWU2jN+4vN0gImCXFGdJmc0wO4Mig==",
+    Utils       = "sha512-bUcJxlqkiGA3cmoYPuZaLRsyc5ChG9APG4ajom2AXKSlBtOmx4kLV3c8uv/6uSz43FMjI4Q2QI21+D223rT76w=="
+}


### PR DESCRIPTION
Motivation: this commit implements the lazy loading of the resources required for the 3rd party library `International Telephone Input`.

In the future, we will be able to easily change the URLs to self-hosted versions via updating the newly added enum constants in the ITI file.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/769)
<!-- Reviewable:end -->

**Note:** bundle size issue fixed by https://github.com/OneSignal/OneSignal-Website-SDK/pull/771
---