### PR TITLE
Feat: WebPrompts - fix slidedown bug

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -56,7 +56,7 @@ import { EnvironmentInfo } from './context/browser/models/EnvironmentInfo';
 import { SessionManager } from './managers/sessionManager/page/SessionManager';
 import OutcomesHelper from "./helpers/shared/OutcomesHelper";
 import { OutcomeAttributionType } from "./models/Outcomes";
-import { AppUserConfigNotifyButton } from './models/Prompts';
+import { AppUserConfigNotifyButton, DelayedPromptType } from './models/Prompts';
 import LocalStorage from './utils/LocalStorage';
 
 export default class OneSignal {
@@ -387,7 +387,7 @@ export default class OneSignal {
    */
   public static async showSlidedownPrompt(options?: AutoPromptOptions): Promise<void> {
     await awaitOneSignalInitAndSupported();
-    await OneSignal.context.promptsManager.internalShowSlidedownPrompt(options);
+    await OneSignal.context.promptsManager.internalShowParticularSlidedown(DelayedPromptType.Push, options);
   }
 
   public static async showCategorySlidedown(options?: AutoPromptOptions): Promise<void> {

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -368,8 +368,7 @@ export default class OneSignal {
    * @PublicApi
    */
   public static async showHttpPrompt(options?: AutoPromptOptions) {
-    await awaitOneSignalInitAndSupported();
-    await OneSignal.context.promptsManager.internalShowSlidedownPrompt(options);
+    await OneSignal.showSlidedownPrompt(options);
   }
 
   /**

--- a/src/managers/PromptsManager.ts
+++ b/src/managers/PromptsManager.ts
@@ -159,7 +159,7 @@ export class PromptsManager {
     DismissHelper.markPromptDismissedWithType(DismissPrompt.Push);
   }
 
-  public async internalShowSlidedownPrompt(options: AutoPromptOptions = { force: false }): Promise<void> {
+  private async internalShowSlidedownPrompt(options: AutoPromptOptions = { force: false }): Promise<void> {
     OneSignalUtils.logMethodCall("internalShowSlidedownPrompt");
 
     MainHelper.markHttpSlidedownShown();

--- a/test/unit/prompts/SlidedownPrompting/SlidedownPrompting.ts
+++ b/test/unit/prompts/SlidedownPrompting/SlidedownPrompting.ts
@@ -54,7 +54,7 @@ const testConfig: TestEnvironmentConfig = {
 
 test("singular push slidedown prompts successfully", async t => {
   await testHelper.setupWithStubs(testConfig, t);
-  const showSlidedownSpy = sinonSandbox.spy(PromptsManager.prototype, "internalShowSlidedownPrompt");
+  const showSlidedownSpy = sinonSandbox.spy(PromptsManager.prototype as any, "internalShowSlidedownPrompt");
   await testHelper.initWithPromptOptions([ minimalPushSlidedownOptions ]);
 
   t.is(showSlidedownSpy.callCount, 1);

--- a/test/unit/public-sdk-apis/showHttpPrompt.ts
+++ b/test/unit/public-sdk-apis/showHttpPrompt.ts
@@ -4,6 +4,7 @@ import { TestEnvironment } from "../../support/sdk/TestEnvironment";
 import Context from "../../../src/models/Context";
 import sinon, { SinonSandbox } from 'sinon';
 import { DismissHelper } from "../../../src/helpers/DismissHelper";
+import { DelayedPromptType } from "../../../src/models/Prompts";
 
 const sinonSandbox: SinonSandbox = sinon.sandbox.create();
 
@@ -21,7 +22,7 @@ test("Test showHttpPrompt with no params", async t => {
 
   // Ensure both public and private calls work
   await OneSignal.showHttpPrompt();
-  await OneSignal.context.promptsManager.internalShowSlidedownPrompt();
+  await OneSignal.context.promptsManager.internalShowParticularSlidedown(DelayedPromptType.Push);
   // Pass if we did not throw
   t.pass();
 });


### PR DESCRIPTION
# Description
Fixes bug where configured prompt options were being ignored for programmaticly prompted push slidedowns. This had secondary effects such as also impacting back-off logic.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/793)
<!-- Reviewable:end -->

