### PR TITLE
User model/api

### DIFF
--- a/src/core/requestService/IdentityRequests.ts
+++ b/src/core/requestService/IdentityRequests.ts
@@ -1,4 +1,4 @@
-import OneSignalApiBaseResult from "../../shared/api/OneSignalApiBaseResult";
+import OneSignalApiBaseResponse from "../../shared/api/OneSignalApiBaseResponse";
 import { logMethodCall } from "../../shared/utils/utils";
 import OneSignalError from "../../shared/errors/OneSignalError";
 import ExecutorResult from "../executors/ExecutorResult";
@@ -41,7 +41,7 @@ export default class IdentityRequests {
     return this._processIdentityResponse(response);
   }
 
-  private static _processIdentityResponse(response?: OneSignalApiBaseResult): ExecutorResult<IdentityModel> {
+  private static _processIdentityResponse(response?: OneSignalApiBaseResponse): ExecutorResult<IdentityModel> {
     if (!response) {
       throw new OneSignalError("processIdentityResponse: response is not defined");
     }

--- a/src/core/requestService/RequestService.ts
+++ b/src/core/requestService/RequestService.ts
@@ -1,4 +1,4 @@
-import OneSignalApiBaseResult from "../../shared/api/OneSignalApiBaseResult";
+import OneSignalApiBaseResponse from "../../shared/api/OneSignalApiBaseResponse";
 import OneSignalError from "../../shared/errors/OneSignalError";
 import OneSignalApiBase from "../../shared/api/OneSignalApiBase";
 import { IdentityModel } from "../models/IdentityModel";
@@ -11,7 +11,7 @@ import UserData from "../models/UserData";
 export class RequestService {
   /* U S E R   O P E R A T I O N S */
 
-  static createUser(requestBody: UserData): Promise<OneSignalApiBaseResult | undefined> {
+  static createUser(requestBody: UserData): Promise<OneSignalApiBaseResponse | undefined> {
     return OneSignalApiBase.post(`user`, requestBody);
   }
 
@@ -20,7 +20,7 @@ export class RequestService {
    * @param alias - alias label & id
    * @returns user properties object, identity object, and subscription objects
    */
-  static getUser(alias: AliasPair): Promise<OneSignalApiBaseResult | undefined> {
+  static getUser(alias: AliasPair): Promise<OneSignalApiBaseResponse | undefined> {
     return OneSignalApiBase.get(`user/by/${alias.label}/${alias.id}`);
   }
 
@@ -31,7 +31,7 @@ export class RequestService {
    * @param refreshDeviceMetaData - if true, updates ip, country, & last active
    * @returns properties object
    */
-  static updateUser(alias: AliasPair, payload: UpdateUserPayload): Promise<OneSignalApiBaseResult | undefined> {
+  static updateUser(alias: AliasPair, payload: UpdateUserPayload): Promise<OneSignalApiBaseResponse | undefined> {
     return OneSignalApiBase.patch(`user/by/${alias.label}/${alias.id}`, payload);
   }
 
@@ -39,7 +39,7 @@ export class RequestService {
    * Removes the user identified by the given alias pair, and all subscriptions and aliases
    * @param alias - alias label & id
    */
-  static deleteUser(alias: AliasPair): Promise<OneSignalApiBaseResult | undefined> {
+  static deleteUser(alias: AliasPair): Promise<OneSignalApiBaseResponse | undefined> {
     return OneSignalApiBase.delete(`user/by/${alias.label}/${alias.id}`);
   }
 
@@ -51,7 +51,7 @@ export class RequestService {
    * @param identity - identity object
    * @returns identity object
    */
-  static identifyUser(alias: AliasPair, identity: IdentityModel): Promise<OneSignalApiBaseResult | undefined> {
+  static identifyUser(alias: AliasPair, identity: IdentityModel): Promise<OneSignalApiBaseResponse | undefined> {
     return OneSignalApiBase.put(`user/by/${alias.label}/${alias.id}/identity`, {
       identity
     });
@@ -62,7 +62,7 @@ export class RequestService {
    * @param alias - alias label & id
    * @returns identity object
    */
-  static getUserIdentity(alias: AliasPair): Promise<OneSignalApiBaseResult | undefined> {
+  static getUserIdentity(alias: AliasPair): Promise<OneSignalApiBaseResponse | undefined> {
     return OneSignalApiBase.get(`user/by/${alias.label}/${alias.id}/identity`);
   }
 
@@ -72,7 +72,7 @@ export class RequestService {
    * @param labelToRemove - alias label to remove
    * @returns identity object
    */
-  static deleteAlias(alias: AliasPair, labelToRemove: string): Promise<OneSignalApiBaseResult | undefined> {
+  static deleteAlias(alias: AliasPair, labelToRemove: string): Promise<OneSignalApiBaseResponse | undefined> {
     const identity = OneSignalApiBase.delete(`user/by/${alias.label}/${alias.id}/identity/${labelToRemove}`);
 
     if (isIdentityObject(identity)) {
@@ -91,7 +91,7 @@ export class RequestService {
    * @returns subscription object
    */
   static createSubscription(alias: AliasPair, subscription: FutureSubscriptionModel):
-    Promise<OneSignalApiBaseResult | undefined> {
+    Promise<OneSignalApiBaseResponse | undefined> {
       return OneSignalApiBase.post(`user/by/${alias.label}/${alias.id}/subscription`, subscription);
   }
 
@@ -102,7 +102,7 @@ export class RequestService {
    * @returns subscription object
    */
   static updateSubscription(subscriptionId: string, subscription: Partial<SubscriptionModel>):
-    Promise<OneSignalApiBaseResult | undefined> {
+    Promise<OneSignalApiBaseResponse | undefined> {
       return OneSignalApiBase.patch(`subscriptions/${subscriptionId}`, subscription);
   }
 
@@ -111,7 +111,7 @@ export class RequestService {
    * Creates an "orphan" user record if the user has no other subscriptions.
    * @param subscriptionId - subscription id
    */
-  static deleteSubscription(subscriptionId: string): Promise<OneSignalApiBaseResult | undefined> {
+  static deleteSubscription(subscriptionId: string): Promise<OneSignalApiBaseResponse | undefined> {
     return OneSignalApiBase.delete(`subscriptions/${subscriptionId}`);
   }
 
@@ -120,7 +120,7 @@ export class RequestService {
    * @param subscriptionId - subscription id
    * @returns identity object
    */
-  static fetchAliasesForSubscription(subscriptionId: string): Promise<OneSignalApiBaseResult | undefined> {
+  static fetchAliasesForSubscription(subscriptionId: string): Promise<OneSignalApiBaseResponse | undefined> {
     return OneSignalApiBase.get(`subscriptions/${subscriptionId}/identity`);
   }
 
@@ -131,7 +131,7 @@ export class RequestService {
    * @returns identity object
    */
   static identifyUserForSubscription(subscriptionId: string, identity: IdentityModel):
-    Promise<OneSignalApiBaseResult | undefined> {
+    Promise<OneSignalApiBaseResponse | undefined> {
       return OneSignalApiBase.put(`user/by/subscriptions/${subscriptionId}/identity`, identity);
   }
 
@@ -148,7 +148,7 @@ export class RequestService {
   static transferSubscription(
     subscriptionId: string,
     identity: IdentityModel,
-    retainPreviousOwner: boolean): Promise<OneSignalApiBaseResult | undefined> {
+    retainPreviousOwner: boolean): Promise<OneSignalApiBaseResponse | undefined> {
       return OneSignalApiBase.put(`subscriptions/${subscriptionId}/owner`, {
         identity,
         retain_previous_owner: retainPreviousOwner

--- a/src/core/requestService/RequestService.ts
+++ b/src/core/requestService/RequestService.ts
@@ -11,7 +11,7 @@ import UserData from "../models/UserData";
 export class RequestService {
   /* U S E R   O P E R A T I O N S */
 
-  static createUser(requestBody: UserData): Promise<OneSignalApiBaseResponse | undefined> {
+  static createUser(requestBody: UserData): Promise<OneSignalApiBaseResponse>{
     return OneSignalApiBase.post(`user`, requestBody);
   }
 
@@ -20,7 +20,7 @@ export class RequestService {
    * @param alias - alias label & id
    * @returns user properties object, identity object, and subscription objects
    */
-  static getUser(alias: AliasPair): Promise<OneSignalApiBaseResponse | undefined> {
+  static getUser(alias: AliasPair): Promise<OneSignalApiBaseResponse>{
     return OneSignalApiBase.get(`user/by/${alias.label}/${alias.id}`);
   }
 
@@ -31,7 +31,7 @@ export class RequestService {
    * @param refreshDeviceMetaData - if true, updates ip, country, & last active
    * @returns properties object
    */
-  static updateUser(alias: AliasPair, payload: UpdateUserPayload): Promise<OneSignalApiBaseResponse | undefined> {
+  static updateUser(alias: AliasPair, payload: UpdateUserPayload): Promise<OneSignalApiBaseResponse>{
     return OneSignalApiBase.patch(`user/by/${alias.label}/${alias.id}`, payload);
   }
 
@@ -39,7 +39,7 @@ export class RequestService {
    * Removes the user identified by the given alias pair, and all subscriptions and aliases
    * @param alias - alias label & id
    */
-  static deleteUser(alias: AliasPair): Promise<OneSignalApiBaseResponse | undefined> {
+  static deleteUser(alias: AliasPair): Promise<OneSignalApiBaseResponse>{
     return OneSignalApiBase.delete(`user/by/${alias.label}/${alias.id}`);
   }
 
@@ -51,7 +51,7 @@ export class RequestService {
    * @param identity - identity object
    * @returns identity object
    */
-  static identifyUser(alias: AliasPair, identity: IdentityModel): Promise<OneSignalApiBaseResponse | undefined> {
+  static identifyUser(alias: AliasPair, identity: IdentityModel): Promise<OneSignalApiBaseResponse>{
     return OneSignalApiBase.put(`user/by/${alias.label}/${alias.id}/identity`, {
       identity
     });
@@ -62,7 +62,7 @@ export class RequestService {
    * @param alias - alias label & id
    * @returns identity object
    */
-  static getUserIdentity(alias: AliasPair): Promise<OneSignalApiBaseResponse | undefined> {
+  static getUserIdentity(alias: AliasPair): Promise<OneSignalApiBaseResponse>{
     return OneSignalApiBase.get(`user/by/${alias.label}/${alias.id}/identity`);
   }
 
@@ -72,7 +72,7 @@ export class RequestService {
    * @param labelToRemove - alias label to remove
    * @returns identity object
    */
-  static deleteAlias(alias: AliasPair, labelToRemove: string): Promise<OneSignalApiBaseResponse | undefined> {
+  static deleteAlias(alias: AliasPair, labelToRemove: string): Promise<OneSignalApiBaseResponse>{
     const identity = OneSignalApiBase.delete(`user/by/${alias.label}/${alias.id}/identity/${labelToRemove}`);
 
     if (isIdentityObject(identity)) {
@@ -91,7 +91,7 @@ export class RequestService {
    * @returns subscription object
    */
   static createSubscription(alias: AliasPair, subscription: FutureSubscriptionModel):
-    Promise<OneSignalApiBaseResponse | undefined> {
+    Promise<OneSignalApiBaseResponse>{
       return OneSignalApiBase.post(`user/by/${alias.label}/${alias.id}/subscription`, subscription);
   }
 
@@ -102,7 +102,7 @@ export class RequestService {
    * @returns subscription object
    */
   static updateSubscription(subscriptionId: string, subscription: Partial<SubscriptionModel>):
-    Promise<OneSignalApiBaseResponse | undefined> {
+    Promise<OneSignalApiBaseResponse>{
       return OneSignalApiBase.patch(`subscriptions/${subscriptionId}`, subscription);
   }
 
@@ -111,7 +111,7 @@ export class RequestService {
    * Creates an "orphan" user record if the user has no other subscriptions.
    * @param subscriptionId - subscription id
    */
-  static deleteSubscription(subscriptionId: string): Promise<OneSignalApiBaseResponse | undefined> {
+  static deleteSubscription(subscriptionId: string): Promise<OneSignalApiBaseResponse>{
     return OneSignalApiBase.delete(`subscriptions/${subscriptionId}`);
   }
 
@@ -120,7 +120,7 @@ export class RequestService {
    * @param subscriptionId - subscription id
    * @returns identity object
    */
-  static fetchAliasesForSubscription(subscriptionId: string): Promise<OneSignalApiBaseResponse | undefined> {
+  static fetchAliasesForSubscription(subscriptionId: string): Promise<OneSignalApiBaseResponse>{
     return OneSignalApiBase.get(`subscriptions/${subscriptionId}/identity`);
   }
 
@@ -131,7 +131,7 @@ export class RequestService {
    * @returns identity object
    */
   static identifyUserForSubscription(subscriptionId: string, identity: IdentityModel):
-    Promise<OneSignalApiBaseResponse | undefined> {
+    Promise<OneSignalApiBaseResponse>{
       return OneSignalApiBase.put(`user/by/subscriptions/${subscriptionId}/identity`, identity);
   }
 
@@ -148,7 +148,7 @@ export class RequestService {
   static transferSubscription(
     subscriptionId: string,
     identity: IdentityModel,
-    retainPreviousOwner: boolean): Promise<OneSignalApiBaseResponse | undefined> {
+    retainPreviousOwner: boolean): Promise<OneSignalApiBaseResponse>{
       return OneSignalApiBase.put(`subscriptions/${subscriptionId}/owner`, {
         identity,
         retain_previous_owner: retainPreviousOwner

--- a/src/shared/api/OneSignalApiBase.ts
+++ b/src/shared/api/OneSignalApiBase.ts
@@ -1,5 +1,5 @@
-import Utils from "../context/Utils";
 import { OneSignalApiError, OneSignalApiErrorKind } from "../errors/OneSignalApiError";
+import OneSignalError from "../errors/OneSignalError";
 import Environment from "../helpers/Environment";
 import SdkEnvironment from "../managers/SdkEnvironment";
 import OneSignalApiBaseResponse from "./OneSignalApiBaseResponse";
@@ -67,14 +67,18 @@ export class OneSignalApiBase {
   }
 
   private static async executeFetch(url: string, contents: RequestInit): Promise<OneSignalApiBaseResponse> {
-    const response = await fetch(url, contents);
-    const { status } = response;
-    const json = await response.json();
+    try {
+      const response = await fetch(url, contents);
+      const { status } = response;
+      const json = await response.json();
 
-    return {
-      result: json,
-      status
-    };
+      return {
+        result: json,
+        status
+      };
+    } catch (e) {
+      throw new OneSignalError(`OneSignalApiBase: failed to execute HTTP call: ${e}`);
+    }
   }
 }
 

--- a/src/shared/api/OneSignalApiBase.ts
+++ b/src/shared/api/OneSignalApiBase.ts
@@ -8,29 +8,29 @@ type Headers = any[] & {[key: string]: any};
 type SupportedMethods = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
 
 export class OneSignalApiBase {
-  static get(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResponse | undefined> {
+  static get(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResponse> {
     return OneSignalApiBase.call('GET', action, data, headers);
   }
 
-  static post(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResponse | undefined> {
+  static post(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResponse> {
     return OneSignalApiBase.call('POST', action, data, headers);
   }
 
-  static put(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResponse | undefined> {
+  static put(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResponse> {
     return OneSignalApiBase.call('PUT', action, data, headers);
   }
 
   static delete(action: string, data?: any, headers?: Headers | undefined):
-    Promise<OneSignalApiBaseResponse | undefined> {
+    Promise<OneSignalApiBaseResponse> {
       return OneSignalApiBase.call('DELETE', action, data, headers);
   }
 
-  static patch(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResponse | undefined> {
+  static patch(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResponse> {
     return OneSignalApiBase.call('PATCH', action, data, headers);
   }
 
   private static call(method: SupportedMethods, action: string, data: any, headers: Headers | undefined):
-    Promise<OneSignalApiBaseResponse | undefined> {
+    Promise<OneSignalApiBaseResponse> {
       if (method === "GET") {
         if (action.indexOf("players") > -1 && action.indexOf("app_id=") === -1) {
           console.error("Calls to player api are not permitted without app_id");
@@ -66,7 +66,7 @@ export class OneSignalApiBase {
       return OneSignalApiBase.executeFetch(url, contents);
   }
 
-  private static async executeFetch(url: string, contents: RequestInit): Promise<OneSignalApiBaseResponse | undefined> {
+  private static async executeFetch(url: string, contents: RequestInit): Promise<OneSignalApiBaseResponse> {
     const response = await fetch(url, contents);
     const { status } = response;
     const json = await response.json();

--- a/src/shared/api/OneSignalApiBase.ts
+++ b/src/shared/api/OneSignalApiBase.ts
@@ -71,12 +71,10 @@ export class OneSignalApiBase {
     const { status } = response;
     const json = await response.json();
 
-    if (status >= 200 && status < 300) {
       return {
         result: json,
         status
       };
-    }
 
     const error = OneSignalApiBase.identifyError(json);
     if (error === 'no-user-id-error') {
@@ -84,7 +82,6 @@ export class OneSignalApiBase {
     } else {
       return Promise.reject(json);
     }
-    return undefined;
   }
 
   /** TO DO: remove for user model */

--- a/src/shared/api/OneSignalApiBase.ts
+++ b/src/shared/api/OneSignalApiBase.ts
@@ -2,35 +2,35 @@ import Utils from "../context/Utils";
 import { OneSignalApiError, OneSignalApiErrorKind } from "../errors/OneSignalApiError";
 import Environment from "../helpers/Environment";
 import SdkEnvironment from "../managers/SdkEnvironment";
-import OneSignalApiBaseResult from "./OneSignalApiBaseResult";
+import OneSignalApiBaseResponse from "./OneSignalApiBaseResponse";
 
 type Headers = any[] & {[key: string]: any};
 type SupportedMethods = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
 
 export class OneSignalApiBase {
-  static get(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResult | undefined> {
+  static get(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResponse | undefined> {
     return OneSignalApiBase.call('GET', action, data, headers);
   }
 
-  static post(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResult | undefined> {
+  static post(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResponse | undefined> {
     return OneSignalApiBase.call('POST', action, data, headers);
   }
 
-  static put(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResult | undefined> {
+  static put(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResponse | undefined> {
     return OneSignalApiBase.call('PUT', action, data, headers);
   }
 
   static delete(action: string, data?: any, headers?: Headers | undefined):
-    Promise<OneSignalApiBaseResult | undefined> {
+    Promise<OneSignalApiBaseResponse | undefined> {
       return OneSignalApiBase.call('DELETE', action, data, headers);
   }
 
-  static patch(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResult | undefined> {
+  static patch(action: string, data?: any, headers?: Headers | undefined): Promise<OneSignalApiBaseResponse | undefined> {
     return OneSignalApiBase.call('PATCH', action, data, headers);
   }
 
   private static call(method: SupportedMethods, action: string, data: any, headers: Headers | undefined):
-    Promise<OneSignalApiBaseResult | undefined> {
+    Promise<OneSignalApiBaseResponse | undefined> {
       if (method === "GET") {
         if (action.indexOf("players") > -1 && action.indexOf("app_id=") === -1) {
           console.error("Calls to player api are not permitted without app_id");
@@ -66,7 +66,7 @@ export class OneSignalApiBase {
       return OneSignalApiBase.executeFetch(url, contents);
   }
 
-  private static async executeFetch(url: string, contents: RequestInit): Promise<OneSignalApiBaseResult | undefined> {
+  private static async executeFetch(url: string, contents: RequestInit): Promise<OneSignalApiBaseResponse | undefined> {
     const response = await fetch(url, contents);
     const { status } = response;
     const json = await response.json();

--- a/src/shared/api/OneSignalApiBase.ts
+++ b/src/shared/api/OneSignalApiBase.ts
@@ -71,30 +71,10 @@ export class OneSignalApiBase {
     const { status } = response;
     const json = await response.json();
 
-      return {
-        result: json,
-        status
-      };
-
-    const error = OneSignalApiBase.identifyError(json);
-    if (error === 'no-user-id-error') {
-      // TODO: This returns undefined
-    } else {
-      return Promise.reject(json);
-    }
-  }
-
-  /** TO DO: remove for user model */
-  private static identifyError(error: any) {
-    if (!error || !error.errors) {
-      return 'no-error';
-    }
-    const errors = error.errors;
-    if (Utils.contains(errors, 'No user with this id found') ||
-        Utils.contains(errors, 'Could not find app_id for given player id.')) {
-      return 'no-user-id-error';
-    }
-    return 'unknown-error';
+    return {
+      result: json,
+      status
+    };
   }
 }
 

--- a/src/shared/api/OneSignalApiBaseResponse.ts
+++ b/src/shared/api/OneSignalApiBaseResponse.ts
@@ -1,0 +1,4 @@
+export default interface OneSignalApiBaseResponse {
+  result: any;
+  status: number;
+}

--- a/src/shared/api/OneSignalApiBaseResult.ts
+++ b/src/shared/api/OneSignalApiBaseResult.ts
@@ -1,4 +1,0 @@
-export default interface OneSignalApiBaseResult {
-  result: any;
-  status: number;
-}


### PR DESCRIPTION
# Description
## 1 Line Summary
API-related improvements.

## Details
[Rename OneSignalApiBaseResult -> OneSignalApiBaseResponse](https://github.com/OneSignal/OneSignal-Website-SDK/commit/0e67e0f9cd7904a65cf479853520574d344eb5f8) 

@[rgomezp](https://github.com/OneSignal/OneSignal-Website-SDK/commits?author=rgomezp)
rgomezp committed 17 minutes ago
 
[Update return types based on OneSignalApiBase changes](https://github.com/OneSignal/OneSignal-Website-SDK/commit/f0a84f7cd780eca3ef3ee48bd60ab4d81bdb9e15) 

@[rgomezp](https://github.com/OneSignal/OneSignal-Website-SDK/commits?author=rgomezp)
rgomezp committed 15 minutes ago
 
[Always return the response](https://github.com/OneSignal/OneSignal-Website-SDK/commit/f97dd209b3a398a1b104deed2fbb771ab67b451e) 

@[rgomezp](https://github.com/OneSignal/OneSignal-Website-SDK/commits?author=rgomezp)
rgomezp committed 12 minutes ago
 
[Remove use of identifyError helper function](https://github.com/OneSignal/OneSignal-Website-SDK/commit/24006811fb141043c841a6b96e78554ae045c7f6) 

@[rgomezp](https://github.com/OneSignal/OneSignal-Website-SDK/commits?author=rgomezp)
rgomezp committed 6 minutes ago
 
[Add try catch around executeFetch code](https://github.com/OneSignal/OneSignal-Website-SDK/commit/610f9e5ae0bdc28ebc8021c6236c003c3cd376b8)

**More details in commits**

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/928)
<!-- Reviewable:end -->
