### PR TITLE
Feat: WebPrompts - fix reshow web prompts bug

### DIFF
--- a/src/errors/ExistingChannelError.ts
+++ b/src/errors/ExistingChannelError.ts
@@ -1,0 +1,15 @@
+import { DelayedPromptType } from '../models/Prompts';
+import OneSignalError from './OneSignalError';
+
+export default class ExistingChannelError extends OneSignalError {
+  constructor(type: DelayedPromptType) {
+    super(`This operation can only be performed when the channel '${type}' does not yet exist.`);
+
+    /**
+     * Important! Required to make sure the correct error type is detected during instanceof checks.
+     * Same applies to all derived classes.
+     * https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+     */
+    Object.setPrototypeOf(this, ExistingChannelError.prototype);
+  }
+}

--- a/src/managers/PromptsManager.ts
+++ b/src/managers/PromptsManager.ts
@@ -210,7 +210,7 @@ export class PromptsManager {
       PromptsHelper.getFirstSlidedownPromptOptionsWithType(prompts, typeToPullFromConfig);
 
     if (!slidedownPromptOptions) {
-      Log.error(`OneSignal: slidedown of type '${typeToPullFromConfig} couldn't be shown. Check your configuration`+
+      Log.error(`OneSignal: slidedown of type '${typeToPullFromConfig}' couldn't be shown. Check your configuration`+
         ` on the OneSignal dashboard or your custom code initialization.`);
       return;
     }


### PR DESCRIPTION
# Description
## 1 Line Summary
If the channel is already "subscribed", do not allow re-showing of the slidedown for now.

--- 

Since the dismiss key-value auto-erases based on the back-off logic, `autoPrompt: true` would result in the prompt re-showing even though the end-user may already have inputted their info.

Instead, we go based off of whether the non-push channel is already "subscribed", similar to how the push-dependent slidedown logic is done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/811)
<!-- Reviewable:end -->
