### PR TITLE
Border style fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build:dev-stag": "./build/scripts/build.sh -f development -t staging"
   },
   "config": {
-    "sdkVersion": "151401"
+    "sdkVersion": "151402"
   },
   "repository": {
     "type": "git",

--- a/src/stylesheets/reset.scss
+++ b/src/stylesheets/reset.scss
@@ -29,14 +29,18 @@
     background-image: none ; /* This rule affects the use of pngfix JavaScript http://dillerdesign.com/experiment/DD_BelatedPNG for IE6, which is used to force the browser to recognise alpha-transparent PNGs files that replace the IE6 lack of PNG transparency. (The rule overrides the VML image that is used to replace the given CSS background-image). If you don't know what that means, then you probably haven't used the pngfix script, and this comment may be ignored :) */
     background-position: 0 0 ;
     background-repeat: repeat ;
-    border: inherit;
+    border-color: black ;
+    border-color: currentColor ; /* `border-color` should match font color. Modern browsers (incl. IE9) allow the use of "currentColor" to match the current font 'color' value <http://www.w3.org/TR/css3-color/#currentcolor>. For older browsers, a default of 'black' is given before this rule. Guideline to support older browsers: if you haven't already declared a border-color for an element, be sure to do so, e.g. when you first declare the border-width. */
+    border-radius: 0 ;
+    border-style: none ;
+    border-width: medium ;
     bottom: auto ;
     clear: none ;
     clip: auto ;
     color: inherit ;
     counter-increment: none ;
     counter-reset: none ;
-    cursor: inherit ;
+    cursor: auto ;
     direction: inherit ;
     display: inline ;
     float: none ;
@@ -72,7 +76,7 @@
     unicode-bidi: normal ;
     vertical-align: baseline ;
     visibility: inherit ;
-    white-space: inherit ;
+    white-space: normal ;
     width: auto ;
     word-spacing: normal ;
     z-index: auto ;


### PR DESCRIPTION
# Description
## 1 Line Summary
Styling fix for border issue in slidedown. Also reverted other reset styles to [original property values](https://github.com/OneSignal/OneSignal-Website-SDK/commit/571eac78099635f577df1300442975d970934c84) due to potential unforeseen consequences. 

![Screen Shot 2021-04-19 at 7 18 13 PM](https://user-images.githubusercontent.com/11739227/115321524-a0f49480-a149-11eb-83be-cb92005963c9.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/802)
<!-- Reviewable:end -->
