### PR TITLE
Reshown Category Slidedown Fix

### DIFF
--- a/src/managers/slidedownManager/SlidedownManager.ts
+++ b/src/managers/slidedownManager/SlidedownManager.ts
@@ -51,13 +51,17 @@ export class SlidedownManager {
       isSlidedownPushDependent = PromptsHelper.isSlidedownPushDependent(slidedownType);
     }
 
-    // applies to push slidedown type only
-    if (slidedownType === DelayedPromptType.Push && isSubscribed) {
-      return false;
-    }
-
     // applies to both push and category slidedown types
     if (isSlidedownPushDependent) {
+      if (isSubscribed) {
+        // applies to category slidedown type only
+        if (options.isInUpdateMode) {
+          return true;
+        }
+
+        return false;
+      }
+
       wasDismissed = DismissHelper.wasPromptOfTypeDismissed(DismissPrompt.Push);
 
       if (!notOptedOut) {

--- a/test/support/tester/EventsTestHelper.ts
+++ b/test/support/tester/EventsTestHelper.ts
@@ -57,6 +57,7 @@ export default class EventsTestHelper {
 
   public simulateSubscribingAfterNativeAllow() {
     OneSignal.emitter.on(OneSignal.EVENTS.PERMISSION_PROMPT_DISPLAYED, () => {
+        this.sinonSandbox.stub(OneSignal, "privateGetSubscription").resolves(true);
         this.sinonSandbox.stub(SubscriptionManager.prototype, "getSubscriptionState")
             .resolves({ subscribed: true, isOptedOut: false });
         stubServiceWorkerInstallation(this.sinonSandbox);

--- a/test/unit/helpers/DismissHelper.ts
+++ b/test/unit/helpers/DismissHelper.ts
@@ -14,11 +14,15 @@ import { DismissHelper } from "../../../src/helpers/DismissHelper";
 import { SlidedownManager } from "../../../src/managers/slidedownManager/SlidedownManager";
 import TimedLocalStorage from "../../../src/modules/TimedLocalStorage";
 import { DismissTimeKey } from "../../../src/models/Dismiss";
+import Slidedown from "../../../src/slidedown/Slidedown";
+import { AutoPromptOptions } from "../../../src/managers/PromptsManager";
 
 const sinonSandbox: SinonSandbox = sinon.sandbox.create();
 const testHelper = new SlidedownPromptingTestHelper(sinonSandbox);
-const minimalPushSlidedownOptions = testHelper.getMinimalPushSlidedownOptions();
-const minimalSmsAndEmailOptions = testHelper.getMinimalSmsAndEmailOptions();
+
+const minimalPushSlidedownOptions     = testHelper.getMinimalPushSlidedownOptions();
+const minimalSmsAndEmailOptions       = testHelper.getMinimalSmsAndEmailOptions();
+const minimalCategorySlidedownOptions = testHelper.getMinimalCategorySlidedownOptions();
 
 test.beforeEach(() => {
     mockGetIcon();
@@ -112,8 +116,6 @@ test("on non-push slidedown dismiss, mark non-push prompt as dismissed", async t
   t.is(nonPushDismissed, "dismissed");
 });
 
-test.todo("uncomment below test");
-
 test("on non-push slidedown dismiss, dismissed slidedown cannot be reshown programmatically", async t => {
   await TestEnvironment.setupOneSignalPageWithStubs(sinonSandbox, testConfig, t);
   sinonSandbox.stub(SlidedownManager.prototype as any, "checkIfSlidedownShouldBeShown").resolves(true);
@@ -139,4 +141,37 @@ test("on non-push slidedown dismiss, dismissed slidedown cannot be reshown progr
   t.is(dismissSpy.callCount, 1);
   t.is(pushDismissed, null);
   t.is(nonPushDismissed, "dismissed");
+});
+
+test("if subscribed w/ expired dismiss value, category slidedown doesn't prompt", async t => {
+  await TestEnvironment.setupOneSignalPageWithStubs(sinonSandbox, testConfig, t);
+  const eventsHelper = new EventsTestHelper(sinonSandbox);
+  const slidedownCreateSpy = sinonSandbox.spy(Slidedown.prototype, "create");
+  EventsTestHelper.simulateSlidedownAllowAfterShown();
+  eventsHelper.simulateSubscribingAfterNativeAllow();
+
+  const subscriptionPromise = EventsTestHelper.getSubscriptionPromise();
+
+  // initialize
+  await testHelper.initWithPromptOptions([
+      testHelper.addPromptDelays(minimalCategorySlidedownOptions, 1, 0),
+  ]);
+
+  await subscriptionPromise;
+  t.is(slidedownCreateSpy.callCount, 1);
+
+  // simulate timed storage value expiration
+  TimedLocalStorage.removeItem(DismissTimeKey.OneSignalNotificationPrompt);
+
+  const options: AutoPromptOptions = { slidedownPromptOptions: minimalCategorySlidedownOptions };
+
+  // should fail to successfully create slidedown since already subscribed and not in update mode
+  await OneSignal.context.slidedownManager.createSlidedown(options);
+
+  t.is(slidedownCreateSpy.callCount, 1); // unchanged
+
+  sinonSandbox.stub(SlidedownManager.prototype, "handleAllowClick");
+  await OneSignal.showCategorySlidedown(); // isInUpdateMode = true
+
+  t.is(slidedownCreateSpy.callCount, 2);
 });


### PR DESCRIPTION
# Description
## 1 Line Summary
We should not allow subscribed sites to re-show the category slidedown prompt unless prompted programmatically (`options.isInUpdateMode`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/798)
<!-- Reviewable:end -->
