### PR TITLE
Use the prompt-specific icon OR the app default icon

### DIFF
--- a/src/slidedown/Slidedown.ts
+++ b/src/slidedown/Slidedown.ts
@@ -87,7 +87,8 @@ export default class Slidedown {
       const messageText = isInUpdateMode && !!this.tagCategories ?
         this.updateMessage : this.options.text.actionMessage;
 
-      const icon = this.getPlatformNotificationIcon();
+      // use the prompt-specific icon OR the app default icon
+      const icon = this.options.icon || this.getPlatformNotificationIcon();
       const slidedownElement = getSlidedownElement({
         messageText,
         icon,


### PR DESCRIPTION
Motivation: fixes bug that was ignoring the prompt-specific icon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/816)
<!-- Reviewable:end -->
