### PR TITLE
Move sendTags logic into UpdateManager

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -440,23 +440,8 @@ export default class OneSignal {
       if (tags[key] === false)
         tags[key] = "false";
     });
-    const { appId } = await Database.getAppConfig();
 
-    this.context.secondaryChannelManager.synchronizer.setTags(tags);
-
-    const { deviceId } = await Database.getSubscription();
-    if (!deviceId) {
-      await awaitSdkEvent(OneSignal.EVENTS.REGISTERED);
-    }
-    // After the user subscribes, he will have a device ID, so get it again
-    const { deviceId: newDeviceId } = await Database.getSubscription();
-    const authHash = await Database.getExternalUserIdAuthHash();
-    const options : UpdatePlayerOptions = { tags };
-
-    if (!!authHash) {
-      options.external_user_id_auth_hash = authHash;
-    }
-    await OneSignalApi.updatePlayer(appId, newDeviceId!, options);
+    await this.context.updateManager.sendTagsUpdate(tags);
     executeCallback(callback, tags);
     return tags;
   }

--- a/src/managers/UpdateManager.ts
+++ b/src/managers/UpdateManager.ts
@@ -12,6 +12,7 @@ import { OutcomeRequestData } from "../models/OutcomeRequestData";
 import { awaitSdkEvent, logMethodCall } from '../utils';
 import { UpdatePlayerExternalUserId, UpdatePlayerOptions } from "../models/UpdatePlayerOptions";
 import { ExternalUserIdHelper } from "../helpers/shared/ExternalUserIdHelper";
+import { TagsObject } from "../models/Tags";
 
 export class UpdateManager {
   private context: ContextSWInterface;
@@ -142,6 +143,21 @@ export class UpdateManager {
 
     // 2. Update push player with external_user_id
     const pushUpdatePromise = this.sendPushPlayerUpdate(payload);
+    if (await this.isDeviceIdAvailable()) {
+      await pushUpdatePromise;
+    }
+  }
+
+  public async sendTagsUpdate(tags: TagsObject<any>): Promise<void> {
+    this.context.secondaryChannelManager.synchronizer.setTags(tags);
+
+    const options: UpdatePlayerOptions = { tags };
+    const authHash = await Database.getExternalUserIdAuthHash();
+    if (!!authHash) {
+      options.external_user_id_auth_hash = authHash;
+    }
+
+    const pushUpdatePromise = this.sendPushPlayerUpdate(options);
     if (await this.isDeviceIdAvailable()) {
       await pushUpdatePromise;
     }


### PR DESCRIPTION
# Description
## 1 Line Summary
Match the same change we did recently for sendExternalUserIdUpdate in PR #817. This doesn't change the behavior, so no new tests were added.

## Details

# Validation
## Tests
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/818)
<!-- Reviewable:end -->
