### PR TITLE
`userConfig` service worker param fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build:dev-stag": "./build/scripts/build.sh -f development -t staging"
   },
   "config": {
-    "sdkVersion": "151507"
+    "sdkVersion": "151508"
   },
   "repository": {
     "type": "git",

--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -489,6 +489,20 @@ export class ConfigHelper {
           Ignores dashboard configuration and uses code-based configuration only.
           Except injecting some default values for prompts.
         */
+        const isTopLevelServiceWorkerParamDefined = typeof OneSignal !== 'undefined' &&
+          !!OneSignal.SERVICE_WORKER_PARAM;
+        const isTopLevelServiceWorkerPathDefined = typeof OneSignal !== 'undefined' &&
+          !!OneSignal.SERVICE_WORKER_PATH;
+        const isTopLevelServiceWorkerUpdaterPathDefined = typeof OneSignal !== 'undefined' &&
+          !!OneSignal.SERVICE_WORKER_UPDATER_PATH;
+
+        const fallbackServiceWorkerParam = isTopLevelServiceWorkerParamDefined ?
+          OneSignal.SERVICE_WORKER_PARAM : { scope: '/' };
+        const fallbackServiceWorkerPath = isTopLevelServiceWorkerPathDefined ?
+          OneSignal.SERVICE_WORKER_PATH : 'OneSignalSDKWorker.js';
+        const fallbackServiceWorkerUpdaterPath = isTopLevelServiceWorkerUpdaterPathDefined ?
+          OneSignal.SERVICE_WORKER_UPDATER_PATH : 'OneSignalSDKUpdaterWorker.js';
+
         const config = {
           ...userConfig,
           promptOptions: this.injectDefaultsIntoPromptOptions(
@@ -498,15 +512,12 @@ export class ConfigHelper {
             isUsingSubscriptionWorkaround
           ),
           ...{
-            serviceWorkerParam: typeof OneSignal !== 'undefined' && !!OneSignal.SERVICE_WORKER_PARAM
-              ? OneSignal.SERVICE_WORKER_PARAM
-              : { scope: '/' },
-            serviceWorkerPath: typeof OneSignal !== 'undefined' && !!OneSignal.SERVICE_WORKER_PATH
-                ? OneSignal.SERVICE_WORKER_PATH
-                : 'OneSignalSDKWorker.js',
-            serviceWorkerUpdaterPath: typeof OneSignal !== 'undefined' && !!OneSignal.SERVICE_WORKER_UPDATER_PATH
-                ? OneSignal.SERVICE_WORKER_UPDATER_PATH
-                : 'OneSignalSDKUpdaterWorker.js',
+            serviceWorkerParam: !!userConfig.serviceWorkerParam ?
+              userConfig.serviceWorkerParam : fallbackServiceWorkerParam,
+            serviceWorkerPath: !!userConfig.serviceWorkerPath ?
+              userConfig.serviceWorkerPath : fallbackServiceWorkerPath,
+            serviceWorkerUpdaterPath: !!userConfig.serviceWorkerUpdaterPath ?
+              userConfig.serviceWorkerUpdaterPath : fallbackServiceWorkerUpdaterPath,
             path: !!userConfig.path ? userConfig.path : '/'
           },
           outcomes: {

--- a/test/unit/modules/mergedLegacyConfig.ts
+++ b/test/unit/modules/mergedLegacyConfig.ts
@@ -23,14 +23,20 @@ test('should assign the default service worker file path if not provided', async
   t.is(result.userConfig.path, '/');
 });
 
-test('should not overwrite a provided service worker file path', async t => {
+test('should not overwrite a provided service worker parameters', async t => {
   const result = new ConfigManager().getMergedConfig(
     {
-      path: '/existing-path'
+      path: '/existing-path',
+      serviceWorkerParam: { scope: '/existing-path' },
+      serviceWorkerPath: '/existing-path/OneSignalSDKWorker.js',
+      serviceWorkerUpdaterPath: '/existing-path/OneSignalSDKUpdaterWorker.js'
     },
     TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom)
   );
   t.is(result.userConfig.path, '/existing-path');
+  t.deepEqual(result.userConfig.serviceWorkerParam, { scope: '/existing-path' });
+  t.is(result.userConfig.serviceWorkerPath, '/existing-path/OneSignalSDKWorker.js');
+  t.is(result.userConfig.serviceWorkerUpdaterPath, '/existing-path/OneSignalSDKUpdaterWorker.js');
 });
 
 test('should assign the default service worker registration params if not provided', async t => {


### PR DESCRIPTION
This PR makes use of the `userConfig` versions of the Service Worker config parameters which were previously unused. This is crucial to easily support non-root scope integrations when using the web-shim distributions.

See commits for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/858)
<!-- Reviewable:end -->
