### PR TITLE
Fix/allow set external user id for secondary channels, without push

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -508,14 +508,7 @@ export default class OneSignal {
     authHash?: string,
   ): Promise<void> {
     AuthHashOptionsValidatorHelper.throwIfInvalidAuthHash(authHash, "authHash");
-
     await OneSignal.database.setExternalUserId(externalUserId, authHash);
-
-    const isExistingUser = await this.context.subscriptionManager.isAlreadyRegisteredWithOneSignal();
-    if (!isExistingUser) {
-      await awaitSdkEvent(OneSignal.EVENTS.REGISTERED);
-    }
-
     await OneSignal.context.updateManager.sendExternalUserIdUpdate(externalUserId, authHash);
   }
 

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -163,7 +163,7 @@ export class SubscriptionManager {
 
     let newDeviceId: string | undefined = undefined;
     if (await this.isAlreadyRegisteredWithOneSignal()) {
-      await this.context.updateManager.sendPlayerUpdate(deviceRecord);
+      await this.context.updateManager.sendPushDeviceRecordUpdate(deviceRecord);
     } else {
       newDeviceId = await this.context.updateManager.sendPlayerCreate(deviceRecord);
       if (newDeviceId) {

--- a/src/managers/UpdateManager.ts
+++ b/src/managers/UpdateManager.ts
@@ -35,7 +35,7 @@ export class UpdateManager {
     return MainHelper.createDeviceRecord(this.context.appConfig.appId);
   }
 
-  public async sendPlayerUpdate(deviceRecord?: PushDeviceRecord): Promise<void> {
+  public async sendPushDeviceRecordUpdate(deviceRecord?: PushDeviceRecord): Promise<void> {
     const existingUser = await this.context.subscriptionManager.isAlreadyRegisteredWithOneSignal();
     if (!existingUser) {
       Log.debug("Not sending the update because user is not registered with OneSignal (no device id)");

--- a/src/managers/UpdateManager.ts
+++ b/src/managers/UpdateManager.ts
@@ -9,8 +9,8 @@ import { ContextSWInterface } from '../models/ContextSW';
 import Utils from "../context/shared/utils/Utils";
 import { SessionOrigin } from "../models/Session";
 import { OutcomeRequestData } from "../models/OutcomeRequestData";
-import { logMethodCall } from '../utils';
-import { UpdatePlayerExternalUserId } from "../models/UpdatePlayerOptions";
+import { awaitSdkEvent, logMethodCall } from '../utils';
+import { UpdatePlayerExternalUserId, UpdatePlayerOptions } from "../models/UpdatePlayerOptions";
 import { ExternalUserIdHelper } from "../helpers/shared/ExternalUserIdHelper";
 
 export class UpdateManager {
@@ -21,6 +21,10 @@ export class UpdateManager {
   constructor(context: ContextSWInterface) {
     this.context = context;
     this.onSessionSent = context.pageViewManager.getPageViewCount() > 1;
+  }
+
+  private async isDeviceIdAvailable(): Promise<boolean> {
+    return (await Database.getSubscription()).deviceId != null;
   }
 
   private async getDeviceId(): Promise<string> {
@@ -118,16 +122,14 @@ export class UpdateManager {
 
   public async sendExternalUserIdUpdate(externalUserId: string | undefined | null, authHash?: string | null )
   :Promise<any> {
-    const deviceId: string = await this.getDeviceId();
-
     if (!authHash) {
       authHash = await Database.getExternalUserIdAuthHash();
     }
 
-    const payload = {
+    const payload: UpdatePlayerExternalUserId = {
       external_user_id: Utils.getValueOrDefault(externalUserId, ""),
       external_user_id_auth_hash: Utils.getValueOrDefault(authHash, undefined)
-    } as UpdatePlayerExternalUserId;
+    };
 
     // 1. Update any secondary channels such as email with external_user_id
     // Not awaiting as this may never complete, as promise only completes if we have a player record for each channel.
@@ -139,7 +141,24 @@ export class UpdateManager {
     /* tslint:enable:no-floating-promises */
 
     // 2. Update push player with external_user_id
-    return await OneSignalApiShared.updatePlayer(this.context.appConfig.appId, deviceId, payload);
+    const pushUpdatePromise = this.sendPushPlayerUpdate(payload);
+    if (await this.isDeviceIdAvailable()) {
+      await pushUpdatePromise;
+    }
+  }
+
+  // Send REST API payload to update the push player record.
+  // Await until we have a push playerId, which is require to make a PUT call.
+  private async sendPushPlayerUpdate(payload: UpdatePlayerOptions): Promise<void> {
+    let { deviceId } = await Database.getSubscription();
+    if (!deviceId) {
+      await awaitSdkEvent(OneSignal.EVENTS.REGISTERED);
+      ({ deviceId } = await Database.getSubscription());
+    }
+
+    if (deviceId) {
+      return await OneSignalApiShared.updatePlayer(this.context.appConfig.appId, deviceId, payload);
+    }
   }
 
   public async sendOutcomeDirect(appId: string, notificationIds: string[], outcomeName: string, value?: number) {

--- a/test/unit/managers/SubscriptionManager.ts
+++ b/test/unit/managers/SubscriptionManager.ts
@@ -295,7 +295,7 @@ test("registerSubscription with an existing subsription sends player update", as
   sandbox.stub(SubscriptionManager, "isSafari").returns(false);
   sandbox.stub(Database, "setSubscription").resolves();
 
-  const playerUpdateSpy = sandbox.stub(OneSignal.context.updateManager, "sendPlayerUpdate");
+  const playerUpdateSpy = sandbox.stub(OneSignal.context.updateManager, "sendPushDeviceRecordUpdate");
   const playerCreateSpy = sandbox.stub(OneSignal.context.updateManager, "sendPlayerCreate");
 
   await subscriptionManager.registerSubscription(pushSubscription)
@@ -332,7 +332,7 @@ test("registerSubscription without an existing subsription sends player create",
   sandbox.stub(SubscriptionManager, "isSafari").returns(false);
   sandbox.stub(Database, "setSubscription").resolves();
 
-  const playerUpdateSpy = sandbox.stub(OneSignal.context.updateManager, "sendPlayerUpdate");
+  const playerUpdateSpy = sandbox.stub(OneSignal.context.updateManager, "sendPushDeviceRecordUpdate");
   const playerCreateSpy = sandbox.stub(OneSignal.context.updateManager, "sendPlayerCreate");
 
   await subscriptionManager.registerSubscription(pushSubscription)
@@ -370,7 +370,7 @@ test('device ID is available after register event', async t => {
     });
   });
 
-  const playerUpdateStub = sandbox.stub(OneSignal.context.updateManager, "sendPlayerUpdate").resolves();
+  const playerUpdateStub = sandbox.stub(OneSignal.context.updateManager, "sendPushDeviceRecordUpdate").resolves();
   const playerCreateStub = sandbox.stub(OneSignal.context.updateManager, "sendPlayerCreate").resolves(randomPlayerId);
 
   await OneSignal.context.subscriptionManager.registerSubscription(rawPushSubscription);
@@ -388,7 +388,7 @@ test('safari 11.1+ with service worker but not pushManager', async t => {
     pushManager: null,
   };
   await TestEnvironment.mockInternalOneSignal();
-  
+
   sandbox.stub(SdkEnvironment, "getIntegration").returns(IntegrationKind.Secure);
   sandbox.stub(SdkEnvironment, "getWindowEnv").returns(WindowEnvironmentKind.ServiceWorker);
   sandbox.stub(navigator.serviceWorker, "getRegistration").returns(serviceWorkerRegistration);

--- a/test/unit/managers/UpdateManager.ts
+++ b/test/unit/managers/UpdateManager.ts
@@ -193,8 +193,8 @@ test("sendPlayerCreate, includes external_user_id when calling createUser", asyn
 test("sendExternalUserIdUpdate makes an api call with the provided external user id", async t => {
   const deviceId = Random.getRandomUuid();
   const externalUserId = "external_email@example.com";
-  
-  sandbox.stub(OneSignal.context.updateManager, "getDeviceId").resolves(deviceId);
+
+  sandbox.stub(Database, "getSubscription").resolves({ deviceId });
   const updatePlayerSpy = sandbox.stub(OneSignalApiShared, "updatePlayer");
   await OneSignal.context.updateManager.sendExternalUserIdUpdate(externalUserId);
 

--- a/test/unit/managers/UpdateManager.ts
+++ b/test/unit/managers/UpdateManager.ts
@@ -31,18 +31,18 @@ test.afterEach(function () {
   sandbox.restore();
 });
 
-test("sendPlayerUpdate doesn't do anything for new users", async t => {
+test("sendPushDeviceRecordUpdate doesn't do anything for new users", async t => {
   sandbox.stub(Database, "getSubscription").resolves({ deviceId: undefined });
   const playerUpdateAPISpy = sandbox.stub(OneSignalApiShared, "updatePlayer");
   const onSessionSpy = sandbox.stub(OneSignal.context.sessionManager, "upsertSession");
 
-  await OneSignal.context.updateManager.sendPlayerUpdate();
+  await OneSignal.context.updateManager.sendPushDeviceRecordUpdate();
 
   t.is(playerUpdateAPISpy.called, false);
   t.is(onSessionSpy.called, false);
 });
 
-test("sendPlayerUpdate sends on_session if on_session hasn't been sent before", async t => {
+test("sendPushDeviceRecordUpdate sends on_session if on_session hasn't been sent before", async t => {
   markUserAsSubscribed(sandbox);
   stubServiceWorkerInstallation(sandbox);
 
@@ -54,15 +54,15 @@ test("sendPlayerUpdate sends on_session if on_session hasn't been sent before", 
 
   t.is(OneSignal.context.updateManager.onSessionAlreadyCalled(), false);
 
-  await OneSignal.context.updateManager.sendPlayerUpdate();
+  await OneSignal.context.updateManager.sendPushDeviceRecordUpdate();
 
   t.is(playerUpdateAPISpy.called, false);
   t.is(onSessionSpy.callCount, 1);
 });
 
-test("sendPlayerUpdate sends playerUpdate if on_session has already been sent", async t => {
+test("sendPushDeviceRecordUpdate sends playerUpdate if on_session has already been sent", async t => {
   sandbox.stub(Database, "getSubscription").resolves({ deviceId: Random.getRandomUuid() });
-  
+
   OneSignal.context.pageViewManager.setPageViewCount(2);
   OneSignal.context.updateManager = new UpdateManager(OneSignal.context);
 
@@ -71,7 +71,7 @@ test("sendPlayerUpdate sends playerUpdate if on_session has already been sent", 
   const playerUpdateAPISpy = sandbox.stub(OneSignalApiShared, "updatePlayer").resolves();
   const onSessionSpy = sandbox.stub(OneSignal.context.sessionManager, "upsertSession").resolves();
 
-  await OneSignal.context.updateManager.sendPlayerUpdate();
+  await OneSignal.context.updateManager.sendPushDeviceRecordUpdate();
 
   t.is(playerUpdateAPISpy.calledOnce, true);
   t.is(onSessionSpy.called, false);
@@ -79,7 +79,7 @@ test("sendPlayerUpdate sends playerUpdate if on_session has already been sent", 
 
 test("sendOnSessionUpdate doesn't trigger on_session call if already did so", async t => {
   sandbox.stub(Database, "getSubscription").resolves({ deviceId: Random.getRandomUuid() });
-  
+
   OneSignal.context.pageViewManager.setPageViewCount(2);
   OneSignal.context.updateManager = new UpdateManager(OneSignal.context);
   const onSessionSpy = sandbox.stub(OneSignal.context.sessionManager, "upsertSession");

--- a/test/unit/public-sdk-apis/onSession.ts
+++ b/test/unit/public-sdk-apis/onSession.ts
@@ -364,7 +364,7 @@ test.serial(`HTTPS: User subscribed => first page view => expiring subscription 
   // Using spy instead of stub here is intended. Spy does callThrough, i.e. executes underlying function, by default
   //  while stub prevents the actual execution.
   // Workaround with stubs would be `sinon.stub(object, "method", object.method);`
-  const playerUpdateStub = sinonSandbox.spy(UpdateManager.prototype, "sendPlayerUpdate");
+  const playerUpdateStub = sinonSandbox.spy(UpdateManager.prototype, "sendPushDeviceRecordUpdate");
   await markUserAsSubscribed(sinonSandbox, playerId, true);
   stubServiceWorkerInstallation(sinonSandbox);
 

--- a/test/unit/public-sdk-apis/setExternalUserIdWithSecondaryChannel.ts
+++ b/test/unit/public-sdk-apis/setExternalUserIdWithSecondaryChannel.ts
@@ -13,7 +13,7 @@ test.beforeEach(async _t => {
   await Database.put('Ids', { type: 'appId', id: OneSignal.context.appConfig.appId });
 });
 
-test("setExternalUserId after email, makes PUT call to update Email record", async t => {
+test("setExternalUserId after email, w/ push player, makes PUT call to update Email record", async t => {
   // 1. Nock out email create
   const emailPostNock = NockOneSignalHelper.nockPlayerPost();
   await OneSignal.setEmail(TEST_EMAIL_ADDRESS);
@@ -46,7 +46,7 @@ test("setExternalUserId before email, makes PUT call to update Email record", as
   NockOneSignalHelper.nockPlayerPut(pushPlayerId);
 
   // 3. Call OneSignal.setExternalUserId
-  OneSignal.setExternalUserId(TEST_EXTERNAL_USER_ID);
+  await OneSignal.setExternalUserId(TEST_EXTERNAL_USER_ID);
 
   // 4. Nock out parent_player_id update for push player, ignore it
   // TODO: This is repeated again here. Can we just ignore all player PUT requests to the push player?
@@ -73,19 +73,24 @@ test("setExternalUserId before email, includes external_user_id in POST create c
   NockOneSignalHelper.nockPlayerPut(pushPlayerId);
 
   // 3. Call OneSignal.setExternalUserId
-  OneSignal.setExternalUserId(TEST_EXTERNAL_USER_ID);
+  await OneSignal.setExternalUserId(TEST_EXTERNAL_USER_ID);
 
   // 4. Nock out parent_player_id update for push player, ignore it
   NockOneSignalHelper.nockPlayerPut(pushPlayerId);
 
   // 5. Call OneSignal.setEmail and get the returned playerId from the POST call.
   const emailPostNock = NockOneSignalHelper.nockPlayerPost();
-  OneSignal.setEmail(TEST_EMAIL_ADDRESS);
+  const setEmailPromise = OneSignal.setEmail(TEST_EMAIL_ADDRESS);
 
   t.is(
     (await emailPostNock.result).request.body.external_user_id,
     TEST_EXTERNAL_USER_ID
   );
+
+  // 6. Nock out PUT call for external_user_id on emailId, and wait promise so
+  //    we don't have test carry over.
+  NockOneSignalHelper.nockPlayerPut((await emailPostNock.result).response.body.id);
+  await setEmailPromise;
 });
 
 test("setExternalUserId after email, w/o push player, makes PUT call to update Email record", async t => {

--- a/test/unit/public-sdk-apis/setExternalUserIdWithSecondaryChannel.ts
+++ b/test/unit/public-sdk-apis/setExternalUserIdWithSecondaryChannel.ts
@@ -87,3 +87,23 @@ test("setExternalUserId before email, includes external_user_id in POST create c
     TEST_EXTERNAL_USER_ID
   );
 });
+
+test("setExternalUserId after email, w/o push player, makes PUT call to update Email record", async t => {
+  // 1. Nock out email create
+  const emailPostNock = NockOneSignalHelper.nockPlayerPost();
+  await OneSignal.setEmail(TEST_EMAIL_ADDRESS);
+  const emailPlayerId = (await emailPostNock.result).response.body.id;
+
+  // 2. Call OneSignal.setExternalUserId
+  const externalUserIdUpdateOnEmail = NockOneSignalHelper.nockPlayerPut(emailPlayerId);
+  await OneSignal.setExternalUserId(TEST_EXTERNAL_USER_ID);
+
+  // 3. Ensure we made a PUT call and it includes the external_user_id we just set above.
+  t.deepEqual(
+    (await externalUserIdUpdateOnEmail.result).request.body,
+    {
+      app_id: OneSignal.context.appConfig.appId,
+      external_user_id: TEST_EXTERNAL_USER_ID
+    }
+  );
+});


### PR DESCRIPTION
# Description
## 1 Line Summary
Fixes limitation where setExternalUserId did not work for email or SMS unless the user also accepted push.

## Details
* Moved logic from OneSignal.privateSetExternalUserId to UpdateManager, this way it can encapsulate push and secondary channels. 
* Review commit-by-commit for more details.

# Validation
## Tests
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed
      - No visual changes

---

## Related Tickets

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/817)
<!-- Reviewable:end -->
