### PR TITLE
WebPrompts: Fix tabbing and default Enter behavior

### DIFF
--- a/src/slidedown/ChannelCaptureContainer.ts
+++ b/src/slidedown/ChannelCaptureContainer.ts
@@ -148,9 +148,15 @@ export default class ChannelCaptureContainer {
   private addSmsInputEventListeners(): void {
     const smsInput = getDomElementOrStub(`#${CHANNEL_CAPTURE_CONTAINER_CSS_IDS.onesignalSmsInput}`);
 
-    smsInput.addEventListener('keyup', () => {
+    smsInput.addEventListener('keyup', event => {
       this.smsInputFieldIsValid = this.itiOneSignal.isValidNumber() ||
         (<HTMLInputElement>smsInput)?.value === "";
+
+      // enter key
+      if (event.keyCode === 13) {
+        // Trigger the button element with a click
+        document.getElementById(SLIDEDOWN_CSS_IDS.allowButton)?.click();
+      }
 
       this.updateValidationOnSmsInputChange();
     });
@@ -167,9 +173,15 @@ export default class ChannelCaptureContainer {
   private addEmailInputEventListeners(): void {
     const emailInput = getDomElementOrStub(`#${CHANNEL_CAPTURE_CONTAINER_CSS_IDS.onesignalEmailInput}`);
 
-    emailInput.addEventListener('keyup', () => {
+    emailInput.addEventListener('keyup', event => {
       const emailValue = (<HTMLInputElement>emailInput)?.value;
       this.emailInputFieldIsValid = ChannelCaptureContainer.validateEmailInputWithReturnVal(emailValue);
+
+      // enter key
+      if (event.keyCode === 13) {
+        // Trigger the button element with a click
+        document.getElementById(SLIDEDOWN_CSS_IDS.allowButton)?.click();
+      }
 
       this.updateValidationOnEmailInputChange();
     });

--- a/src/slidedown/ChannelCaptureContainer.ts
+++ b/src/slidedown/ChannelCaptureContainer.ts
@@ -17,6 +17,7 @@ interface TypeSpecificVariablePayload {
   inputElementId: string;
   inputClass: string;
   wrappingDivId: string;
+  tabIndex: number;
 }
 
 export default class ChannelCaptureContainer {
@@ -95,8 +96,9 @@ export default class ChannelCaptureContainer {
     labelElement.innerText  = label;
     labelElement.htmlFor    = varPayload.inputElementId;
 
-    inputElement.type  = varPayload.domElementType;
-    inputElement.id    = varPayload.inputElementId;
+    inputElement.type     = varPayload.domElementType;
+    inputElement.id       = varPayload.inputElementId;
+    inputElement.tabIndex = varPayload.tabIndex;
 
     addCssClass(inputElement, varPayload.inputClass);
     addCssClass(wrappingDiv, CHANNEL_CAPTURE_CONTAINER_CSS_CLASSES.inputWithValidationElement);
@@ -119,7 +121,8 @@ export default class ChannelCaptureContainer {
         validationElementId: CHANNEL_CAPTURE_CONTAINER_CSS_IDS.onesignalEmailValidationElement,
         inputElementId: CHANNEL_CAPTURE_CONTAINER_CSS_IDS.onesignalEmailInput,
         inputClass: CHANNEL_CAPTURE_CONTAINER_CSS_CLASSES.onesignalEmailInput,
-        wrappingDivId: CHANNEL_CAPTURE_CONTAINER_CSS_IDS.emailInputWithValidationElement
+        wrappingDivId: CHANNEL_CAPTURE_CONTAINER_CSS_IDS.emailInputWithValidationElement,
+        tabIndex: 1,
       };
     } else if (type === DelayedPromptType.Sms) {
       return {
@@ -128,7 +131,8 @@ export default class ChannelCaptureContainer {
         validationElementId: CHANNEL_CAPTURE_CONTAINER_CSS_IDS.onesignalSmsValidationElement,
         inputElementId: CHANNEL_CAPTURE_CONTAINER_CSS_IDS.onesignalSmsInput,
         inputClass: CHANNEL_CAPTURE_CONTAINER_CSS_CLASSES.onesignalSmsInput,
-        wrappingDivId: CHANNEL_CAPTURE_CONTAINER_CSS_IDS.smsInputWithValidationElement
+        wrappingDivId: CHANNEL_CAPTURE_CONTAINER_CSS_IDS.smsInputWithValidationElement,
+        tabIndex: 2
       };
     } else throw new Error("invalid channel type for input validation");
   }
@@ -152,8 +156,7 @@ export default class ChannelCaptureContainer {
       this.smsInputFieldIsValid = this.itiOneSignal.isValidNumber() ||
         (<HTMLInputElement>smsInput)?.value === "";
 
-      // enter key
-      if (event.keyCode === 13) {
+      if (event.key === "Enter") {
         // Trigger the button element with a click
         document.getElementById(SLIDEDOWN_CSS_IDS.allowButton)?.click();
       }
@@ -177,8 +180,7 @@ export default class ChannelCaptureContainer {
       const emailValue = (<HTMLInputElement>emailInput)?.value;
       this.emailInputFieldIsValid = ChannelCaptureContainer.validateEmailInputWithReturnVal(emailValue);
 
-      // enter key
-      if (event.keyCode === 13) {
+      if (event.key === "Enter") {
         // Trigger the button element with a click
         document.getElementById(SLIDEDOWN_CSS_IDS.allowButton)?.click();
       }


### PR DESCRIPTION
# Description
## 1 Line Summary
This PR improves the behavior related to tabbing order and default Enter key behavior for WebPrompts.

## Details
- Adds enter = submit functionality
- Adds tabbing functionality to allow tabbing through input fields

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed
      - Not needed as this is minor change and easier to test functionally via the browser
      - 
**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed
      - No visual changes

---

## Related Tickets

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/822)
<!-- Reviewable:end -->
