### PR TITLE
Fixes ServiceWorker Build Script

### DIFF
--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -66,7 +66,17 @@ echo "Unknown options -> ${POSITIONAL}"
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
 # build local SW file for dev env
-./build/scripts/buildServiceWorker.sh $BUILD_ORIGIN
+if [ "$NO_DEV_PORT" = false ]; then
+  if [ "$HTTPS" = true ]; then
+      PORT=":4001"
+  else
+      PORT=":4000"
+  fi
+else
+  PORT=""
+fi
+
+./build/scripts/buildServiceWorker.sh $BUILD_ORIGIN $PORT
 
 ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN HTTPS=$HTTPS NO_DEV_PORT=$NO_DEV_PORT yarn transpile:sources
 ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN HTTPS=$HTTPS NO_DEV_PORT=$NO_DEV_PORT yarn bundle-sw

--- a/build/scripts/buildServiceWorker.sh
+++ b/build/scripts/buildServiceWorker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 # Builds the local service worker file for express_webpack for use in local dev env
-echo "importScripts(\"https://${1}/sdks/Dev-OneSignalSDKWorker.js\");" > express_webpack/push/onesignal/OneSignalSDKWorker.js
+echo "Building local service worker file with arguments: ${1} ${2}"
+echo "importScripts(\"https://${1}${2}/sdks/Dev-OneSignalSDKWorker.js\");" > express_webpack/push/onesignal/OneSignalSDKWorker.js


### PR DESCRIPTION
Previously wasn't taking the port into consideration

# Description
## 1 Line Summary
Service worker build script was not including the port, leading to runtime errors in the sandbox environment.

## Details
Passes the appropriate port into the build script or omits it if the omit flag is set to true.

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/915)
<!-- Reviewable:end -->
