### PR TITLE
Add `device_type` to Confirmed Delivery Request

### DIFF
--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -362,7 +362,8 @@ export class ServiceWorker {
     // Our response will not contain those fields here which have undefined values
     const postData = {
       player_id : deviceId,
-      app_id : appId
+      app_id : appId,
+      device_type: DeviceRecord.prototype.getDeliveryPlatform()
     };
 
     Log.debug(`Called %csendConfirmedDelivery(${

--- a/test/support/tester/NockOneSignalHelper.ts
+++ b/test/support/tester/NockOneSignalHelper.ts
@@ -27,6 +27,30 @@ export interface NockScopeWithResultPromisePlayerPost extends NockScopeWithResul
 }
 
 export class NockOneSignalHelper {
+  static nockNotificationPut(notificationId?: string): NockScopeWithResultPromise {
+    return NockHelper.nockBase({
+      method: "put",
+      baseUrl: "https://onesignal.com",
+      path: `/api/v1/notifications/${notificationId}`,
+      reply: {
+        status: 200,
+        body: { success: true }
+      }
+    });
+  }
+
+  static nockNotificationConfirmedDelivery(notificationId?: string): NockScopeWithResultPromise {
+    return NockHelper.nockBase({
+      method: "put",
+      baseUrl: "https://onesignal.com",
+      path: `/api/v1/notifications/${notificationId}/report_received`,
+      reply: {
+        status: 200,
+        body: { success: true }
+      }
+    });
+  }
+
   /**
    * Call this before a /players POST REST API call to mock it out and capture it's request and response.
    * @returns {NockScopeWithResultPromisePlayerPost} This is a typed response where you can await for a

--- a/test/unit/context/sw/ServiceWorker.ts
+++ b/test/unit/context/sw/ServiceWorker.ts
@@ -17,6 +17,7 @@ import { MockPushMessageData } from '../../../support/mocks/service-workers/mode
 import OneSignalUtils from '../../../../src/utils/OneSignalUtils';
 import { setupFakePlayerId } from '../../../support/tester/utils';
 import * as awaitableTimeout from '../../../../src/utils/AwaitableTimeout';
+import { NockOneSignalHelper } from '../../../../test/support/tester/NockOneSignalHelper';
 
 declare var self: MockServiceWorkerGlobalScope;
 
@@ -115,7 +116,7 @@ test('onPushReceived - Ensure display when only required values', async t => {
  * displayNotification()
  ****************************************************/
 
-  
+
 // Start - displayNotification - persistNotification
 test('displayNotification - persistNotification - true', async t => {
   setUserAgent(BrowserUserAgent.ChromeWindowsSupported);
@@ -172,22 +173,20 @@ test('onNotificationClicked - notification click sends PUT api/v1/notification',
   const playerId = await setupFakePlayerId();
   const notificationId = Random.getRandomUuid();
 
-  const notificationPutCall = nock("https://onesignal.com")
-    .put(`/api/v1/notifications/${notificationId}`)
-    .reply(200, (_uri: string, requestBody: string) => {
-      t.deepEqual(JSON.parse(requestBody), {
-        app_id: appConfig.appId,
-        opened: true,
-        player_id: playerId,
-        device_type: 5
-      });
-      return { success: true };
-    });
+  const notificationPutNock = NockOneSignalHelper.nockNotificationPut(notificationId);
 
   const notificationEvent = mockNotificationNotificationEventInit(notificationId);
   await OSServiceWorker.onNotificationClicked(notificationEvent);
 
-  t.true(notificationPutCall.isDone());
+  const { request } = (await notificationPutNock.result);
+
+  t.true(notificationPutNock.nockScope.isDone());
+  t.deepEqual(request.body, {
+    app_id: appConfig.appId,
+    opened: true,
+    player_id: playerId,
+    device_type: 5
+  });
 });
 
 test('onNotificationClicked - notification click count omitted when appId is null', async t => {
@@ -199,27 +198,17 @@ test('onNotificationClicked - notification click count omitted when appId is nul
 
   const notificationId = Random.getRandomUuid();
 
-  const notificationPutCall = nock("https://onesignal.com")
-    .put(`/api/v1/notifications/${notificationId}`)
-    .reply(200);
+  const notificationPutCall = NockOneSignalHelper.nockNotificationPut(notificationId);
 
   const notificationEvent = mockNotificationNotificationEventInit(notificationId);
   await OSServiceWorker.onNotificationClicked(notificationEvent);
 
-  t.false(notificationPutCall.isDone());
+  t.false(notificationPutCall.nockScope.isDone());
 });
-
-function addNotificationPutNock(notificationId: string) {
-  nock("https://onesignal.com")
-    .put(`/api/v1/notifications/${notificationId}`)
-    .reply(200, (_uri: string, _requestBody: string) => {
-      return { success: true };
-    });
-}
 
 test('onNotificationClicked - sends webhook', async t => {
   const notificationId = Random.getRandomUuid();
-  addNotificationPutNock(notificationId);
+  NockOneSignalHelper.nockNotificationPut(notificationId);
 
   const executeWebhooksSpy = sandbox.stub(OSServiceWorker, "executeWebhooks");
 
@@ -233,7 +222,7 @@ test('onNotificationClicked - sends webhook', async t => {
 
 test('onNotificationClicked - openWindow', async t => {
   const notificationId = Random.getRandomUuid();
-  addNotificationPutNock(notificationId);
+  NockOneSignalHelper.nockNotificationPut(notificationId);
 
   const openWindowMock = sandbox.stub(self.clients, "openWindow");
 
@@ -272,15 +261,8 @@ test('onNotificationClicked - notification PUT Before openWindow', async t => {
 });
 
 /***************************************************
- * sendConfirmedDelivery() 
+ * sendConfirmedDelivery()
  ****************************************************/
-
- // HELPER: mocks the call to the notifications report_received endpoint
- function mockNotificationPutCall(notificationId: string | null) {
-  return nock("https://onesignal.com")
-    .put(`/api/v1/notifications/${notificationId}/report_received`)
-    .reply(200, { success: true });
- }
 
  // HELPER: sets a fake subscription
  async function fakeSetSubscription(){
@@ -290,54 +272,55 @@ test('onNotificationClicked - notification PUT Before openWindow', async t => {
   await Database.setSubscription(subscription);
  }
 
- test('sendConfirmedDelivery - notification is null - feature flag is y', async t => {
+ test('sendConfirmedDelivery - notification is undefined - feature flag is y', async t => {
    sandbox.stub(awaitableTimeout, 'awaitableTimeout');
-   const notificationId = null;
-   const notificationPutCall = mockNotificationPutCall(notificationId);
+   const notificationId = undefined;
+   const notificationPutCall = NockOneSignalHelper.nockNotificationConfirmedDelivery(notificationId);
    await fakeSetSubscription();
 
    await OSServiceWorker.sendConfirmedDelivery({ id: notificationId, rr: "y" });
-   t.false(notificationPutCall.isDone());
+   t.false(notificationPutCall.nockScope.isDone());
  });
 
  test('sendConfirmedDelivery - notification is valid - feature flag is y', async t => {
   sandbox.stub(awaitableTimeout, 'awaitableTimeout');
   const notificationId = Random.getRandomUuid();
-  const notificationPutCall = mockNotificationPutCall(notificationId);
+  const notificationPutCall = NockOneSignalHelper.nockNotificationConfirmedDelivery(notificationId);
   await fakeSetSubscription();
 
   await OSServiceWorker.sendConfirmedDelivery({ id: notificationId, rr: "y" });
-  t.true(notificationPutCall.isDone());
+  t.true(notificationPutCall.nockScope.isDone());
  });
 
  test('sendConfirmedDelivery - notification is valid - feature flag is n', async t => {
   sandbox.stub(awaitableTimeout, 'awaitableTimeout');
   const notificationId = Random.getRandomUuid();
-  const notificationPutCall = mockNotificationPutCall(notificationId);
+  const notificationPutCall = NockOneSignalHelper.nockNotificationConfirmedDelivery(notificationId);
   await fakeSetSubscription();
 
   await OSServiceWorker.sendConfirmedDelivery({ id: notificationId, rr: "n" });
-  t.false(notificationPutCall.isDone());
+  t.false(notificationPutCall.nockScope.isDone());
  });
 
  test('sendConfirmedDelivery - notification is valid - feature flag is undefined', async t => {
   sandbox.stub(awaitableTimeout, 'awaitableTimeout');
   const notificationId = Random.getRandomUuid();
-  const notificationPutCall = mockNotificationPutCall(notificationId);
+  const notificationPutCall = NockOneSignalHelper.nockNotificationConfirmedDelivery(notificationId);
   await fakeSetSubscription();
 
   await OSServiceWorker.sendConfirmedDelivery({ id: notificationId });
-  t.false(notificationPutCall.isDone());
+  t.false(notificationPutCall.nockScope.isDone());
  });
 
  test('sendConfirmedDelivery - notification is valid - feature flag is null', async t => {
   sandbox.stub(awaitableTimeout, 'awaitableTimeout');
   const notificationId = Random.getRandomUuid();
-  const notificationPutCall = mockNotificationPutCall(notificationId);
+  const notificationPutCall = NockOneSignalHelper.nockNotificationConfirmedDelivery(notificationId);
   await fakeSetSubscription();
 
   await OSServiceWorker.sendConfirmedDelivery({ id: notificationId, rr: null });
-  t.false(notificationPutCall.isDone());
+  t.false(notificationPutCall.nockScope.isDone());
+ });
 
  // checks `device_type` is being sent: helpful in reducing lookup time for outcome events on backend
  test('sendConfirmedDelivery - sends device_type', async t => {

--- a/test/unit/context/sw/ServiceWorker.ts
+++ b/test/unit/context/sw/ServiceWorker.ts
@@ -338,4 +338,15 @@ test('onNotificationClicked - notification PUT Before openWindow', async t => {
 
   await OSServiceWorker.sendConfirmedDelivery({ id: notificationId, rr: null });
   t.false(notificationPutCall.isDone());
+
+ // checks `device_type` is being sent: helpful in reducing lookup time for outcome events on backend
+ test('sendConfirmedDelivery - sends device_type', async t => {
+  sandbox.stub(awaitableTimeout, 'awaitableTimeout');
+  await fakeSetSubscription();
+  const notificationId = Random.getRandomUuid();
+  const notificationNock = NockOneSignalHelper.nockNotificationConfirmedDelivery(notificationId);
+
+  await OSServiceWorker.sendConfirmedDelivery({ id: notificationId, rr: 'y' });
+  const requestBody = (await notificationNock.result).request.body;
+  t.is(requestBody.device_type, 5); // 5 = chrome like
  });


### PR DESCRIPTION
# Description
## 1 Line Summary
Providing this param will help in backend look-ups for outcome event reporting.

## Details
See commits for further details

# Systems Affected
   - [x] WebSDK
   - [x] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info
Added testing coverage via `nock` to ensure we are sending the `device_type` on confirmed deliveries.

Includes some refactoring also related to nock.

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed
      **No screenshots necessary**

---

## Related Tickets

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/850)
<!-- Reviewable:end -->
