### PR TITLE
Define font-weight for the body-message

### DIFF
--- a/src/stylesheets/slidedown.scss
+++ b/src/stylesheets/slidedown.scss
@@ -427,6 +427,7 @@ $desktop-width: 1024px;
     .slidedown-body-message, .popover-body-message {
       box-sizing: border-box;
       padding: 0 0 0 1em;
+      font-weight: 400;
       float: left;
       width: calc(100% - 80px);
       line-height: 1.45em;


### PR DESCRIPTION
Motivation: on some sites, their global styles will apply to the font-weight of the slidedown body message.

This change defines it at 400 in order to prevent erroneous modification.

![Screen Shot 2021-04-20 at 12 54 21 PM](https://user-images.githubusercontent.com/11739227/115442417-984a9f80-a1d7-11eb-97dd-4eb706196bf5.png)
![Screen Shot 2021-04-20 at 12 54 42 PM](https://user-images.githubusercontent.com/11739227/115442418-98e33600-a1d7-11eb-9b67-3ace3a37142e.png)

## <!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/803)
<!-- Reviewable:end -->

