### PR TITLE
Cleanup secondary channel device type

### DIFF
--- a/src/OneSignalApi.ts
+++ b/src/OneSignalApi.ts
@@ -50,21 +50,6 @@ export default class OneSignalApi {
     return await OneSignalApiShared.createUser(deviceRecord);
   }
 
-  static async createSecondaryChannelRecord(
-    appConfig: AppConfig,
-    profile: SecondaryChannelProfile,
-    pushDeviceRecordId?: string
-  ): Promise<string | null> {
-    return await OneSignalApiShared.createSecondaryChannelRecord(appConfig, profile, pushDeviceRecordId);
-  }
-
-  static async updateSecondaryChannelRecord(
-    appConfig: AppConfig,
-    profile: SecondaryChannelProfile
-  ): Promise<void> {
-    await OneSignalApiShared.updateSecondaryChannelRecord(appConfig, profile);
-  }
-
   static async logoutEmail(appConfig: AppConfig, emailProfile: EmailProfile, deviceId: string): Promise<boolean> {
     return await OneSignalApiShared.logoutEmail(appConfig, emailProfile, deviceId);
   }

--- a/src/OneSignalApiShared.ts
+++ b/src/OneSignalApiShared.ts
@@ -55,49 +55,6 @@ export default class OneSignalApiShared {
     return null;
   }
 
-  static async createSecondaryChannelRecord(
-    appConfig: AppConfig,
-    profile: SecondaryChannelProfile,
-    pushDeviceRecordId?: string
-  ): Promise<string | null> {
-    Utils.enforceAppId(appConfig.appId);
-
-    const secondaryChannelRecord = new SecondaryChannelDeviceRecord(
-      profile.identifier,
-      profile.identifierAuthHash,
-      pushDeviceRecordId
-    );
-
-    secondaryChannelRecord.appId = appConfig.appId;
-    const response = await OneSignalApiBase.post(`players`, secondaryChannelRecord.serialize());
-    if (response && response.success) {
-      return response.id;
-    } else {
-      return null;
-    }
-  }
-
-  /**
-   * Make a PUT call to update the secondary channel's identifier.
-   * @param {AppConfig} appConfig - This contains an appId which will be included
-   * @param {SecondaryChannelProfile} profile - This the profile we will be using fields from to include in the update
-   */
-  static async updateSecondaryChannelRecord(
-    appConfig: AppConfig,
-    profile: SecondaryChannelProfile
-  ): Promise<void> {
-    Utils.enforceAppId(appConfig.appId);
-    Utils.enforcePlayerId(profile.subscriptionId);
-
-    const secondaryChannelRecord = new SecondaryChannelDeviceRecord(
-      profile.identifier,
-      profile.identifierAuthHash
-    );
-
-    secondaryChannelRecord.appId = appConfig.appId;
-    await OneSignalApiBase.put(`players/${profile.subscriptionId}`, secondaryChannelRecord.serialize());
-  }
-
   static async logoutEmail(appConfig: AppConfig, emailProfile: EmailProfile, deviceId: string): Promise<boolean> {
     Utils.enforceAppId(appConfig.appId);
     Utils.enforcePlayerId(deviceId);

--- a/src/managers/channelManager/shared/providers/SecondaryChannelProfileProvider.ts
+++ b/src/managers/channelManager/shared/providers/SecondaryChannelProfileProvider.ts
@@ -1,3 +1,4 @@
+import { DeliveryPlatformKind } from "../../../../models/DeliveryPlatformKind";
 import { SecondaryChannelProfile } from "../../../../models/SecondaryChannelProfile";
 
 // Interface to do the following operations on a SecondaryChannelProfile
@@ -6,6 +7,7 @@ import { SecondaryChannelProfile } from "../../../../models/SecondaryChannelProf
 
 // * Save to storage
 export interface SecondaryChannelProfileProvider {
+  readonly deviceType: DeliveryPlatformKind;
   newProfile(subscriptionId?: string, identifier?: string, identifierAuthHash?: string): SecondaryChannelProfile;
   getProfile(): Promise<SecondaryChannelProfile>;
   setProfile(profile: SecondaryChannelProfile): Promise<void>;

--- a/src/managers/channelManager/shared/updaters/SecondaryChannelSessionUpdater.ts
+++ b/src/managers/channelManager/shared/updaters/SecondaryChannelSessionUpdater.ts
@@ -14,6 +14,7 @@ export class SecondaryChannelSessionUpdater {
     }
 
     const secondaryChannelRecord = new SecondaryChannelDeviceRecord(
+      this.profileProvider.deviceType,
       profile.identifier,
       profile.identifierAuthHash
     );

--- a/src/models/SecondaryChannelDeviceRecord.ts
+++ b/src/models/SecondaryChannelDeviceRecord.ts
@@ -10,12 +10,12 @@ export class SecondaryChannelDeviceRecord extends DeviceRecord {
    * @param identifier Omitting this parameter does not void the record's identifier.
    */
   constructor(
+    public deliveryPlatform: DeliveryPlatformKind,
     public identifier?: string | null,
     public identifierAuthHash?: string | null,
     public pushDeviceRecordId?: string | null,
   ) {
     super();
-    this.deliveryPlatform = DeliveryPlatformKind.Email;
   }
 
   serialize() {


### PR DESCRIPTION
# Description
## 1 Line Summary
 `SecondaryChannelDeviceRecord` now requires a `deliveryPlatform` constructor param to support other platforms than email.

## Details
In PR #797 we renamed `EmailDeviceRecord` to `SecondaryChannelDeviceRecord` to support future channels such as SMS. However it's `deliveryPlatform` was still hard coded to Email. This PR enforces a constructor parameter for this.

Since `OneSignalApiShared` uses `SecondaryChannelDeviceRecord` directly I opted to remove its dependency on it for player creates and identifier updates by changing `SecondaryChannelIdentifierUpdater` to create the `SecondaryChannelDeviceRecord` instead. This resulted in being able to remove some methods from `OneSignalApiShared` and `OneSignalApi`.

# Validation
## Tests
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
      - Will be doing manual testing in a follow up PR with the addition of SMS.
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---
`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/806)
<!-- Reviewable:end -->
