### PR TITLE
Randomize Confirmed Delivery to 25 second max delay

### DIFF
--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -27,8 +27,11 @@ import ServiceWorkerHelper from "../helpers/ServiceWorkerHelper";
 import { NotificationReceived, NotificationClicked } from "../models/Notification";
 import { cancelableTimeout } from "../helpers/sw/CancelableTimeout";
 import { DeviceRecord } from '../models/DeviceRecord';
+import { awaitableTimeout } from "../utils/AwaitableTimeout";
 
 declare var self: ServiceWorkerGlobalScope & OSServiceWorkerFields;
+
+const MAX_CONFIRMED_DELIVERY_DELAY = 25;
 
 /**
  * The main service worker script fetching and displaying notifications to users in the background even when the client
@@ -354,18 +357,19 @@ export class ServiceWorker {
     if (!hasRequiredParams) {
       return null;
     }
- 
+
     // JSON.stringify() does not include undefined values
     // Our response will not contain those fields here which have undefined values
     const postData = {
-      player_id : deviceId, 
+      player_id : deviceId,
       app_id : appId
     };
-    
+
     Log.debug(`Called %csendConfirmedDelivery(${
       JSON.stringify(notification, null, 4)
     })`, Utils.getConsoleStyle('code'));
-    
+
+    await awaitableTimeout(Math.floor(Math.random() * MAX_CONFIRMED_DELIVERY_DELAY * 1_000));
     return await OneSignalApiBase.put(`notifications/${notification.id}/report_received`, postData);
   }
 

--- a/test/unit/context/sw/ServiceWorker.ts
+++ b/test/unit/context/sw/ServiceWorker.ts
@@ -16,6 +16,7 @@ import { MockPushEvent } from '../../../support/mocks/service-workers/models/Moc
 import { MockPushMessageData } from '../../../support/mocks/service-workers/models/MockPushMessageData';
 import OneSignalUtils from '../../../../src/utils/OneSignalUtils';
 import { setupFakePlayerId } from '../../../support/tester/utils';
+import * as awaitableTimeout from '../../../../src/utils/AwaitableTimeout';
 
 declare var self: MockServiceWorkerGlobalScope;
 
@@ -24,7 +25,6 @@ const appConfig = TestEnvironment.getFakeAppConfig();
 
 test.beforeEach(async function() {
   sandbox = sinon.sandbox.create();
-  
   await TestEnvironment.initializeForServiceWorker();
 
   await Database.setAppConfig(appConfig);
@@ -291,6 +291,7 @@ test('onNotificationClicked - notification PUT Before openWindow', async t => {
  }
 
  test('sendConfirmedDelivery - notification is null - feature flag is y', async t => {
+   sandbox.stub(awaitableTimeout, 'awaitableTimeout');
    const notificationId = null;
    const notificationPutCall = mockNotificationPutCall(notificationId);
    await fakeSetSubscription();
@@ -300,6 +301,7 @@ test('onNotificationClicked - notification PUT Before openWindow', async t => {
  });
 
  test('sendConfirmedDelivery - notification is valid - feature flag is y', async t => {
+  sandbox.stub(awaitableTimeout, 'awaitableTimeout');
   const notificationId = Random.getRandomUuid();
   const notificationPutCall = mockNotificationPutCall(notificationId);
   await fakeSetSubscription();
@@ -309,6 +311,7 @@ test('onNotificationClicked - notification PUT Before openWindow', async t => {
  });
 
  test('sendConfirmedDelivery - notification is valid - feature flag is n', async t => {
+  sandbox.stub(awaitableTimeout, 'awaitableTimeout');
   const notificationId = Random.getRandomUuid();
   const notificationPutCall = mockNotificationPutCall(notificationId);
   await fakeSetSubscription();
@@ -318,6 +321,7 @@ test('onNotificationClicked - notification PUT Before openWindow', async t => {
  });
 
  test('sendConfirmedDelivery - notification is valid - feature flag is undefined', async t => {
+  sandbox.stub(awaitableTimeout, 'awaitableTimeout');
   const notificationId = Random.getRandomUuid();
   const notificationPutCall = mockNotificationPutCall(notificationId);
   await fakeSetSubscription();
@@ -327,6 +331,7 @@ test('onNotificationClicked - notification PUT Before openWindow', async t => {
  });
 
  test('sendConfirmedDelivery - notification is valid - feature flag is null', async t => {
+  sandbox.stub(awaitableTimeout, 'awaitableTimeout');
   const notificationId = Random.getRandomUuid();
   const notificationPutCall = mockNotificationPutCall(notificationId);
   await fakeSetSubscription();


### PR DESCRIPTION
# Description
Add 25 randomized delay to Confirmed Deliveries

## Details
Aim is to lighten load on backend systems

# Systems Affected
   - [x] WebSDK
   - [x] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info
Tests pass

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed
      - Small change, complicated to test

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/841)
<!-- Reviewable:end -->
