### PR TITLE
Move the bell manager function until after knowing whether to show sl…

### DIFF
--- a/src/managers/PromptsManager.ts
+++ b/src/managers/PromptsManager.ts
@@ -3,7 +3,7 @@ import OneSignalUtils from "../utils/OneSignalUtils";
 import { ContextInterface } from "../models/Context";
 import MainHelper from '../helpers/MainHelper';
 import { ResourceLoadState } from '../services/DynamicResourceLoader';
-import Slidedown, { manageNotifyButtonStateWhileSlidedownShows } from '../slidedown/Slidedown';
+import Slidedown from '../slidedown/Slidedown';
 import {
   DelayedPromptOptions,
   AppUserConfigPromptOptions,
@@ -232,7 +232,6 @@ export class PromptsManager {
 
   public installEventHooksForSlidedown(): void {
     this.eventHooksInstalled = true;
-    manageNotifyButtonStateWhileSlidedownShows();
 
     OneSignal.emitter.on(Slidedown.EVENTS.SHOWN, () => {
       this.context.slidedownManager.setIsSlidedownShowing(true);

--- a/src/managers/slidedownManager/SlidedownManager.ts
+++ b/src/managers/slidedownManager/SlidedownManager.ts
@@ -3,7 +3,7 @@ import TaggingContainer from "../../slidedown/TaggingContainer";
 import TagUtils from "../../utils/TagUtils";
 import { ContextInterface } from "../../models/Context";
 import { DelayedPromptType } from "../../models/Prompts";
-import Slidedown from "../../slidedown/Slidedown";
+import Slidedown, { manageNotifyButtonStateWhileSlidedownShows } from "../../slidedown/Slidedown";
 import { AutoPromptOptions } from "../PromptsManager";
 import Log from "../../libraries/Log";
 import { CONFIG_DEFAULTS_SLIDEDOWN_OPTIONS } from "../../config";
@@ -375,6 +375,8 @@ export class SlidedownManager {
       Log.warn("checkIfSlidedownShouldBeShown returned an error", e);
       return;
     }
+
+    manageNotifyButtonStateWhileSlidedownShows();
 
     if (this.isSlidedownShowing) {
       // already showing, enqueue


### PR DESCRIPTION
…idedown

# Description
## 1 Line Summary
this commit moves the function that manages the bell while slidedown shows until later (after we know whether we *should* show the slidedown to begin with

## Details
This fixes an issue where we were still hiding the bell when the slidedown attempted and failed to show (due to being previously dismissed, for example)

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Related Tickets

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/844)
<!-- Reviewable:end -->
