### PR TITLE
Fix box-sizing on checkmark after

### DIFF
--- a/src/stylesheets/slidedown.scss
+++ b/src/stylesheets/slidedown.scss
@@ -319,6 +319,7 @@ $desktop-width: 1024px;
 
       &:checked ~ .onesignal-checkmark:after {
         display: block;
+        box-sizing: content-box;
       }
     }
 
@@ -356,6 +357,7 @@ $desktop-width: 1024px;
         width: 0.33em;
         height: 0.66em;
         border: solid white;
+        box-sizing: content-box;
         border-width: 0 3px 3px 0;
         -webkit-transform: rotate(45deg);
         -ms-transform: rotate(45deg);


### PR DESCRIPTION
# Description
Small styling fix related to checkmark in Category Slidedown (`:after`)

![Screen Shot 2021-04-14 at 11 29 06 PM](https://user-images.githubusercontent.com/11739227/114814154-36bea700-9d79-11eb-900d-8568bf0808f1.png)

![Screen Shot 2021-04-14 at 11 27 04 PM](https://user-images.githubusercontent.com/11739227/114814136-2dcdd580-9d79-11eb-8c87-52699d371fd0.png)

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/795)
<!-- Reviewable:end -->

