### PR TITLE
Clarifying comment regarding why autoPrompt is defaulting to true

### DIFF
--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -266,6 +266,7 @@ export class ConfigHelper {
             SERVER_CONFIG_DEFAULTS_SLIDEDOWN.confirmMessage)
         };
 
+        // default autoPrompt to true iff slidedown config exists but omitted the autoPrompt setting
         promptOption.autoPrompt = Utils.getValueOrDefault(promptOption.autoPrompt, true);
 
         promptOption.delay = {


### PR DESCRIPTION
Motivation: elsewhere in the codebase we have this setting defaulting to false. This might be confusing.

The reason is that here, we are defaulting to true iff (if and only if) the slidedown config exists in the initialization options. Think, if it was passed into the initialization, most likely the developer wants the slidedown to prompt.

In the other autoPrompt default definition, we default to false since it is used for the case where the entire slidedown config wasn't passed in at all. However, we still want it to be defined in order to support the programmatic showing of slidedowns e.g: via `showSlidedownPrompt`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/790)
<!-- Reviewable:end -->
