### PR TITLE
AMP Subscribe - Was previously not saving  to DB

### DIFF
--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -196,6 +196,7 @@ export class ServiceWorker {
       const context = new ContextSW(appConfig);
       const rawSubscription = await context.subscriptionManager.subscribe(SubscriptionStrategyKind.ResubscribeExisting);
       const subscription = await context.subscriptionManager.registerSubscription(rawSubscription);
+      await Database.put('Ids', { type: 'appId', id: appId });
       ServiceWorker.workerMessenger.broadcast(WorkerMessengerCommand.AmpSubscribe, subscription.deviceId);
     });
     ServiceWorker.workerMessenger.on(WorkerMessengerCommand.AmpUnsubscribe, async () => {
@@ -245,7 +246,7 @@ export class ServiceWorker {
               //Display push notifications in the order we received them
               const notificationEventPromiseFns = [];
               const notificationReceivedPromises: Promise<void>[] = [];
-              const appId = await Database.get<string>("Ids", "appId");
+              const appId = await ServiceWorker.getAppId();
 
               for (const rawNotification of notifications) {
                 Log.debug('Raw Notification from OneSignal:', rawNotification);
@@ -785,7 +786,7 @@ export class ServiceWorker {
 
     const launchUrl: string = await ServiceWorker.getNotificationUrlToOpen(notificationData);
     const notificationOpensLink: boolean = ServiceWorker.shouldOpenNotificationUrl(launchUrl);
-    const appId = await Database.get<string>("Ids", "appId");
+    const appId = await ServiceWorker.getAppId();
     const deviceType = DeviceRecord.prototype.getDeliveryPlatform();
 
     let saveNotificationClickedPromise: Promise<void> | undefined;


### PR DESCRIPTION
# Description

In AMP integrations (service worker code only) we were previously not saving the `appId` to the IndexeDB. This was previously only being done in the `InitHelper` which is called from the main context.

The `getAppId` function in [`ServiceWorker`](https://github.com/OneSignal/OneSignal-Website-SDK/blob/main/src/service-worker/ServiceWorker.ts#L151) was written in a way that it first tries to get the query param before trying the Database. Weirdly, on that line the variable `appId` loses its reference within the block scope and suddenly becomes `undefined` after stepping through to the following line (`match` also gets lost).

After spending some time trying to resolve this bizarre behavior with no luck, I figured we can simply add the same line from the `InitHelper` so that no further code changes are needed.

After trying this for myself, it works fine and the clicks are being recorded successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/860)
<!-- Reviewable:end -->
