### PR TITLE
Feat: WebPrompts - Validation Bug Fixes

### DIFF
--- a/src/helpers/PromptsHelper.ts
+++ b/src/helpers/PromptsHelper.ts
@@ -38,4 +38,8 @@ export default class PromptsHelper {
     }
     return false;
   }
+
+  static isSlidedownPushDependent(slidedownType: DelayedPromptType): boolean {
+  return slidedownType === DelayedPromptType.Push || slidedownType === DelayedPromptType.Category;
+  }
 }

--- a/src/helpers/PromptsHelper.ts
+++ b/src/helpers/PromptsHelper.ts
@@ -40,6 +40,6 @@ export default class PromptsHelper {
   }
 
   static isSlidedownPushDependent(slidedownType: DelayedPromptType): boolean {
-  return slidedownType === DelayedPromptType.Push || slidedownType === DelayedPromptType.Category;
+    return slidedownType === DelayedPromptType.Push || slidedownType === DelayedPromptType.Category;
   }
 }

--- a/src/managers/slidedownManager/SlidedownManager.ts
+++ b/src/managers/slidedownManager/SlidedownManager.ts
@@ -20,6 +20,7 @@ import { ChannelCaptureError, InvalidChannelInputField } from "../../errors/Chan
 import InitHelper, { RegisterOptions } from "../../helpers/InitHelper";
 import LocalStorage from "../../utils/LocalStorage";
 import DismissHelper from "../../helpers/DismissHelper";
