### PR TITLE
Perform build upload for staging branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - BUILD_ORIGIN=${STAGING_DOMAIN} API=staging API_ORIGIN=${STAGING_DOMAIN} yarn build:staging
   # thanks to https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
   - BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-  - if [ "$BRANCH" = "master" ]; then ./.travis/s3-simple-upload-all.sh build/releases s3://onesignal-build/websdk/$TRAVIS_COMMIT && ./.travis/s3-simple-upload-all.sh build/amp s3://onesignal-build/websdk/$TRAVIS_COMMIT && echo Successfully uploaded Web SDK artifacts for version $TRAVIS_COMMIT; else echo Not uploading artifacts for this build; fi
+  - if [[ "$BRANCH" == "master" || "$BRANCH" == "staging" ]]; then ./.travis/s3-simple-upload-all.sh build/releases s3://onesignal-build/websdk/$TRAVIS_COMMIT && ./.travis/s3-simple-upload-all.sh build/amp s3://onesignal-build/websdk/$TRAVIS_COMMIT && echo Successfully uploaded Web SDK artifacts for version $TRAVIS_COMMIT; else echo Not uploading artifacts for this build; fi
 git:
   depth: 5
 env:


### PR DESCRIPTION
# Description
## 1 Line Summary
Performs upload of build files when a travis build is triggered on the branch named "staging".

## Details

# Validation
## Tests
Tested on travisCI and confirmed files are uploaded to S3.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/819)
<!-- Reviewable:end -->
