### PR TITLE
Add SecondaryChannelManager to email & sms Slidedown to make WebPrompts Functional

### DIFF
--- a/src/managers/UpdateManager.ts
+++ b/src/managers/UpdateManager.ts
@@ -185,12 +185,4 @@ export class UpdateManager {
     }
     await OneSignalApiShared.sendOutcome(outcomeRequestData);
   }
-
-  public async updateEmail(email: string) {
-    // to do
-  }
-
-  public async updateSms(smsNumber: string) {
-    // to do
-  }
 }

--- a/src/managers/slidedownManager/SlidedownManager.ts
+++ b/src/managers/slidedownManager/SlidedownManager.ts
@@ -129,12 +129,12 @@ export class SlidedownManager {
   private async handleAllowForSmsType(): Promise<void> {
     const smsInputFieldIsValid = OneSignal.slidedown.channelCaptureContainer.smsInputFieldIsValid;
     const isSmsEmpty = ChannelCaptureContainer.isSmsInputFieldEmpty();
-    const sms = ChannelCaptureContainer.getValueFromSmsInput();
 
-    if (!sms || !smsInputFieldIsValid || isSmsEmpty) {
+    if (!smsInputFieldIsValid || isSmsEmpty) {
       throw new ChannelCaptureError(InvalidChannelInputField.InvalidSms);
     }
 
+    const sms = ChannelCaptureContainer.getValueFromSmsInput();
     this.updateSMS(sms);
   }
 

--- a/src/managers/slidedownManager/SlidedownManager.ts
+++ b/src/managers/slidedownManager/SlidedownManager.ts
@@ -23,13 +23,17 @@ import PromptsHelper from "../../helpers/PromptsHelper";
 import ConfirmationToast from "../../slidedown/ConfirmationToast";
 import { awaitableTimeout } from "../../utils/AwaitableTimeout";
 import { DismissPrompt } from "../../models/Dismiss";
+import { SecondaryChannelManager } from "../channelManager/shared/SecondaryChannelManager";
 
 export class SlidedownManager {
   private context: ContextInterface;
   private slidedownQueue: AutoPromptOptions[];
   private isSlidedownShowing: boolean;
 
-  constructor(context: ContextInterface) {
+  constructor(
+    context: ContextInterface,
+    private readonly secondaryChannelManager: SecondaryChannelManager
+    ) {
     this.context = context;
     this.slidedownQueue = [];
     this.isSlidedownShowing = false;
@@ -119,19 +123,19 @@ export class SlidedownManager {
     }
 
     const email = ChannelCaptureContainer.getValueFromEmailInput();
-    this.context.updateManager.updateEmail(email);
+    this.updateEmail(email);
   }
 
   private async handleAllowForSmsType(): Promise<void> {
     const smsInputFieldIsValid = OneSignal.slidedown.channelCaptureContainer.smsInputFieldIsValid;
     const isSmsEmpty = ChannelCaptureContainer.isSmsInputFieldEmpty();
+    const sms = ChannelCaptureContainer.getValueFromSmsInput();
 
-    if (!smsInputFieldIsValid || isSmsEmpty) {
+    if (!sms || !smsInputFieldIsValid || isSmsEmpty) {
       throw new ChannelCaptureError(InvalidChannelInputField.InvalidSms);
     }
 
-    const sms = ChannelCaptureContainer.getValueFromSmsInput();
-    this.context.updateManager.updateSms(sms);
+    this.updateSMS(sms);
   }
 
   private async handleAllowForSmsAndEmailType(): Promise<void> {
@@ -162,7 +166,7 @@ export class SlidedownManager {
      */
     if (emailInputFieldIsValid) {
       if (!isEmailEmpty) {
-        this.context.updateManager.updateEmail(email);
+        this.updateEmail(email);
       }
     } else {
       throw new ChannelCaptureError(InvalidChannelInputField.InvalidEmail);
@@ -170,11 +174,19 @@ export class SlidedownManager {
 
     if (smsInputFieldIsValid) {
       if (!isSmsEmpty) {
-        this.context.updateManager.updateSms(sms);
+        this.updateSMS(sms);
       }
     } else {
       throw new ChannelCaptureError(InvalidChannelInputField.InvalidSms);
     }
+  }
+
+  private updateEmail(email: string): void {
+    this.secondaryChannelManager.email.setIdentifier(email);
+  }
+
+  private updateSMS(sms: string): void {
+    this.secondaryChannelManager.sms.setIdentifier(sms);
   }
 
   private async showConfirmationToast(): Promise<void> {

--- a/src/models/Context.ts
+++ b/src/models/Context.ts
@@ -49,6 +49,7 @@ export default class Context implements ContextInterface {
     if (typeof OneSignal !== "undefined" && !!OneSignal.environmentInfo) {
       this.environmentInfo = OneSignal.environmentInfo;
     }
+    this.secondaryChannelManager = new SecondaryChannelManager();
     this.subscriptionManager = ContextHelper.getSubscriptionManager(this);
     this.serviceWorkerManager = ContextHelper.getServiceWorkerManager(this);
     this.pageViewManager = new PageViewManager();
@@ -57,10 +58,9 @@ export default class Context implements ContextInterface {
     this.updateManager = new UpdateManager(this);
     this.sessionManager = new SessionManager(this);
     this.tagManager = new TagManager(this);
-    this.slidedownManager = new SlidedownManager(this);
+    this.slidedownManager = new SlidedownManager(this, this.secondaryChannelManager);
     this.promptsManager = new PromptsManager(this);
     this.dynamicResourceLoader = new DynamicResourceLoader();
     this.metricsManager = new MetricsManager(appConfig.metrics.enable, appConfig.metrics.mixpanelReportingToken);
-    this.secondaryChannelManager = new SecondaryChannelManager();
   }
 }


### PR DESCRIPTION
# Description
## 1 Line Summary
Added SecondaryChannelManager to SlidedownManager and connected it to email and sms updates so WebPrompts is now functional!

## Details
See commits for details.

# Validation
## Tests
Tested the following prompts
* Email
* SMS
* EmailAndSMS

Found pre existing bug where `updateSMS` is not given a phone number in a E.164 format. However fixed this in PR #809
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed
       - No visual changes

---

## Related Tickets

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/808)
<!-- Reviewable:end -->
