### PR TITLE
Dev/vscode docker sandbox and build fixes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 
 	// The optional 'workspaceFolder' property is the path VS Code should open by default when
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
-	"workspaceFolder": "/workspace",
+	"workspaceFolder": "/sdk",
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,36 +3,28 @@ services:
   # Update this to the name of the service you want to work with in your docker-compose.yml file
   onesignal-web-sdk-dev:
     # If you want add a non-root user to your Dockerfile, you can use the "remoteUser"
-    # property in devcontainer.json to cause VS Code its sub-processes (terminals, tasks, 
-    # debugging) to execute as the user. Uncomment the next line if you want the entire 
-    # container to run as this user instead. Note that, on Linux, you may need to 
-    # ensure the UID and GID of the container user you create matches your local user. 
+    # property in devcontainer.json to cause VS Code its sub-processes (terminals, tasks,
+    # debugging) to execute as the user. Uncomment the next line if you want the entire
+    # container to run as this user instead. Note that, on Linux, you may need to
+    # ensure the UID and GID of the container user you create matches your local user.
     # See https://aka.ms/vscode-remote/containers/non-root for details.
     #
     # user: vscode
 
-    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer 
-    # folder. Note that the path of the Dockerfile and context is relative to the *primary* 
+    # Uncomment if you want to override the service's Dockerfile to one in the .devcontainer
+    # folder. Note that the path of the Dockerfile and context is relative to the *primary*
     # docker-compose.yml file (the first in the devcontainer.json "dockerComposeFile"
     # array). The sample below assumes your primary file is in the root of your project.
     #
     # build:
     #   context: .
     #   dockerfile: .devcontainer/Dockerfile
-    
-    volumes:
-      # Update this to wherever you want VS Code to mount the folder of your project
-      - .:/workspace:cached
 
       # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
-      # - /var/run/docker.sock:/var/run/docker.sock 
+      # - /var/run/docker.sock:/var/run/docker.sock
 
     # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
     # cap_add:
     #   - SYS_PTRACE
     # security_opt:
     #   - seccomp:unconfined
-
-    # Overrides default command so things don't shut down after the process ends.
-    command: /bin/sh -c "while sleep 1000; do :; done"
- 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,3 @@ FROM node:12.18.0
 WORKDIR /sdk
 COPY package.json .
 RUN yarn
-
-CMD ./docker/docker-entry-point.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,17 +7,12 @@ services:
       volumes:
         - .:/sdk:cached
         - sdk-build:/sdk/build/releases
-
-      # docker for Ubuntu VM
-      # network_mode: "host"
-      
-      # docker for mac
       ports:
           - published: 4001
             target: 4001
           - published: 4000
             target: 4000
-
+      command: /bin/sh -c "./docker/docker-entry-point.sh"
 # Named volumes that are persisted between docker-compose rebuilds.
 # If you need to remove these volumes for some reason, run `docker-compose down -v`
 volumes:


### PR DESCRIPTION
# Description
## 1 Line Summary
Fixes VSCode with docker specific issues; 1. Sandbox not starting. 2. Wrong docker volume name for `yarn build`

## Details
See commit by commit for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/805)
<!-- Reviewable:end -->
