### PR TITLE
Use persisted external user id for player create

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -534,13 +534,8 @@ export default class OneSignal {
   public static async removeExternalUserId(): Promise<void> {
     await awaitOneSignalInitAndSupported();
     logMethodCall("removeExternalUserId");
-    const isExistingUser = await this.context.subscriptionManager.isAlreadyRegisteredWithOneSignal();
-    if (!isExistingUser) {
-      Log.warn("User is not subscribed, cannot remove external user id.");
-      return;
-    }
-    await OneSignal.context.updateManager.sendExternalUserIdUpdate(undefined),
-    await OneSignal.database.setExternalUserId(undefined);
+
+    await OneSignal.privateSetExternalUserId(undefined);
   }
 
   /**

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -500,6 +500,13 @@ export default class OneSignal {
     await awaitOneSignalInitAndSupported();
     logMethodCall("setExternalUserId");
 
+    await OneSignal.privateSetExternalUserId(externalUserId, authHash);
+  }
+
+  private static async privateSetExternalUserId(
+    externalUserId: string | undefined | null,
+    authHash?: string,
+  ): Promise<void> {
     AuthHashOptionsValidatorHelper.throwIfInvalidAuthHash(authHash, "authHash");
 
     await OneSignal.database.setExternalUserId(externalUserId, authHash);

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -502,15 +502,14 @@ export default class OneSignal {
 
     AuthHashOptionsValidatorHelper.throwIfInvalidAuthHash(authHash, "authHash");
 
+    await OneSignal.database.setExternalUserId(externalUserId, authHash);
+
     const isExistingUser = await this.context.subscriptionManager.isAlreadyRegisteredWithOneSignal();
     if (!isExistingUser) {
       await awaitSdkEvent(OneSignal.EVENTS.REGISTERED);
     }
 
-    const response = await OneSignal.context.updateManager.sendExternalUserIdUpdate(externalUserId, authHash);
-    if (response && response.success) {
-      OneSignal.database.setExternalUserId(externalUserId, authHash);
-    }
+    await OneSignal.context.updateManager.sendExternalUserIdUpdate(externalUserId, authHash);
   }
 
    /**

--- a/src/helpers/shared/ExternalUserIdHelper.ts
+++ b/src/helpers/shared/ExternalUserIdHelper.ts
@@ -1,0 +1,17 @@
+import { DeviceRecord } from "../../models/DeviceRecord";
+import Database from "../../services/Database";
+
+export class ExternalUserIdHelper {
+  static async addExternalUserIdToDeviceRecord(deviceRecord: DeviceRecord): Promise<void> {
+    const externalUserId = await Database.getExternalUserId();
+    if (!externalUserId) {
+      return;
+    }
+    deviceRecord.externalUserId = externalUserId;
+
+    const externalUserIdAuthHash = await Database.getExternalUserIdAuthHash();
+    if (externalUserIdAuthHash) {
+      deviceRecord.externalUserIdAuthHash = externalUserIdAuthHash;
+    }
+  }
+}

--- a/src/managers/UpdateManager.ts
+++ b/src/managers/UpdateManager.ts
@@ -11,6 +11,7 @@ import { SessionOrigin } from "../models/Session";
 import { OutcomeRequestData } from "../models/OutcomeRequestData";
 import { logMethodCall } from '../utils';
 import { UpdatePlayerExternalUserId } from "../models/UpdatePlayerOptions";
+import { ExternalUserIdHelper } from "../helpers/shared/ExternalUserIdHelper";
 
 export class UpdateManager {
   private context: ContextSWInterface;
@@ -93,6 +94,7 @@ export class UpdateManager {
   }
 
   public async sendPlayerCreate(deviceRecord: PushDeviceRecord): Promise<string | undefined> {
+    await ExternalUserIdHelper.addExternalUserIdToDeviceRecord(deviceRecord);
     try {
       const deviceId = await OneSignalApiShared.createUser(deviceRecord);
       if (deviceId) {

--- a/src/managers/channelManager/shared/updaters/SecondaryChannelIdentifierUpdater.ts
+++ b/src/managers/channelManager/shared/updaters/SecondaryChannelIdentifierUpdater.ts
@@ -1,3 +1,4 @@
+import { ExternalUserIdHelper } from "../../../../helpers/shared/ExternalUserIdHelper";
 import { SecondaryChannelDeviceRecord } from "../../../../models/SecondaryChannelDeviceRecord";
 import OneSignalApi from "../../../../OneSignalApi";
 import Database from "../../../../services/Database";
@@ -31,6 +32,8 @@ export class SecondaryChannelIdentifierUpdater {
         deviceId,
       );
       deviceRecord.appId = appConfig.appId;
+      await ExternalUserIdHelper.addExternalUserIdToDeviceRecord(deviceRecord);
+
       newProfile.subscriptionId = await OneSignalApi.createUser(deviceRecord);
     }
 

--- a/src/models/DeviceRecord.ts
+++ b/src/models/DeviceRecord.ts
@@ -18,6 +18,8 @@ export interface FlattenedDeviceRecord {
   device_model: string;
   // TODO: Make it a required parameter
   app_id?: string;
+  external_user_id?: string;
+  external_user_id_auth_hash?: string;
 }
 
 /**
@@ -35,6 +37,8 @@ export abstract class DeviceRecord implements Serializable {
   public sdkVersion: string;
   public appId: string | undefined;
   public subscriptionState: SubscriptionStateKind | undefined;
+  public externalUserId?: string;
+  public externalUserIdAuthHash?: string;
 
   constructor() {
     // TODO: Possible implementation for appId initialization
@@ -83,6 +87,14 @@ export abstract class DeviceRecord implements Serializable {
 
     if (this.appId) {
       serializedBundle.app_id = this.appId;
+    }
+
+    if (this.externalUserId) {
+      serializedBundle.external_user_id = this.externalUserId;
+    }
+
+    if (this.externalUserIdAuthHash) {
+      serializedBundle.external_user_id_auth_hash = this.externalUserIdAuthHash;
     }
 
     return serializedBundle;

--- a/test/unit/managers/UpdateManager.ts
+++ b/test/unit/managers/UpdateManager.ts
@@ -14,6 +14,7 @@ import { NotificationPermission } from "../../../src/models/NotificationPermissi
 import {
   markUserAsSubscribed, stubServiceWorkerInstallation 
 } from "../../support/tester/sinonSandboxUtils";
+import { DeviceRecord } from "../../../src/models/DeviceRecord";
 
 // manually create and restore the sandbox
 const sandbox: SinonSandbox = sinon.sandbox.create();
@@ -176,6 +177,17 @@ test("sendPlayerCreate returns user id", async t => {
   await OneSignal.context.updateManager.sendPlayerCreate(deviceRecord);
   t.is(onCreateSpy.called, true);
   t.is(OneSignal.context.updateManager.onSessionAlreadyCalled(), true);
+});
+
+test("sendPlayerCreate, includes external_user_id when calling createUser", async t => {
+  const EXTERNAL_USER_ID_TEST_VALUE = '1234';
+  sandbox.stub(Database, "getExternalUserId").resolves(EXTERNAL_USER_ID_TEST_VALUE);
+  const onCreateSpy = sandbox.stub(OneSignalApiShared, "createUser").resolves(Random.getRandomUuid());
+
+  await OneSignal.context.updateManager.sendPlayerCreate(new PushDeviceRecord());
+
+  const deviceRecordSet: DeviceRecord = onCreateSpy.getCall(0).args[0];
+  t.is(deviceRecordSet.externalUserId, EXTERNAL_USER_ID_TEST_VALUE);
 });
 
 test("sendExternalUserIdUpdate makes an api call with the provided external user id", async t => {

--- a/test/unit/public-sdk-apis/externalUserId.ts
+++ b/test/unit/public-sdk-apis/externalUserId.ts
@@ -42,6 +42,21 @@ test("setExternalUserId - executes after OneSignal is fully initialized", async 
   t.is(updateManagerSpy.calledOnce, true);
 });
 
+test("setExternalUserId - saves external user id to DB before awaiting for push registration", async t => {
+  const awaitSdkEventSpy = sinonSandbox.stub(Utils, "awaitSdkEvent");
+  sinonSandbox.stub(OneSignal.context.subscriptionManager, "isAlreadyRegisteredWithOneSignal").resolves(false);
+  const databaseSpy = sinonSandbox.stub(OneSignal.database, "setExternalUserId").resolves();
+  sinonSandbox.stub(OneSignal.context.updateManager, "sendExternalUserIdUpdate").resolves({
+    success: true
+  });
+
+  const promise = (OneSignal as any).privateSetExternalUserId(externalUserId);
+  t.is(databaseSpy.calledOnce, true);
+
+  awaitSdkEventSpy.resolves();
+  await promise;
+});
+
 test("setExternalUserId - does not execute until user is registered with OneSignal", async t => {
   const awaitSdkEventSpy = sinonSandbox.stub(Utils, "awaitSdkEvent");
   sinonSandbox.stub(OneSignal.context.subscriptionManager, "isAlreadyRegisteredWithOneSignal").resolves(false);

--- a/test/unit/public-sdk-apis/setExternalUserIdWithSecondaryChannel.ts
+++ b/test/unit/public-sdk-apis/setExternalUserIdWithSecondaryChannel.ts
@@ -64,3 +64,26 @@ test("setExternalUserId before email, makes PUT call to update Email record", as
     TEST_EXTERNAL_USER_ID
   );
 });
+
+test("setExternalUserId before email, includes external_user_id in POST create call", async t => {
+  // 1. Create a push player id in the DB
+  const pushPlayerId = await setupFakePlayerId();
+
+  // 2. Nock out push player set external user id, ignore it
+  NockOneSignalHelper.nockPlayerPut(pushPlayerId);
+
+  // 3. Call OneSignal.setExternalUserId
+  OneSignal.setExternalUserId(TEST_EXTERNAL_USER_ID);
+
+  // 4. Nock out parent_player_id update for push player, ignore it
+  NockOneSignalHelper.nockPlayerPut(pushPlayerId);
+
+  // 5. Call OneSignal.setEmail and get the returned playerId from the POST call.
+  const emailPostNock = NockOneSignalHelper.nockPlayerPost();
+  OneSignal.setEmail(TEST_EMAIL_ADDRESS);
+
+  t.is(
+    (await emailPostNock.result).request.body.external_user_id,
+    TEST_EXTERNAL_USER_ID
+  );
+});


### PR DESCRIPTION
# Description
## 1 Line Summary
If `OneSignal.externalUserId` is called on a different page before the user subscribes (to push, email, or sms) ensure we set it on the subscription.

## Details
This PR fixes the following scenario:
1. OneSignal.setExternalUserId is called.
2. Page is reloaded
3. OneSignal.setEmail (or any player create happens).
4. external_user_id is never set on the player.
* In this commit we are now sending external_user_id on /player create
REST API to cover this scenario.

# Validation
## Tests
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/812)
<!-- Reviewable:end -->
