### PR TITLE
Provide more specific callback type for `getNotificationPermission`

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -379,7 +379,7 @@ export default class OneSignal {
    *           has been obtained, with one of 'default', 'granted', or 'denied'.
    * @PublicApi
    */
-  public static async getNotificationPermission(onComplete?: Function): Promise<NotificationPermission> {
+  public static async getNotificationPermission(onComplete?: Action<NotificationPermission>): Promise<NotificationPermission> {
     await awaitOneSignalInitAndSupported();
     return OneSignal.privateGetNotificationPermission(onComplete);
   }


### PR DESCRIPTION
Motivation: using `Function` is discouraged. The web shims also depend on this callback type being specific (function signatures are parsed by the code generator).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/870)
<!-- Reviewable:end -->
