### PR TITLE
WebPrompts - Fixes issue where we weren't awaiting on the confirmation toast

### DIFF
--- a/src/managers/slidedownManager/SlidedownManager.ts
+++ b/src/managers/slidedownManager/SlidedownManager.ts
@@ -302,7 +302,7 @@ export class SlidedownManager {
       slidedown.close();
 
       if (!PromptsHelper.isSlidedownPushDependent(slidedownType)) {
-        this.showConfirmationToast();
+        await this.showConfirmationToast();
       }
       // timeout to allow slidedown close animation to finish in case another slidedown is queued
       await awaitableTimeout(1000);


### PR DESCRIPTION
# Description
## 1 Line Summary
Await allows the full confirmation toast animation to show and hide before dequeuing any subsequent slide downs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/813)
<!-- Reviewable:end -->
