### PR TITLE
Eliminate layout shift in bell hover

### DIFF
--- a/src/bell/Launcher.ts
+++ b/src/bell/Launcher.ts
@@ -94,16 +94,25 @@ export default class Launcher extends ActiveAnimatedElement {
     this.wasInactive = false;
   }
 
+  scaleDown() {
+      return this.element.style.transform = 'scale(0.95)';
+  }
+
+
+  scaleBack() {
+      return this.element.style.transform = '';
+  }
+
   inactivate() {
     return this.bell.message.hide()
       .then(() => {
         if (this.bell.badge.content.length > 0) {
           return this.bell.badge.hide()
-            .then(() => Promise.all([super.inactivate(), this.resize('small')]))
+            .then(() => Promise.all([super.inactivate(), this.scaleDown()]))
             .then(() => this.bell.badge.show());
         }
         else {
-          return Promise.all([super.inactivate(), this.resize('small')]);
+          return Promise.all([super.inactivate(), this.scaleDown()]);
         }
       });
   }
@@ -111,10 +120,10 @@ export default class Launcher extends ActiveAnimatedElement {
   activate() {
     if (this.bell.badge.content.length > 0) {
       return this.bell.badge.hide()
-        .then(() => Promise.all([super.activate(), this.resize(this.bell.options.size)]));
+        .then(() => Promise.all([super.activate(), this.scaleBack()]));
     }
     else {
-      return Promise.all([super.activate(), this.resize(this.bell.options.size)]);
+      return Promise.all([super.activate(), this.scaleBack()]);
     }
   }
 }


### PR DESCRIPTION
The bell has a responsive effect on hover when the user is subscribed.
This was implemented by adding or removing the "small" css class for the
bell.  The small/medium/large classes are also used to expose size
options to customers.

This change transitions to an approach where we add a scale transform
CSS property, which does not re-trigger layout.