### PR TITLE
Channel subscription observers

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build:dev-stag": "./build/scripts/build.sh -f development -t staging"
   },
   "config": {
-    "sdkVersion": "151512"
+    "sdkVersion": "151513"
   },
   "repository": {
     "type": "git",

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -1036,6 +1036,14 @@ export default class OneSignal {
      */
     PERMISSION_PROMPT_DISPLAYED: 'permissionPromptDisplay',
     /**
+     * Occurs when the email subscription changes
+     */
+    EMAIL_SUBSCRIPTION_CHANGED: 'emailSubscriptionChanged',
+    /**
+     * Occurs when the SMS subscription changes
+     */
+    SMS_SUBSCRIPTION_CHANGED: 'smsSubscriptionChanged',
+    /**
      * For internal testing only. Used for all sorts of things.
      */
     TEST_INIT_OPTION_DISABLED: 'testInitOptionDisabled',

--- a/src/managers/channelManager/shared/SecondaryChannel.ts
+++ b/src/managers/channelManager/shared/SecondaryChannel.ts
@@ -3,7 +3,7 @@ import { TagsObject } from "../../../models/Tags";
 // Interface provided outside of this module.
 //   Example: OneSignal.ts as a consumer.
 export interface SecondaryChannel {
-  setIdentifier(identifier: string, authHash?: string): Promise<string | null>;
+  setIdentifier(identifier: string, authHash?: string): Promise<string | null | undefined>;
   logout(): Promise<boolean>;
 }
 

--- a/src/managers/channelManager/shared/SecondaryChannelSMS.ts
+++ b/src/managers/channelManager/shared/SecondaryChannelSMS.ts
@@ -9,6 +9,7 @@ import { SecondaryChannelFocusUpdater } from "./updaters/SecondaryChannelFocusUp
 import { SecondaryChannelSessionUpdater } from "./updaters/SecondaryChannelSessionUpdater";
 import { TagsObject } from "../../../models/Tags";
 import { SMSProfile } from "../../../models/SMSProfile";
+import Event from "../../../Event";
 
 export class SecondaryChannelSMS implements SecondaryChannel, SecondaryChannelWithSynchronizerEvents {
 
@@ -33,8 +34,12 @@ export class SecondaryChannelSMS implements SecondaryChannel, SecondaryChannelWi
     return true;
   }
 
-  async setIdentifier(identifier: string, authHash?: string): Promise<string | null> {
-    return await this.secondaryChannelIdentifierUpdater.setIdentifier(identifier, authHash);
+  async setIdentifier(identifier: string, authHash?: string): Promise<string | null | undefined> {
+    const profile = await this.secondaryChannelIdentifierUpdater.setIdentifier(identifier, authHash);
+    await Event.trigger(OneSignal.EVENTS.SMS_SUBSCRIPTION_CHANGED, {
+      sms: profile.identifier
+    });
+    return profile.subscriptionId;
   }
 
   async onSession(): Promise<void> {

--- a/src/managers/channelManager/shared/updaters/SecondaryChannelIdentifierUpdater.ts
+++ b/src/managers/channelManager/shared/updaters/SecondaryChannelIdentifierUpdater.ts
@@ -1,3 +1,4 @@
+import { SecondaryChannelProfile } from "../../../../models/SecondaryChannelProfile";
 import { ExternalUserIdHelper } from "../../../../helpers/shared/ExternalUserIdHelper";
 import { SecondaryChannelDeviceRecord } from "../../../../models/SecondaryChannelDeviceRecord";
 import OneSignalApi from "../../../../OneSignalApi";
@@ -8,7 +9,7 @@ import { SecondaryChannelProfileProvider } from "../providers/SecondaryChannelPr
 export class SecondaryChannelIdentifierUpdater {
   constructor(readonly profileProvider: SecondaryChannelProfileProvider) {}
 
-  async setIdentifier(identifier: string, authHash?: string): Promise<string | null> {
+  async setIdentifier(identifier: string, authHash?: string): Promise<SecondaryChannelProfile> {
     const appConfig = await Database.getAppConfig();
     const existingProfile = await this.profileProvider.getProfile();
     const newProfile = this.profileProvider.newProfile(existingProfile.subscriptionId, identifier, authHash);
@@ -42,6 +43,6 @@ export class SecondaryChannelIdentifierUpdater {
        await this.profileProvider.setProfile(newProfile);
      }
 
-     return newProfile.subscriptionId;
+     return newProfile;
   }
 }

--- a/test/support/tester/ChannelSubscriptionChangeEventHelper.ts
+++ b/test/support/tester/ChannelSubscriptionChangeEventHelper.ts
@@ -1,0 +1,9 @@
+type ChannelSubscriptionChangeEvent = "smsSubscriptionChanged" | "emailSubscriptionChanged";
+
+export function awaitSubscriptionChangeEvent(changeEvent: ChannelSubscriptionChangeEvent): Promise<object> {
+  return new Promise<object>(resolve => {
+    OneSignal.on(changeEvent, (event: object) => {
+      resolve(event);
+    });
+  });
+}

--- a/test/unit/public-sdk-apis/setSMSNumber.ts
+++ b/test/unit/public-sdk-apis/setSMSNumber.ts
@@ -5,6 +5,7 @@ import Database from "../../../src/services/Database";
 import { TestEnvironment } from "../../support/sdk/TestEnvironment";
 import { NockOneSignalHelper } from "../../support/tester/NockOneSignalHelper";
 import { setupFakePlayerId } from "../../support/tester/utils";
+import { awaitSubscriptionChangeEvent } from "../../support/tester/ChannelSubscriptionChangeEventHelper";
 
 const TEST_SMS_NUMBER = "+1112223333";
 
@@ -87,4 +88,13 @@ test("setSMSNumber, throws on empty string", async t => {
     },
     { instanceOf: InvalidArgumentError }
   );
+});
+
+test(
+  "Setting SMS causes 'smsSubscriptionChanged' event to fire with sms identifier in event callback", async t => {
+    const subscriptionChangeEventPromise = awaitSubscriptionChangeEvent("smsSubscriptionChanged");
+    NockOneSignalHelper.nockPlayerPost();
+    await OneSignal.setSMSNumber(TEST_SMS_NUMBER);
+    const event = await subscriptionChangeEventPromise as {sms: string};
+      t.is(event["sms"], TEST_SMS_NUMBER);
 });


### PR DESCRIPTION
# Description
## 1 Line Summary
Adds channel subscription observers for email and SMS in the SDK.

## Details
We use event listeners/observers across our SDKs to track subscription changes, notification events, user actions, prompt behavior, and more. Adding events for status changes of our new channels allows users to do more with the OneSignal integration.

### New Events
- `emailSubscriptionChange`
- `smsSubscriptionChange`

The event object:
```
// email
{
   email: "josh@onesignal.com"
} 
// SMS

{
   sms: "+12149874829"
}
```

### Note:
We currently have no way to unsubscribe SMS and EMAIL, just log out which is basically the same as unlinking the browser. So the “subscription change” would really only go from unsubscribed to subscribed in the SDK’s current state.



# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed
   ![Screen Shot 2022-01-13 at 3 57 58 PM](https://user-images.githubusercontent.com/11739227/149415502-0507a347-3401-44c7-8ef3-f2e44b9bf548.png)

---

---

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/872)
<!-- Reviewable:end -->

