### PR TITLE
Add PerformanceObserver to sandbox

### DIFF
--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -153,6 +153,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OneSignal WebSDK Sandbox</title>
     <link rel="shortcut icon" href="#">
+    <script>
+        addEventListener("load", () => {
+          new PerformanceObserver((list) => {
+              list.getEntries().forEach((entry) => {
+                if (entry.hadRecentInput) return;
+                console.log('layout-shift detected', {entry});
+              });
+          }).observe({type: "layout-shift", buffered: true});
+        });
+    </script>
 </head>
 <body>
     <h1>OneSignal WebSDK Sandbox</h1>


### PR DESCRIPTION
This PR adds a PerformanceObserver to the sandbox tool to detect and alert on layout shift.

![image](https://user-images.githubusercontent.com/435158/114821430-68357380-9d75-11eb-897d-94b18b8c36b1.png)

Layout shift has been observed in custom links and Bell (when subscribed & resized over hover).  SMS/Email slidedowns were not tested.

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/796)
<!-- Reviewable:end -->

