### PR TITLE
Fix SMS web prompt to format as e164

### DIFF
--- a/src/managers/slidedownManager/SlidedownManager.ts
+++ b/src/managers/slidedownManager/SlidedownManager.ts
@@ -116,25 +116,25 @@ export class SlidedownManager {
 
   private async handleAllowForEmailType(): Promise<void> {
     const emailInputFieldIsValid = OneSignal.slidedown.channelCaptureContainer.emailInputFieldIsValid;
-    const isEmailEmpty = ChannelCaptureContainer.isEmailInputFieldEmpty();
+    const isEmailEmpty = OneSignal.slidedown.channelCaptureContainer.isEmailInputFieldEmpty();
 
     if (!emailInputFieldIsValid || isEmailEmpty) {
       throw new ChannelCaptureError(InvalidChannelInputField.InvalidEmail);
     }
 
-    const email = ChannelCaptureContainer.getValueFromEmailInput();
+    const email = OneSignal.slidedown.channelCaptureContainer.getValueFromEmailInput();
     this.updateEmail(email);
   }
 
   private async handleAllowForSmsType(): Promise<void> {
     const smsInputFieldIsValid = OneSignal.slidedown.channelCaptureContainer.smsInputFieldIsValid;
-    const isSmsEmpty = ChannelCaptureContainer.isSmsInputFieldEmpty();
+    const isSmsEmpty = OneSignal.slidedown.channelCaptureContainer.isSmsInputFieldEmpty();
 
     if (!smsInputFieldIsValid || isSmsEmpty) {
       throw new ChannelCaptureError(InvalidChannelInputField.InvalidSms);
     }
 
-    const sms = ChannelCaptureContainer.getValueFromSmsInput();
+    const sms = OneSignal.slidedown.channelCaptureContainer.getValueFromSmsInput();
     this.updateSMS(sms);
   }
 
@@ -147,8 +147,8 @@ export class SlidedownManager {
      *
      * thus, we need separate checks for the emptiness properties
      */
-    const isEmailEmpty = ChannelCaptureContainer.isEmailInputFieldEmpty();
-    const isSmsEmpty = ChannelCaptureContainer.isSmsInputFieldEmpty();
+    const isEmailEmpty = OneSignal.slidedown.channelCaptureContainer.isEmailInputFieldEmpty();
+    const isSmsEmpty = OneSignal.slidedown.channelCaptureContainer.isSmsInputFieldEmpty();
 
     const bothFieldsEmpty = isEmailEmpty && isSmsEmpty;
     const bothFieldsInvalid = !smsInputFieldIsValid && !emailInputFieldIsValid;
@@ -157,8 +157,8 @@ export class SlidedownManager {
       throw new ChannelCaptureError(InvalidChannelInputField.InvalidEmailAndSms);
     }
 
-    const email = ChannelCaptureContainer.getValueFromEmailInput();
-    const sms = ChannelCaptureContainer.getValueFromSmsInput();
+    const email = OneSignal.slidedown.channelCaptureContainer.getValueFromEmailInput();
+    const sms = OneSignal.slidedown.channelCaptureContainer.getValueFromSmsInput();
 
     /**
      * empty is ok (we can accept only one of two input fields), but invalid is not

--- a/src/slidedown/ChannelCaptureContainer.ts
+++ b/src/slidedown/ChannelCaptureContainer.ts
@@ -258,7 +258,6 @@ export default class ChannelCaptureContainer {
     }
   }
 
-  /* S T A T I C */
   isEmailInputFieldEmpty(): boolean {
     return this.getValueFromEmailInput() === "";
   }
@@ -267,6 +266,16 @@ export default class ChannelCaptureContainer {
     return this.getValueFromSmsInput() === "";
   }
 
+  getValueFromEmailInput(): string {
+    const inputNode = getDomElementOrStub(`#${CHANNEL_CAPTURE_CONTAINER_CSS_IDS.onesignalEmailInput}`);
+    return (<HTMLInputElement>inputNode)?.value || "";
+  }
+
+  getValueFromSmsInput(): string {
+    return this.itiOneSignal.getNumber(intlTelInputUtils.numberFormat.E164) || "";
+  }
+
+  /* S T A T I C */
   static showSmsInputError(state: boolean): void {
     const validationElement = document.querySelector(
       `#${CHANNEL_CAPTURE_CONTAINER_CSS_IDS.onesignalSmsValidationElement}`
@@ -327,15 +336,6 @@ export default class ChannelCaptureContainer {
       default:
         break;
     }
-  }
-
-  getValueFromEmailInput(): string {
-    const inputNode = getDomElementOrStub(`#${CHANNEL_CAPTURE_CONTAINER_CSS_IDS.onesignalEmailInput}`);
-    return (<HTMLInputElement>inputNode)?.value || "";
-  }
-
-  getValueFromSmsInput(): string {
-    return this.itiOneSignal.getNumber(intlTelInputUtils.numberFormat.E164) || "";
   }
 
   static validateEmailInputWithReturnVal(emailString?: string): boolean {

--- a/src/slidedown/ChannelCaptureContainer.ts
+++ b/src/slidedown/ChannelCaptureContainer.ts
@@ -259,12 +259,12 @@ export default class ChannelCaptureContainer {
   }
 
   /* S T A T I C */
-  static isEmailInputFieldEmpty(): boolean {
-    return ChannelCaptureContainer.getValueFromEmailInput() === "";
+  isEmailInputFieldEmpty(): boolean {
+    return this.getValueFromEmailInput() === "";
   }
 
-  static isSmsInputFieldEmpty(): boolean {
-    return ChannelCaptureContainer.getValueFromSmsInput() === "";
+  isSmsInputFieldEmpty(): boolean {
+    return this.getValueFromSmsInput() === "";
   }
 
   static showSmsInputError(state: boolean): void {
@@ -329,14 +329,13 @@ export default class ChannelCaptureContainer {
     }
   }
 
-  static getValueFromEmailInput(): string {
+  getValueFromEmailInput(): string {
     const inputNode = getDomElementOrStub(`#${CHANNEL_CAPTURE_CONTAINER_CSS_IDS.onesignalEmailInput}`);
     return (<HTMLInputElement>inputNode)?.value || "";
   }
 
-  static getValueFromSmsInput(): string {
-    const inputNode = getDomElementOrStub(`#${CHANNEL_CAPTURE_CONTAINER_CSS_IDS.onesignalSmsInput}`);
-    return (<HTMLInputElement>inputNode)?.value || "";
+  getValueFromSmsInput(): string {
+    return this.itiOneSignal.getNumber(intlTelInputUtils.numberFormat.E164) || "";
   }
 
   static validateEmailInputWithReturnVal(emailString?: string): boolean {


### PR DESCRIPTION
# Description
## 1 Line Summary
The returned value from SMS from the WebPrompt code give us the input instead of a e164 formatted number which is required by the OneSignal API.

## Details
See `getNumber` in [intl-tel-input docs](https://github.com/jackocnr/intl-tel-input#public-methods) for details on the method used in this PR.

# Validation
* Test both SMS and SMSAndEmail prompts to ensure we now have the correct format.
## Tests
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X} New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`
       - Added additional lines accessing "OneSignal" to keep existing pattern in this file.

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed
       - No visual changes.

---

## Related Tickets

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/809)
<!-- Reviewable:end -->
