### PR TITLE
Single url setup for service worker

### DIFF
--- a/express_webpack/amp/index.html
+++ b/express_webpack/amp/index.html
@@ -22,7 +22,6 @@
     var OneSignal = window.OneSignal || [];
     OneSignal.push(function() {
       OneSignal.SERVICE_WORKER_PARAM = { scope: "/" + SERVICE_WORKER_PATH };
-      OneSignal.SERVICE_WORKER_UPDATER_PATH = SERVICE_WORKER_PATH + "OneSignalSDKUpdaterWorker.js";
       OneSignal.SERVICE_WORKER_PATH = SERVICE_WORKER_PATH + "OneSignalSDKWorker.js";
 
       OneSignal.init({ appId });

--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -24,7 +24,6 @@
     var OneSignal = window.OneSignal || [];
     OneSignal.push(function() {
       OneSignal.SERVICE_WORKER_PARAM = { scope: "/" + SERVICE_WORKER_PATH };
-      OneSignal.SERVICE_WORKER_UPDATER_PATH = SERVICE_WORKER_PATH + "OneSignalSDKUpdaterWorker.js";
       OneSignal.SERVICE_WORKER_PATH = SERVICE_WORKER_PATH + "OneSignalSDKWorker.js";
 
       OneSignal.init({

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -899,7 +899,6 @@ export default class OneSignal {
    * However, the init options 'path' should be used to specify the folder path instead since service workers will not
    * auto-update correctly on HTTPS site load if the config init options 'path' is not set.
    */
-  static SERVICE_WORKER_UPDATER_PATH = 'OneSignalSDKUpdaterWorker.js';
   static SERVICE_WORKER_PATH = 'OneSignalSDKWorker.js';
 
   /**

--- a/src/context/shared/utils/Utils.ts
+++ b/src/context/shared/utils/Utils.ts
@@ -46,7 +46,7 @@ export class Utils {
    * @param object
    */
   public static trimUndefined(object: any) {
-    for (var property in object) {
+    for (const property in object) {
       if (object.hasOwnProperty(property)) {
         if (object[property] === undefined) {
           delete object[property];
@@ -90,10 +90,17 @@ export class Utils {
     }, 4);
   }
 
+  /**
+   * Used for generating query params
+   *  e.g: -> hash = { appId } // with appId = '1234'
+   *       -> returns "appId=1234"
+   * @param  {any} hash
+   * @returns string
+   */
   public static encodeHashAsUriComponent(hash: any): string {
     let uriComponent = '';
     const keys = Object.keys(hash);
-    for (var key of keys) {
+    for (const key of keys) {
       const value = hash[key];
       uriComponent += `${encodeURIComponent(key)}=${encodeURIComponent(value)}`;
     }

--- a/src/helpers/ConfigHelper.ts
+++ b/src/helpers/ConfigHelper.ts
@@ -401,7 +401,6 @@ export class ConfigHelper {
           autoResubscribe: serverConfig.config.autoResubscribe,
           path: serverConfig.config.serviceWorker.path,
           serviceWorkerPath: serverConfig.config.serviceWorker.workerName,
-          serviceWorkerUpdaterPath: serverConfig.config.serviceWorker.updaterWorkerName,
           serviceWorkerParam: { scope: serverConfig.config.serviceWorker.registrationScope },
           subdomainName: serverConfig.config.siteInfo.proxyOrigin,
           promptOptions: this.getPromptOptionsForDashboardConfiguration(serverConfig),
@@ -493,15 +492,11 @@ export class ConfigHelper {
           !!OneSignal.SERVICE_WORKER_PARAM;
         const isTopLevelServiceWorkerPathDefined = typeof OneSignal !== 'undefined' &&
           !!OneSignal.SERVICE_WORKER_PATH;
-        const isTopLevelServiceWorkerUpdaterPathDefined = typeof OneSignal !== 'undefined' &&
-          !!OneSignal.SERVICE_WORKER_UPDATER_PATH;
 
         const fallbackServiceWorkerParam = isTopLevelServiceWorkerParamDefined ?
           OneSignal.SERVICE_WORKER_PARAM : { scope: '/' };
         const fallbackServiceWorkerPath = isTopLevelServiceWorkerPathDefined ?
           OneSignal.SERVICE_WORKER_PATH : 'OneSignalSDKWorker.js';
-        const fallbackServiceWorkerUpdaterPath = isTopLevelServiceWorkerUpdaterPathDefined ?
-          OneSignal.SERVICE_WORKER_UPDATER_PATH : 'OneSignalSDKUpdaterWorker.js';
 
         const config = {
           ...userConfig,
@@ -516,8 +511,6 @@ export class ConfigHelper {
               userConfig.serviceWorkerParam : fallbackServiceWorkerParam,
             serviceWorkerPath: !!userConfig.serviceWorkerPath ?
               userConfig.serviceWorkerPath : fallbackServiceWorkerPath,
-            serviceWorkerUpdaterPath: !!userConfig.serviceWorkerUpdaterPath ?
-              userConfig.serviceWorkerUpdaterPath : fallbackServiceWorkerUpdaterPath,
             path: !!userConfig.path ? userConfig.path : '/'
           },
           outcomes: {

--- a/src/helpers/ContextHelper.ts
+++ b/src/helpers/ContextHelper.ts
@@ -11,17 +11,14 @@ export class ContextHelper {
 
     const envPrefix = SdkEnvironment.getBuildEnvPrefix();
     const serviceWorkerManagerConfig = {
-      workerAPath: new Path(`/${envPrefix}OneSignalSDKWorker.js`),
-      workerBPath: new Path(`/${envPrefix}OneSignalSDKUpdaterWorker.js`),
+      workerPath: new Path(`/${envPrefix}OneSignalSDKWorker.js`),
       registrationOptions: { scope: '/' }
     };
 
     if (config.userConfig) {
       if (config.userConfig.path) {
-        serviceWorkerManagerConfig.workerAPath =
+        serviceWorkerManagerConfig.workerPath =
           new Path(`${config.userConfig.path}${config.userConfig.serviceWorkerPath}`);
-        serviceWorkerManagerConfig.workerBPath =
-          new Path(`${config.userConfig.path}${config.userConfig.serviceWorkerUpdaterPath}`);
       }
       if (config.userConfig.serviceWorkerParam) {
         serviceWorkerManagerConfig.registrationOptions = config.userConfig.serviceWorkerParam;

--- a/src/helpers/ServiceWorkerHelper.ts
+++ b/src/helpers/ServiceWorkerHelper.ts
@@ -256,15 +256,7 @@ export enum ServiceWorkerActiveState {
   /**
    * OneSignalSDKWorker.js, or the equivalent custom file name, is active.
    */
-  WorkerA = 'Worker A (Main)',
-  /**
-   * OneSignalSDKUpdaterWorker.js, or the equivalent custom file name, is
-   * active.
-   *
-   * We no longer need to use this filename. We can update Worker A by appending
-   * a random query parameter to A.
-   */
-  WorkerB = 'Worker B (Updater)',
+  OneSignalWorker = 'OneSignal Worker',
   /**
    * A service worker is active, but it is neither OneSignalSDKWorker.js nor
    * OneSignalSDKUpdaterWorker.js (or the equivalent custom file names as
@@ -287,12 +279,7 @@ export interface ServiceWorkerManagerConfig {
   /**
    * The path and filename of the "main" worker (e.g. '/OneSignalSDKWorker.js');
    */
-  workerAPath: Path;
-  /**
-   * The path and filename to the "alternate" worker, used to update an existing
-   * service worker. (e.g. '/OneSignalSDKUpdaterWorer.js')
-   */
-  workerBPath: Path;
+  workerPath: Path;
   /**
    * Describes how much of the origin the service worker controls.
    * This is currently always "/".

--- a/src/helpers/ServiceWorkerHelper.ts
+++ b/src/helpers/ServiceWorkerHelper.ts
@@ -239,9 +239,8 @@ export enum ServiceWorkerActiveState {
    */
   OneSignalWorker = 'OneSignal Worker',
   /**
-   * A service worker is active, but it is neither OneSignalSDKWorker.js nor
-   * OneSignalSDKUpdaterWorker.js (or the equivalent custom file names as
-   * provided by user config).
+   * A service worker is active, but it is not OneSignalSDKWorker.js
+   * (or the equivalent custom file names as provided by user config).
    */
   ThirdParty = '3rd Party',
   /**

--- a/src/helpers/ServiceWorkerHelper.ts
+++ b/src/helpers/ServiceWorkerHelper.ts
@@ -17,38 +17,19 @@ import { SecondaryChannelManager } from "../managers/channelManager/shared/Secon
 declare var self: ServiceWorkerGlobalScope & OSServiceWorkerFields;
 
 export default class ServiceWorkerHelper {
-
-  // Get the href of the OneSiganl ServiceWorker that should be installed
-  // If a OneSignal ServiceWorker is already installed we will use an alternating name
-  //   to force an update to the worker.
-  public static getAlternatingServiceWorkerHref(
-    workerState: ServiceWorkerActiveState,
+  public static getServiceWorkerHref(
     config: ServiceWorkerManagerConfig,
-    appId: string
+    appId: string,
+    sdkVersion: number
     ): string {
-    let workerFullPath: string;
-
-    // Determine which worker to install
-    if (workerState === ServiceWorkerActiveState.WorkerA)
-      workerFullPath = config.workerBPath.getFullPath();
-    else
-      workerFullPath = config.workerAPath.getFullPath();
-
-    return ServiceWorkerHelper.appendServiceWorkerParams(workerFullPath, appId);
+    return ServiceWorkerHelper.appendServiceWorkerParams(config.workerPath.getFullPath(), appId, sdkVersion);
   }
 
-  public static getPossibleServiceWorkerHrefs(
-    config: ServiceWorkerManagerConfig,
-    appId: string
-    ): string[] {
-    const workerFullPaths = [config.workerAPath.getFullPath(), config.workerBPath.getFullPath()];
-    return workerFullPaths.map(href => ServiceWorkerHelper.appendServiceWorkerParams(href, appId));
-  }
-
-  private static appendServiceWorkerParams(workerFullPath: string, appId: string): string {
+  private static appendServiceWorkerParams(workerFullPath: string, appId: string, sdkVersion: number): string {
     const fullPath = new URL(workerFullPath, OneSignalUtils.getBaseUrl()).href;
-    const appIdHasQueryParam = Utils.encodeHashAsUriComponent({ appId });
-    return `${fullPath}?${appIdHasQueryParam}`;
+    const appIdAsQueryParam      = Utils.encodeHashAsUriComponent({ appId });
+    const sdkVersionAsQueryParam = Utils.encodeHashAsUriComponent({ sdkVersion });
+    return `${fullPath}?${appIdAsQueryParam}?${sdkVersionAsQueryParam}`;
   }
 
   public static async upsertSession(

--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -104,13 +104,11 @@ export class ServiceWorkerManager {
   }
 
   // Check if the ServiceWorker file name is ours or a third party's
-  private swActiveStateByFileName(fileName: string | null): ServiceWorkerActiveState {
+  private swActiveStateByFileName(fileName?: string | null): ServiceWorkerActiveState {
     if (!fileName)
       return ServiceWorkerActiveState.None;
-    if (fileName == this.config.workerAPath.getFileName())
-      return ServiceWorkerActiveState.WorkerA;
-    if (fileName == this.config.workerBPath.getFileName())
-      return  ServiceWorkerActiveState.WorkerB;
+    if (fileName == this.config.workerPath.getFileName())
+      return ServiceWorkerActiveState.OneSignalWorker;
     return ServiceWorkerActiveState.ThirdParty;
   }
 

--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -203,19 +203,20 @@ export class ServiceWorkerManager {
 
     // 3. Different href?, asking if (path + filename [A or B] + queryParams) is different
     const availableWorker = ServiceWorkerUtilHelper.getAvailableServiceWorker(workerRegistration);
-    const serviceWorkerHrefs = ServiceWorkerHelper.getPossibleServiceWorkerHrefs(
+    const serviceWorkerHref = ServiceWorkerHelper.getServiceWorkerHref(
       this.config,
-      this.context.appConfig.appId
+      this.context.appConfig.appId,
+      Environment.version()
     );
     // 3.1 If we can't get a scriptURL assume it is different
     if (!availableWorker?.scriptURL) {
       return true;
     }
-    // 3.2 We don't care if the only differences is between OneSignal's A(Worker) vs B(WorkerUpdater) filename.
-    if (serviceWorkerHrefs.indexOf(availableWorker.scriptURL) === -1) {
+    // 3.2 If the new serviceWorkerHref (page-env SDK version as query param) is different than existing worker URL
+    if (serviceWorkerHref !== availableWorker.scriptURL) {
       Log.info(
         "[changedServiceWorkerParams] ServiceWorker href changing:",
-        { a_old: availableWorker?.scriptURL, b_new: serviceWorkerHrefs }
+        { a_old: availableWorker?.scriptURL, b_new: serviceWorkerHref }
       );
       return true;
     }

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -634,9 +634,7 @@ export class SubscriptionManager {
 
   private async isSubscriptionExpiringForSecureIntegration(): Promise<boolean> {
     const serviceWorkerState = await this.context.serviceWorkerManager.getActiveState();
-    if (!(
-      serviceWorkerState === ServiceWorkerActiveState.WorkerA ||
-      serviceWorkerState === ServiceWorkerActiveState.WorkerB)) {
+    if (!(serviceWorkerState === ServiceWorkerActiveState.OneSignalWorker)) {
         /* If the service worker isn't activated, there's no subscription to look for */
         return false;
     }
@@ -748,10 +746,7 @@ export class SubscriptionManager {
     const workerRegistration = await this.context.serviceWorkerManager.getRegistration();
     const notificationPermission =
       await this.context.permissionManager.getNotificationPermission(this.context.appConfig.safariWebId);
-    const isWorkerActive = (
-      workerState === ServiceWorkerActiveState.WorkerA ||
-      workerState === ServiceWorkerActiveState.WorkerB
-    );
+    const isWorkerActive = (workerState === ServiceWorkerActiveState.OneSignalWorker);
 
     if (!workerRegistration) {
       /* You can't be subscribed without a service worker registration */
@@ -761,7 +756,7 @@ export class SubscriptionManager {
       };
     }
 
-    /* 
+    /*
      * Removing pushSubscription from this method due to inconsistent behavior between browsers.
      * Doesn't matter for re-subscribing, worker is present and active.
      * Previous implementation for reference:

--- a/src/models/AppConfig.ts
+++ b/src/models/AppConfig.ts
@@ -95,7 +95,6 @@ export interface AppUserConfig {
   autoResubscribe?: boolean;
   path?: string;
   serviceWorkerPath?: string;
-  serviceWorkerUpdaterPath?: string;
   serviceWorkerParam?: any;
   subdomainName?: string;
   promptOptions?: AppUserConfigPromptOptions;
@@ -261,7 +260,6 @@ export interface ServerAppConfig {
       path?: string;
       workerName?: string;
       registrationScope?: string;
-      updaterWorkerName?: string;
       customizationEnabled: boolean;
     };
     setupBehavior?: {

--- a/src/models/Path.ts
+++ b/src/models/Path.ts
@@ -17,7 +17,7 @@ export default class Path {
     this.path = path.trim();
   }
 
-  getQueryString(): string {
+  getQueryString(): string | null {
     // If there are no ? characters, return null
     // If there are multiple ?, return the substring starting after the first ? all the way to the end
     const indexOfDelimiter = this.path.indexOf('?');
@@ -37,12 +37,12 @@ export default class Path {
     return this.path.split(Path.QUERY_STRING)[0];
   }
 
-  getFileName(): string {
-    return this.getWithoutQueryString().split('\\').pop().split('/').pop();
+  getFileName(): string | undefined {
+    return this.getWithoutQueryString().split('\\').pop()?.split('/').pop();
   }
 
-  getFileNameWithQuery(): string {
-    return this.path.split('\\').pop().split('/').pop();
+  getFileNameWithQuery(): string | undefined {
+    return this.path.split('\\').pop()?.split('/').pop();
   }
 
   getFullPath() {

--- a/src/models/ServiceWorkerState.ts
+++ b/src/models/ServiceWorkerState.ts
@@ -1,6 +1,5 @@
 class ServiceWorkerState {
   workerVersion: number;
-  updaterWorkerVersion: number;
 }
 
 export { ServiceWorkerState };

--- a/src/modules/frames/RemoteFrame.ts
+++ b/src/modules/frames/RemoteFrame.ts
@@ -110,7 +110,6 @@ export default class RemoteFrame implements Disposable {
   }
 
   async subscribe() {
-    // Do not register OneSignalSDKUpdaterWorker.js for HTTP popup sites; the file does not exist
     const isPushEnabled = LocalStorage.getIsPushNotificationsEnabled();
     const windowCreator = opener || parent;
 

--- a/src/service-worker/ServiceWorker.ts
+++ b/src/service-worker/ServiceWorker.ts
@@ -181,12 +181,12 @@ export class ServiceWorker {
       Log.debug('[Service Worker] Received AMP subscription state message.');
       const pushSubscription = await self.registration.pushManager.getSubscription();
       if (!pushSubscription) {
-        ServiceWorker.workerMessenger.broadcast(WorkerMessengerCommand.AmpSubscriptionState, false);
+        await ServiceWorker.workerMessenger.broadcast(WorkerMessengerCommand.AmpSubscriptionState, false);
       } else {
         const permission = await self.registration.pushManager.permissionState(pushSubscription.options);
         const { optedOut } = await Database.getSubscription();
         const isSubscribed = !!pushSubscription && permission === "granted" && optedOut !== true;
-        ServiceWorker.workerMessenger.broadcast(WorkerMessengerCommand.AmpSubscriptionState, isSubscribed);
+        await ServiceWorker.workerMessenger.broadcast(WorkerMessengerCommand.AmpSubscriptionState, isSubscribed);
       }
     });
     ServiceWorker.workerMessenger.on(WorkerMessengerCommand.AmpSubscribe, async () => {

--- a/src/services/Database.ts
+++ b/src/services/Database.ts
@@ -289,15 +289,12 @@ export default class Database {
   async getServiceWorkerState(): Promise<ServiceWorkerState> {
     const state = new ServiceWorkerState();
     state.workerVersion = await this.get<number>("Ids", "WORKER1_ONE_SIGNAL_SW_VERSION");
-    state.updaterWorkerVersion = await this.get<number>("Ids", "WORKER2_ONE_SIGNAL_SW_VERSION");
     return state;
   }
 
    async setServiceWorkerState(state: ServiceWorkerState) {
     if (state.workerVersion)
       await this.put("Ids", { type: "WORKER1_ONE_SIGNAL_SW_VERSION", id: state.workerVersion });
-    if (state.updaterWorkerVersion)
-      await this.put("Ids", { type: "WORKER2_ONE_SIGNAL_SW_VERSION", id: state.updaterWorkerVersion });
   }
 
   async getSubscription(): Promise<Subscription> {

--- a/src/utils/OneSignalStub.ts
+++ b/src/utils/OneSignalStub.ts
@@ -5,7 +5,6 @@ export type PossiblePredefinedOneSignal = Array<Object[] | Function> | undefined
 
 export abstract class OneSignalStub<T> implements IndexableByString<any> {
   public VERSION = (typeof __VERSION__) === "undefined" ? 1 : Number(__VERSION__);
-  public SERVICE_WORKER_UPDATER_PATH: string | undefined;
   public SERVICE_WORKER_PATH: string | undefined;
   public SERVICE_WORKER_PARAM: { scope: string } | undefined;
 

--- a/src/utils/ReplayCallsOnOneSignal.ts
+++ b/src/utils/ReplayCallsOnOneSignal.ts
@@ -34,9 +34,6 @@ export class ReplayCallsOnOneSignal {
     if (stubOneSignal.SERVICE_WORKER_PATH)
       OneSignal.SERVICE_WORKER_PATH = stubOneSignal.SERVICE_WORKER_PATH;
 
-    if (stubOneSignal.SERVICE_WORKER_UPDATER_PATH)
-      OneSignal.SERVICE_WORKER_UPDATER_PATH = stubOneSignal.SERVICE_WORKER_UPDATER_PATH;
-
     if (stubOneSignal.currentLogLevel)
       OneSignal.log.setLevel(stubOneSignal.currentLogLevel);
 

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -535,7 +535,6 @@ export class TestEnvironment {
             path: "/",
             workerName: "OneSignalSDKWorker.js",
             registrationScope: "/",
-            updaterWorkerName: "OneSignalSDKUpdaterWorker.js"
           },
           welcomeNotification: {
             enable: true,
@@ -718,7 +717,6 @@ export class TestEnvironment {
           path: undefined,
           workerName: undefined,
           registrationScope: undefined,
-          updaterWorkerName: undefined,
           customizationEnabled: true
         },
         setupBehavior: {
@@ -776,7 +774,6 @@ export class TestEnvironment {
       autoResubscribe: true,
       path: '/fake-page',
       serviceWorkerPath: 'fakeWorkerName.js',
-      serviceWorkerUpdaterPath: 'fakeUpdaterWorkerName.js',
       serviceWorkerParam: { scope: '/fake-page' },
       subdomainName: 'fake-subdomain',
       promptOptions: {

--- a/test/support/tester/sinonSandboxUtils.ts
+++ b/test/support/tester/sinonSandboxUtils.ts
@@ -52,7 +52,7 @@ export function stubServiceWorkerInstallation(sinonSandbox: SinonSandbox) {
   sinonSandbox.stub(SubscriptionManager.prototype, "subscribeWithVapidKey")
     .resolves(TestEnvironment.getFakeRawPushSubscription());
   sinonSandbox.stub(ServiceWorkerManager.prototype, "getActiveState")
-    .resolves(ServiceWorkerActiveState.WorkerA);
+    .resolves(ServiceWorkerActiveState.OneSignalWorker);
   sinonSandbox.stub(ServiceWorkerManager.prototype, "getRegistration")
     .resolves(swRegistration);
   sinonSandbox.stub(WorkerMessenger.prototype, "unicast").resolves();

--- a/test/unit/managers/ServiceWorkerManager.ts
+++ b/test/unit/managers/ServiceWorkerManager.ts
@@ -25,7 +25,9 @@ import {
 import Event from "../../../src/Event";
 import { ServiceWorkerRegistrationError } from '../../../src/errors/ServiceWorkerRegistrationError';
 import OneSignalUtils from "../../../src/utils/OneSignalUtils";
-import { MockServiceWorkerRegistration } from "../../support/mocks/service-workers/models/MockServiceWorkerRegistration";
+import {
+  MockServiceWorkerRegistration
+} from "../../support/mocks/service-workers/models/MockServiceWorkerRegistration";
 import { MockServiceWorker } from "../../support/mocks/service-workers/models/MockServiceWorker";
 import { ConfigIntegrationKind } from "../../../src/models/AppConfig";
 import Environment from '../../../src/Environment';

--- a/test/unit/managers/SubscriptionManager.ts
+++ b/test/unit/managers/SubscriptionManager.ts
@@ -392,7 +392,7 @@ test('safari 11.1+ with service worker but not pushManager', async t => {
   sandbox.stub(SdkEnvironment, "getIntegration").returns(IntegrationKind.Secure);
   sandbox.stub(SdkEnvironment, "getWindowEnv").returns(WindowEnvironmentKind.ServiceWorker);
   sandbox.stub(navigator.serviceWorker, "getRegistration").returns(serviceWorkerRegistration);
-  sandbox.stub(OneSignal.context.serviceWorkerManager, "getActiveState").returns(ServiceWorkerActiveState.WorkerA);
+  sandbox.stub(OneSignal.context.serviceWorkerManager, "getActiveState").returns(ServiceWorkerActiveState.OneSignalWorker);
 
   t.is(await OneSignal.context.subscriptionManager.isSubscriptionExpiring(), false);
 });
@@ -521,7 +521,7 @@ async function expirationTestCase(
 
   // Force service worker active state dependency so test can run
   const stub = sandbox.stub(ServiceWorkerManager.prototype, "getActiveState")
-    .resolves(ServiceWorkerActiveState.WorkerA);
+    .resolves(ServiceWorkerActiveState.OneSignalWorker);
   const integrationStub = sandbox.stub(SdkEnvironment, "getIntegration").resolves(env);
 
   // Set the initial datetime, which is used internally for the subscription created at

--- a/test/unit/modules/entryInitialization.ts
+++ b/test/unit/modules/entryInitialization.ts
@@ -379,7 +379,6 @@ test("Test ReplayCallsOnOneSignal replays ES6 calls executing reject promise", a
 });
 
 class MockOneSignalWithPublicProperties {
-  public SERVICE_WORKER_UPDATER_PATH: string | undefined;
   public SERVICE_WORKER_PATH: string | undefined;
   public SERVICE_WORKER_PARAM: { scope: string } | undefined;
 
@@ -394,7 +393,6 @@ class MockOneSignalWithPublicProperties {
 test("Make sure property field transfer over", async t => {
   const oneSignalStub = new OneSignalStubES6();
   oneSignalStub.SERVICE_WORKER_PATH = "SERVICE_WORKER_UPDATER_PATH";
-  oneSignalStub.SERVICE_WORKER_UPDATER_PATH = "SERVICE_WORKER_UPDATER_PATH";
   oneSignalStub.SERVICE_WORKER_PARAM = { scope: "scope" };
   oneSignalStub.log.setLevel("trace");
 
@@ -406,7 +404,6 @@ test("Make sure property field transfer over", async t => {
   ReplayCallsOnOneSignal.doReplay(oneSignalStub);
 
   t.is(mockOneSignal.SERVICE_WORKER_PATH, "SERVICE_WORKER_UPDATER_PATH");
-  t.is(mockOneSignal.SERVICE_WORKER_UPDATER_PATH, "SERVICE_WORKER_UPDATER_PATH");
   t.is(mockOneSignal.currentLogLevel, "trace");
   t.deepEqual(mockOneSignal.SERVICE_WORKER_PARAM, { scope: "scope" });
 });

--- a/test/unit/modules/mergedLegacyConfig.ts
+++ b/test/unit/modules/mergedLegacyConfig.ts
@@ -29,14 +29,12 @@ test('should not overwrite a provided service worker parameters', async t => {
       path: '/existing-path',
       serviceWorkerParam: { scope: '/existing-path' },
       serviceWorkerPath: '/existing-path/OneSignalSDKWorker.js',
-      serviceWorkerUpdaterPath: '/existing-path/OneSignalSDKUpdaterWorker.js'
     },
     TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom)
   );
   t.is(result.userConfig.path, '/existing-path');
   t.deepEqual(result.userConfig.serviceWorkerParam, { scope: '/existing-path' });
   t.is(result.userConfig.serviceWorkerPath, '/existing-path/OneSignalSDKWorker.js');
-  t.is(result.userConfig.serviceWorkerUpdaterPath, '/existing-path/OneSignalSDKUpdaterWorker.js');
 });
 
 test('should assign the default service worker registration params if not provided', async t => {
@@ -90,33 +88,6 @@ test('should not overwrite a provided service worker A filename', async t => {
     TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom)
   );
   t.is(result.userConfig.serviceWorkerPath, 'CustomWorkerA.js');
-});
-
-test('should assign the default service worker B filename if not provided', async t => {
-
-  const result = new ConfigManager().getMergedConfig(
-    {},
-    TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom)
-  );
-  t.is(result.userConfig.serviceWorkerUpdaterPath, 'OneSignalSDKUpdaterWorker.js');
-});
-
-test('should not overwrite a provided service worker B filename', async t => {
-  await TestEnvironment.initialize({
-    initOptions: {
-      httpPermissionRequest: {
-        enable: true
-      }
-    },
-    httpOrHttps: HttpHttpsEnvironment.Http
-  });
-  OneSignal.SERVICE_WORKER_UPDATER_PATH = 'CustomWorkerB.js';
-
-  const result = new ConfigManager().getMergedConfig(
-    {},
-    TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom)
-  );
-  t.is(result.userConfig.serviceWorkerUpdaterPath, 'CustomWorkerB.js');
 });
 
 test("should not use server's subdomain if subdomain not specified in user config on HTTPS site", async t => {


### PR DESCRIPTION
# Description
## 1 Line Summary
Simplifies the service worker update mechanism to require only a single service worker file.

## Details
When pushing WebSDK updates, we want the service worker to update so that any potential changes propagate not only to the page context but also to the underlying worker. The browser will automatically do this if the service worker file contents are different between versions or if the 24-hour cache expiry is hit. However, the hosted service worker file used by OneSignal integrated sites is not actually the full service worker component of the SDK but rather a simple `importScripts` call to our CDN-hosted service worker file. E.g: 
   `importScripts('https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js');`

Thus, the way to force the browser to re-install the service worker (and thus re-fetch the remote worker file) is to use two files:
- `OneSignalSDKWorker.js`
- `OneSignalSDKUpdaterWorker.js`

This ensures that the SW context and page-context are up to date and in sync (important if there are changes across both that require them to be up to date). **Note:** AMP integrations don't use (and have never used) the previous updater-worker file as limited by the AMP web push API. This was not a problem because the "page context" was virtually non-existent due to the AMP restriction of running 3rd party scripts. The SW updates automatically upon cache expiry.

Prior to this PR: Note that the contents of the two files are exactly the same (the import statement above). The browser also re-installs the worker if the file name is different which we take advantage of here.

A negative of this approach is that sites must host two separate files. Luckily, there is a third way to force-update the worker — by changing the query params at the end of the worker path. By leveraging this, we can simplify the integration to require hosting a single worker import file.

## Changes
The OneSignal internal initialization code path always calls `installWorker` on every page load. This is because this function contains the logic to check for a service worker update.

We use the `workerNeedsUpdate` helper function to determine whether we need to update. Currently, we use the `getWorkerVersion` helper to fetch the SW version number via the worker-messenger postmam call. We then compare this to `Environment.version()` which is the page-context SDK version. If they are different, we update. To update, we call the `installAlternatingWorker` which switches back and forth between the two files e.g: A -> B -> A -> B indefinitely.

The core logic-change comes in the `installAlternatingWorker` function. Since this is only called if we have determined we should install the worker, it is safe to modify this code to not alternate between worker files (current) but rather consistently install a single file with a query parameter appended to the end. We can remove ALL code related to this alternating mechanism. Everything else stays the same. E.g:

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info
Tests were updated to no longer use the alternating Service Worker install regime.

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed
      - No visual changes

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/863)
<!-- Reviewable:end -->