+import PromptsHelper from "../../helpers/PromptsHelper";
 
 export class SlidedownManager {
     private context: ContextInterface;
@@ -39,8 +40,12 @@ export class SlidedownManager {
         const notOptedOut = await OneSignal.privateGetSubscription();
 
         const slidedownType = options.slidedownPromptOptions?.type;
-        const slidedownIsPushDependent = slidedownType === DelayedPromptType.Push ||
-            slidedownType === DelayedPromptType.Category;
+
+        let isSlidedownPushDependent;
+
+        if (!!slidedownType) {
+            isSlidedownPushDependent = PromptsHelper.isSlidedownPushDependent(slidedownType);
+        }
 
         // applies to push slidedown type only
         if (slidedownType === DelayedPromptType.Push && isSubscribed) {
@@ -48,7 +53,7 @@ export class SlidedownManager {
         }
 
         // applies to both push and category slidedown types
-        if (slidedownIsPushDependent) {
+        if (isSlidedownPushDependent) {
             if (!notOptedOut) {
                 throw new NotSubscribedError(NotSubscribedReason.OptedOut);
             }

--- a/src/managers/slidedownManager/SlidedownManager.ts
+++ b/src/managers/slidedownManager/SlidedownManager.ts
@@ -41,15 +41,15 @@ export class SlidedownManager {
 
         const slidedownType = options.slidedownPromptOptions?.type;
 
-        let isSlidedownPushDependent;
-
-        if (!!slidedownType) {
-            isSlidedownPushDependent = PromptsHelper.isSlidedownPushDependent(slidedownType);
-        }
-
         // applies to push slidedown type only
         if (slidedownType === DelayedPromptType.Push && isSubscribed) {
             return false;
+        }
+
+        let isSlidedownPushDependent: boolean = false;
+
+        if (!!slidedownType) {
+            isSlidedownPushDependent = PromptsHelper.isSlidedownPushDependent(slidedownType);
         }
 
         // applies to both push and category slidedown types

--- a/src/managers/slidedownManager/SlidedownManager.ts
+++ b/src/managers/slidedownManager/SlidedownManager.ts
@@ -107,10 +107,16 @@ export class SlidedownManager {
                     }
                     break;
                 case DelayedPromptType.Email:
-                    if (!emailInputFieldIsValid) throw new ChannelCaptureError(InvalidChannelInputField.InvalidEmail);
+                    const isEmailEmpty = ChannelCaptureContainer.isEmailInputFieldEmpty();
+                    if (!emailInputFieldIsValid || isEmailEmpty) {
+                        throw new ChannelCaptureError(InvalidChannelInputField.InvalidEmail);
+                    }
                     break;
                 case DelayedPromptType.Sms:
-                    if (!smsInputFieldIsValid) throw new ChannelCaptureError(InvalidChannelInputField.InvalidSms);
+                    const isSmsEmpty = ChannelCaptureContainer.isSmsInputFieldEmpty();
+                    if (!smsInputFieldIsValid || isSmsEmpty) {
+                        throw new ChannelCaptureError(InvalidChannelInputField.InvalidSms);
+                    }
                     break;
                 case DelayedPromptType.SmsAndEmail:
                     const bothFieldsEmpty = ChannelCaptureContainer.areBothInputFieldsEmpty();

--- a/src/slidedown/ChannelCaptureContainer.ts
+++ b/src/slidedown/ChannelCaptureContainer.ts
@@ -257,10 +257,17 @@ export default class ChannelCaptureContainer {
 
     /* S T A T I C */
     static areBothInputFieldsEmpty(): boolean {
+        return ChannelCaptureContainer.isEmailInputFieldEmpty() &&
+            ChannelCaptureContainer.isSmsInputFieldEmpty();
+    }
+
+    static isEmailInputFieldEmpty(): boolean {
+        return ChannelCaptureContainer.getValueFromEmailInput() === "";
+    }
+
+    static isSmsInputFieldEmpty(): boolean {
         const onesignalSmsInput = document.querySelector(`#${CHANNEL_CAPTURE_CONTAINER_CSS_IDS.onesignalSmsInput}`);
-        const smsFieldEmpty = (<HTMLInputElement>onesignalSmsInput).value === "";
-        const emailFieldEmpty = ChannelCaptureContainer.getValueFromEmailInput() === "";
-        return smsFieldEmpty && emailFieldEmpty;
+        return (<HTMLInputElement>onesignalSmsInput).value === "";
     }
 
     static showSmsInputError(state: boolean): void {
@@ -308,9 +315,21 @@ export default class ChannelCaptureContainer {
         }
     }
 
-    static resetInputErrorStates(): void {
-        ChannelCaptureContainer.showEmailInputError(false);
-        ChannelCaptureContainer.showSmsInputError(false);
+    static resetInputErrorStates(type: DelayedPromptType): void {
+        switch (type) {
+            case DelayedPromptType.Sms:
+                ChannelCaptureContainer.showSmsInputError(false);
+                break;
+            case DelayedPromptType.Email:
+                ChannelCaptureContainer.showEmailInputError(false);
+                break;
+            case DelayedPromptType.SmsAndEmail:
+                ChannelCaptureContainer.showSmsInputError(false);
+                ChannelCaptureContainer.showEmailInputError(false);
+                break;
+            default:
+                break;
+        }
     }
 
     static getValueFromEmailInput(): string | undefined {

--- a/src/slidedown/Slidedown.ts
+++ b/src/slidedown/Slidedown.ts
@@ -21,7 +21,7 @@ import { getRetryIndicator } from './RetryIndicator';
 import { SLIDEDOWN_CSS_CLASSES, SLIDEDOWN_CSS_IDS, COLORS } from "./constants";
 import { TagCategory } from '../models/Tags';
 import { getSlidedownElement } from './SlidedownElement';
-import { Utils } from '../../src/context/shared/utils/Utils';
+import { Utils } from '../context/shared/utils/Utils';
 import ChannelCaptureContainer from './ChannelCaptureContainer';
 import { InvalidChannelInputField } from '../errors/ChannelCaptureError';
 import PromptsHelper from '../helpers/PromptsHelper';

--- a/src/slidedown/Slidedown.ts
+++ b/src/slidedown/Slidedown.ts
@@ -196,8 +196,9 @@ export default class Slidedown {
       removeDomElement('#onesignal-button-indicator-holder');
       removeCssClass(this.allowButton, 'onesignal-error-state-button');
 
+      // to do: use helper function
       if (!(this.options.type in [DelayedPromptType.Push, DelayedPromptType.Category])) {
-        ChannelCaptureContainer.resetInputErrorStates();
+        ChannelCaptureContainer.resetInputErrorStates(this.options.type);
       }
     }
 

--- a/src/slidedown/Slidedown.ts
+++ b/src/slidedown/Slidedown.ts
@@ -24,6 +24,7 @@ import { getSlidedownElement } from './SlidedownElement';
 import { Utils } from '../../src/context/shared/utils/Utils';
 import ChannelCaptureContainer from './ChannelCaptureContainer';
 import { InvalidChannelInputField } from '../errors/ChannelCaptureError';
+import PromptsHelper from '../helpers/PromptsHelper';
 
 export default class Slidedown {
   public options: SlidedownPromptOptions;
@@ -196,8 +197,7 @@ export default class Slidedown {
       removeDomElement('#onesignal-button-indicator-holder');
       removeCssClass(this.allowButton, 'onesignal-error-state-button');
 
-      // to do: use helper function
-      if (!(this.options.type in [DelayedPromptType.Push, DelayedPromptType.Category])) {
+      if (!PromptsHelper.isSlidedownPushDependent(this.options.type)) {
         ChannelCaptureContainer.resetInputErrorStates(this.options.type);
       }
     }


### PR DESCRIPTION
Prior to reviewing: review https://github.com/OneSignal/OneSignal-Website-SDK/pull/773
---

Motivation: previously there were two issues:

1. we were allowing slidedowns with only one of the two web prompt fields (sms, email) to be accepted with empty fields
1. we were attempting to reset both error states regardless of slidedown type, leading to an error saying the validation element was not found

This commit introduces differentiation in the `resetInputErrorStates` function as well as more granularity in the `ChannelCaptureContainer` validation via new dedicate functions to check if individual fields are empty.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/772)
<!-- Reviewable:end -->

