### PR TITLE
Catch permissions error

### DIFF
--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -910,7 +910,6 @@ export default class OneSignal {
   static SERVICE_WORKER_PARAM: { scope: string } = { scope: '/' };
   static _LOGGING = false;
   static LOGGING = false;
-  static _usingNativePermissionHook = false;
   static _initCalled = false;
   static __initAlreadyCalled = false;
   static context: Context;

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -365,14 +365,20 @@ export default class InitHelper {
   }
 
   public static async installNativePromptPermissionChangedHook() {
-    if (navigator.permissions && !(bowser.firefox && Number(bowser.version) <= 45)) {
-      OneSignal._usingNativePermissionHook = true;
-      // If the browser natively supports hooking the subscription prompt permission change event,
-      // use it instead of our SDK method
-      const permissionStatus = await navigator.permissions.query({ name: 'notifications' });
-      permissionStatus.onchange = function() {
-        triggerNotificationPermissionChanged();
-      };
+    try {
+      if (navigator.permissions && !(bowser.firefox && Number(bowser.version) <= 45)) {
+        OneSignal._usingNativePermissionHook = true;
+        // If the browser natively supports hooking the subscription prompt permission change event,
+        // use it instead of our SDK method.
+        const permissionStatus = await navigator.permissions.query({ name: 'notifications' });
+        permissionStatus.onchange = function() {
+          triggerNotificationPermissionChanged();
+        };
+      }
+    } catch (e) {
+      // navigator.permissions.query({ name: 'notifications' }) currently not supported on Safari 16 (beta)
+      // as of June 2022
+      Log.warn(`Could not install native prompt permission change hook w/ error: ${e}`);
     }
   }
 

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -367,9 +367,6 @@ export default class InitHelper {
   public static async installNativePromptPermissionChangedHook() {
     try {
       if (navigator.permissions) {
-        OneSignal._usingNativePermissionHook = true;
-        // If the browser natively supports hooking the subscription prompt permission change event,
-        // use it instead of our SDK method.
         const permissionStatus = await navigator.permissions.query({ name: 'notifications' });
         permissionStatus.onchange = function() {
           triggerNotificationPermissionChanged();

--- a/src/helpers/InitHelper.ts
+++ b/src/helpers/InitHelper.ts
@@ -366,7 +366,7 @@ export default class InitHelper {
 
   public static async installNativePromptPermissionChangedHook() {
     try {
-      if (navigator.permissions && !(bowser.firefox && Number(bowser.version) <= 45)) {
+      if (navigator.permissions) {
         OneSignal._usingNativePermissionHook = true;
         // If the browser natively supports hooking the subscription prompt permission change event,
         // use it instead of our SDK method.


### PR DESCRIPTION
Motivation: it appears that Safari 16 does not support `navigator.permissions.query({name: 'notifications'});

Here, we catch the not-supported error to avoid halting execution.

This is not a critical issue since the permission is checked during the on session event.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/898)
<!-- Reviewable:end -->
