### PR TITLE
Add back clients.claim to fix AMP update issue

### DIFF
--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -91,6 +91,7 @@ export class ServiceWorker {
    * Service worker entry point.
    */
   static run() {
+    self.addEventListener('activate', ServiceWorker.onServiceWorkerActivated);
     self.addEventListener('push', ServiceWorker.onPushReceived);
     self.addEventListener('notificationclose', ServiceWorker.onNotificationClosed);
     self.addEventListener('notificationclick', event => event.waitUntil(ServiceWorker.onNotificationClicked(event)));
@@ -968,6 +969,20 @@ export class ServiceWorker {
       Log.warn(`Failed to open the URL '${url}':`, e);
       return null;
     }
+  }
+
+  /**
+   * Fires when the ServiceWorker can control pages.
+   * REQUIRED: AMP WebPush (amp-web-push v0.1) requires clients.claim()
+   *    - It depends on ServiceWorker having full control of the iframe,
+   *      requirement could be lifted by AMP in the future however.
+   *    - Without this the AMP symptom is the subscribe button does not update
+   *      right after accepting the notification permission from the pop-up.
+   * @param event
+   */
+  static onServiceWorkerActivated(event: ExtendableEvent) {
+    Log.info(`OneSignal Service Worker activated (version ${Environment.version()})`);
+    event.waitUntil(self.clients.claim());
   }
 
   static async onPushSubscriptionChange(event: PushSubscriptionChangeEvent) {


### PR DESCRIPTION
# Description
## 1 Line Summary
Fixes AMP WebPush issue where the subscribe button does not update after accepting notifications from the pop-up window.

## Details
* AMP WebPush (amp-web-push v0.1) requires clients.claim()
*  It depends on ServiceWorker having full control of the iframe,
requirement could be lifted by AMP in the future however.
   - Without this the AMP symptom is the subscribe button does not
    update right after accepting the notification permission from
    the pop-up.

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
      - Tested on a standard WebPush setup to ensure it doesn't cause any regression issues.
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

---

## Related Tickets

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/837)
<!-- Reviewable:end -->
