### PR TITLE
Install worker - should not use console.log, reorder operations

### DIFF
--- a/src/managers/ServiceWorkerManager.ts
+++ b/src/managers/ServiceWorkerManager.ts
@@ -387,11 +387,11 @@ export class ServiceWorkerManager {
    */
 
   public async installWorker() {
-    console.log("Installing worker...");
     if (!await this.shouldInstallWorker()) {
       return;
     }
 
+    Log.info("Installing worker...");
     const workerState = await this.getActiveState();
 
     if (workerState === ServiceWorkerActiveState.ThirdParty) {


### PR DESCRIPTION
This PR fixes issue where we were wrongly using `console.log` instead of `Log.info` AND the order of operations was wrong. We should only log that we are installing the worker _after_ checking whether we _should_ install the worker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/868)
<!-- Reviewable:end -->
