### PR TITLE
Feat/safari 16

### DIFF
--- a/build/scripts/build.sh
+++ b/build/scripts/build.sh
@@ -66,7 +66,17 @@ echo "Unknown options -> ${POSITIONAL}"
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
 # build local SW file for dev env
-./build/scripts/buildServiceWorker.sh $BUILD_ORIGIN
+if [ "$NO_DEV_PORT" = false ]; then
+  if [ "$HTTPS" = true ]; then
+      PORT=":4001"
+  else
+      PORT=":4000"
+  fi
+else
+  PORT=""
+fi
+
+./build/scripts/buildServiceWorker.sh $BUILD_ORIGIN $PORT
 
 ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN HTTPS=$HTTPS NO_DEV_PORT=$NO_DEV_PORT yarn transpile:sources
 ENV=$ENV API=$API BUILD_ORIGIN=$BUILD_ORIGIN API_ORIGIN=$API_ORIGIN HTTPS=$HTTPS NO_DEV_PORT=$NO_DEV_PORT yarn bundle-sw

--- a/build/scripts/buildServiceWorker.sh
+++ b/build/scripts/buildServiceWorker.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Builds the local service worker file for express_webpack for use in local dev env
-echo "importScripts(\"https://${1}/sdks/Dev-OneSignalSDKWorker.js\");" > express_webpack/push/onesignal/OneSignalSDKWorker.js
+echo "importScripts(\"https://${1}${2}/sdks/Dev-OneSignalSDKWorker.js\");" > express_webpack/push/onesignal/OneSignalSDKWorker.js

--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -1,9 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
+<!-- This Web Application Manifest is required for iOS 16.4 WebPush -->
+<link rel="manifest" href="manifest.json" />
+
 <!-- Some sites use this HTML base tag to change the origin for all relative links.
     Ensure OneSignal SDK correctly handles this. -->
-<base href="https://www.example.com/">
+<!-- NOTE: This does not work with the relative pathed manifest.json above. -->
+<!--<base href="https://www.example.com/"> -->
+
 <script src="https://localhost:4001/sdks/Dev-OneSignalSDK.js" async=""></script>
+
 <script>
     const SERVICE_WORKER_PATH = "push/onesignal/";
 

--- a/express_webpack/manifest.json
+++ b/express_webpack/manifest.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/web-manifest-combined.json",
+  "name": "OneSignal Sandbox WebSDK WebApp",
+  "short_name": "OSWebAppSandbox",
+  "display": "standalone",
+  "background_color": "#ff0000",
+  "description": "Add this WebApp to your iOS 16.4 homescreen then open it to test WebPush!"
+}

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -39,7 +39,8 @@ export default class Environment {
       const languageSubtags = languageTag.split('-');
       if (languageSubtags[0] == 'zh') {
         // The language is zh-?
-        // We must categorize the language as either zh-Hans (simplified) or zh-Hant (traditional); OneSignal only supports these two Chinese variants
+        // We must categorize the language as either zh-Hans (simplified) or zh-Hant (traditional);
+        // OneSignal only supports these two Chinese variants
         for (const traditionalSubtag of Environment.TRADITIONAL_CHINESE_LANGUAGE_TAG) {
           if (languageSubtags.indexOf(traditionalSubtag) !== -1) {
             return 'zh-Hant';

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -1,6 +1,7 @@
 import SdkEnvironment from './managers/SdkEnvironment';
 import { WindowEnvironmentKind } from './models/WindowEnvironmentKind';
 import bowser from 'bowser';
+import { supportsVapidPush } from './context/browser/utils/BrowserSupportsPush';
 
 export default class Environment {
   /**
@@ -12,6 +13,10 @@ export default class Environment {
 
   public static isSafari(): boolean {
     return Environment.isBrowser() && bowser.safari;
+  }
+
+  public static isNonVapidSafari(): boolean {
+    return this.isSafari() && !supportsVapidPush();
   }
 
   public static version() {

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -91,7 +91,7 @@ export default class OneSignal {
   /**
    * @PublicApi
    */
-  static async setEmail(email: string, options?: SetEmailOptions): Promise<string|null> {
+  static async setEmail(email: string, options?: SetEmailOptions): Promise<string|null|undefined> {
     if (!email) {
       throw new InvalidArgumentError('email', InvalidArgumentReason.Empty);
     }
@@ -113,7 +113,7 @@ export default class OneSignal {
   /**
    * @PublicApi
    */
-  static async setSMSNumber(smsNumber: string, options?: SetSMSOptions): Promise<string | null> {
+  static async setSMSNumber(smsNumber: string, options?: SetSMSOptions): Promise<string|null|undefined> {
     if (!smsNumber) {
       throw new InvalidArgumentError('smsNumber', InvalidArgumentReason.Empty);
     }
@@ -379,9 +379,10 @@ export default class OneSignal {
    *           has been obtained, with one of 'default', 'granted', or 'denied'.
    * @PublicApi
    */
-  public static async getNotificationPermission(onComplete?: Action<NotificationPermission>): Promise<NotificationPermission> {
-    await awaitOneSignalInitAndSupported();
-    return OneSignal.privateGetNotificationPermission(onComplete);
+  public static async getNotificationPermission(onComplete?: Action<NotificationPermission>):
+    Promise<NotificationPermission> {
+      await awaitOneSignalInitAndSupported();
+      return OneSignal.privateGetNotificationPermission(onComplete);
   }
 
   static async privateGetNotificationPermission(onComplete?: Function): Promise<NotificationPermission> {

--- a/src/context/browser/utils/BrowserSupportsPush.ts
+++ b/src/context/browser/utils/BrowserSupportsPush.ts
@@ -14,7 +14,7 @@ export function isMacOSSafariInIframe(): boolean {
   navigator.platform === "MacIntel"; // isMacOS
 }
 
-function supportsSafariPush(): boolean {
+export function supportsSafariPush(): boolean {
   return (window.safari && typeof window.safari.pushNotification !== "undefined") ||
           isMacOSSafariInIframe();
 }

--- a/src/context/browser/utils/BrowserSupportsPush.ts
+++ b/src/context/browser/utils/BrowserSupportsPush.ts
@@ -20,7 +20,7 @@ function supportsSafariPush(): boolean {
 }
 
 // Does the browser support the standard Push API
-function supportsVapidPush(): boolean {
+export function supportsVapidPush(): boolean {
   return typeof PushSubscriptionOptions !== "undefined" &&
          PushSubscriptionOptions.prototype.hasOwnProperty("applicationServerKey");
 }

--- a/src/helpers/MainHelper.ts
+++ b/src/helpers/MainHelper.ts
@@ -214,4 +214,13 @@ export default class MainHelper {
     const subscription = await OneSignal.database.getSubscription();
     return subscription.deviceId || undefined;
   }
+
+  static async getCurrentPushToken(): Promise<string | undefined> {
+    const registration = await OneSignal.context.serviceWorkerManager.getRegistration();
+    if (!registration) {
+      return undefined;
+    }
+    const subscription = await registration.pushManager.getSubscription();
+    return subscription?.endpoint;
+  }
 }

--- a/src/helpers/ServiceWorkerHelper.ts
+++ b/src/helpers/ServiceWorkerHelper.ts
@@ -169,6 +169,8 @@ export default class ServiceWorkerHelper {
         const rawPushSubscription = RawPushSubscription.setFromW3cSubscription(subscription);
         const fullDeviceRecord = new PushDeviceRecord(rawPushSubscription).serialize();
         deviceRecord.identifier = fullDeviceRecord.identifier;
+        deviceRecord.web_p256 = fullDeviceRecord.web_p256;
+        deviceRecord.web_auth = fullDeviceRecord.web_auth;
       }
     }
 

--- a/src/managers/PermissionManager.ts
+++ b/src/managers/PermissionManager.ts
@@ -94,8 +94,9 @@ export default class PermissionManager {
    * @param safariWebId The Safari web ID necessary to access the permission state on Safari.
    */
   private static getSafariNotificationPermission(safariWebId?: string): NotificationPermission {
-    if (safariWebId)
-      return window.safari.pushNotification.permission(safariWebId).permission as NotificationPermission;
+    if (safariWebId) {
+      return window.safari?.pushNotification?.permission(safariWebId).permission as NotificationPermission;
+    }
     throw new InvalidArgumentError('safariWebId', InvalidArgumentReason.Empty);
   }
 

--- a/src/managers/PermissionManager.ts
+++ b/src/managers/PermissionManager.ts
@@ -1,9 +1,9 @@
 import OneSignalUtils from '../utils/OneSignalUtils';
-import bowser from 'bowser';
 import { InvalidArgumentError, InvalidArgumentReason } from '../errors/InvalidArgumentError';
 import { NotificationPermission } from '../models/NotificationPermission';
 import SdkEnvironment from '../managers/SdkEnvironment';
 import LocalStorage from '../utils/LocalStorage';
+import Environment from '../../src/Environment';
 
 /**
  * A permission manager to consolidate the different quirks of obtaining and evaluating permissions
@@ -69,8 +69,10 @@ export default class PermissionManager {
    * @param safariWebId The Safari web ID necessary to access the permission state on Safari.
    */
   public async getReportedNotificationPermission(safariWebId?: string): Promise<NotificationPermission>{
-    if (bowser.safari)
+    if (Environment.isNonVapidSafari()) {
+      // Safari <16
       return PermissionManager.getSafariNotificationPermission(safariWebId);
+    }
 
     // Is this web push setup using subdomain.os.tc or subdomain.onesignal.com?
     if (OneSignalUtils.isUsingSubscriptionWorkaround())

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -30,6 +30,7 @@ import NotImplementedError from "../errors/NotImplementedError";
 import { PermissionUtils } from "../utils/PermissionUtils";
 import { base64ToUint8Array } from "../utils/Encoding";
 import { ContextSWInterface } from '../models/ContextSW';
+import OneSignalApiBase from "../OneSignalApiBase";
 
 export interface SubscriptionManagerConfig {
   safariWebId?: string;
@@ -534,6 +535,14 @@ export class SubscriptionManager {
     const [newPushSubscription, isNewSubscription] =
       await SubscriptionManager.doPushSubscribe(pushManager, this.getVapidKeyForBrowser());
 
+    // If Safari 16+, we need to unsubscribe the user from the old push subscription if it exists
+    const safariDeviceToken = window.safari?.pushNotification?.permission(OneSignal.config.safariWebId).deviceToken;
+    if (bowser.safari && safariDeviceToken) {
+      // see https://apple.co/3XHNuGB for info on this call
+      // handled internally here https://bit.ly/3WqIMvX
+      await OneSignalApiBase.delete(`safari/v2/devices/${safariDeviceToken}/registrations/${this.config.safariWebId}`);
+    }
+
     // Update saved create and expired times
     await SubscriptionManager.updateSubscriptionTime(isNewSubscription, newPushSubscription.expirationTime);
 
@@ -582,7 +591,8 @@ export class SubscriptionManager {
     Log.debug('[Subscription Manager] Subscribing to web push with these options:', subscriptionOptions);
     try {
       const existingSubscription = await pushManager.getSubscription();
-      return [await pushManager.subscribe(subscriptionOptions), !existingSubscription];
+      const subscription = await pushManager.subscribe(subscriptionOptions);
+      return [subscription, !existingSubscription];
     } catch (e) {
       if (e.name == "InvalidStateError") {
         // This exception is thrown if the key for the existing applicationServerKey is different,

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -541,7 +541,10 @@ export class SubscriptionManager {
       // see https://apple.co/3XHNuGB for info on this call
       // handled internally here https://bit.ly/3WqIMvX
       try {
-        await OneSignalApiBase.delete(`safari/v2/devices/${safariDeviceToken}/registrations/${this.config.safariWebId}`);
+        await OneSignalApiBase.delete(
+          `safari/v2/devices/${safariDeviceToken}/registrations/${this.config.safariWebId}`,
+          { app_id: this.config.appId }
+        );
       } catch (e) {
         Log.warn("Could not unsubscribe old Safari push token due error but continuing: ", e);
       }

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -537,10 +537,14 @@ export class SubscriptionManager {
 
     // If Safari 16+, we need to unsubscribe the user from the old push subscription if it exists
     const safariDeviceToken = window.safari?.pushNotification?.permission(OneSignal.config.safariWebId).deviceToken;
-    if (bowser.safari && safariDeviceToken) {
+    if (safariDeviceToken) {
       // see https://apple.co/3XHNuGB for info on this call
       // handled internally here https://bit.ly/3WqIMvX
-      await OneSignalApiBase.delete(`safari/v2/devices/${safariDeviceToken}/registrations/${this.config.safariWebId}`);
+      try {
+        await OneSignalApiBase.delete(`safari/v2/devices/${safariDeviceToken}/registrations/${this.config.safariWebId}`);
+      } catch (e) {
+        Log.warn("Could not unsubscribe old Safari push token due error but continuing: ", e);
+      }
     }
 
     // Update saved create and expired times

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -102,7 +102,8 @@ export class SubscriptionManager {
         if ((await OneSignal.privateGetNotificationPermission()) === NotificationPermission.Denied)
           throw new PushPermissionNotGrantedError(PushPermissionNotGrantedErrorReason.Blocked);
 
-        if (SubscriptionManager.isSafari()) {
+        if (Environment.isNonVapidSafari()) {
+          // Safari <16
           rawPushSubscription = await this.subscribeSafari();
           /* Now that permissions have been granted, install the service worker */
           Log.info("Installing SW on Safari");
@@ -174,7 +175,8 @@ export class SubscriptionManager {
     subscription.deviceId = newDeviceId;
     subscription.optedOut = false;
     if (pushSubscription) {
-      if (SubscriptionManager.isSafari()) {
+      if (Environment.isNonVapidSafari()) {
+        // Safari <16
         subscription.subscriptionToken = pushSubscription.safariDeviceToken;
       } else {
         subscription.subscriptionToken = pushSubscription.w3cEndpoint ? pushSubscription.w3cEndpoint.toString() : null;
@@ -727,7 +729,7 @@ export class SubscriptionManager {
   private async getSubscriptionStateForSecure(): Promise<PushSubscriptionState> {
     const { deviceId, optedOut } = await Database.getSubscription();
 
-    if (SubscriptionManager.isSafari()) {
+    if (Environment.isNonVapidSafari()) {
       const subscriptionState: SafariRemoteNotificationPermission =
         window.safari.pushNotification.permission(this.config.safariWebId);
       const isSubscribedToSafari = !!(

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -83,7 +83,7 @@ export class SubscriptionManager {
 
     switch (env) {
       case WindowEnvironmentKind.ServiceWorker:
-        rawPushSubscription = await this.subscribeFcmFromWorker(subscriptionStrategy);
+        rawPushSubscription = await this.subscribeFromWorkerWithVapid(subscriptionStrategy);
         break;
       case WindowEnvironmentKind.Host:
       case WindowEnvironmentKind.OneSignalSubscriptionModal:
@@ -115,7 +115,7 @@ export class SubscriptionManager {
           }
 
         } else {
-          rawPushSubscription = await this.subscribeFcmFromPage(subscriptionStrategy);
+          rawPushSubscription = await this.subscribeFromPageWithVapid(subscriptionStrategy);
         }
         break;
       default:
@@ -319,7 +319,7 @@ export class SubscriptionManager {
     return pushSubscriptionDetails;
   }
 
-  private async subscribeFcmFromPage(
+  private async subscribeFromPageWithVapid(
     subscriptionStrategy: SubscriptionStrategyKind
   ): Promise<RawPushSubscription> {
     /*
@@ -393,7 +393,7 @@ export class SubscriptionManager {
     return await this.subscribeWithVapidKey(workerRegistration.pushManager, subscriptionStrategy);
   }
 
-  public async subscribeFcmFromWorker(
+  public async subscribeFromWorkerWithVapid(
     subscriptionStrategy: SubscriptionStrategyKind
   ): Promise<RawPushSubscription> {
     /*

--- a/src/managers/tagManager/page/TagManager.ts
+++ b/src/managers/tagManager/page/TagManager.ts
@@ -30,7 +30,7 @@ export default class TagManager implements ITagManager {
         if (shouldSendUpdate) {
             return await OneSignal.sendTags(finalTagsObject) as TagsObjectForApi;
         }
-        Log.warn("OneSignal: no change detected in Category preferences. Skipping tag update.");
+        Log.info("OneSignal: no change detected in Category preferences. Skipping tag update.");
         // no change detected, return {}
         return finalTagsObject;
     }

--- a/src/models/DeliveryPlatformKind.ts
+++ b/src/models/DeliveryPlatformKind.ts
@@ -5,4 +5,5 @@ export enum DeliveryPlatformKind {
   Email = 11,
   Edge = 12,
   SMS = 14,
+  SafariVapid = 16
 }

--- a/src/models/DeliveryPlatformKind.ts
+++ b/src/models/DeliveryPlatformKind.ts
@@ -5,5 +5,5 @@ export enum DeliveryPlatformKind {
   Email = 11,
   Edge = 12,
   SMS = 14,
-  SafariVapid = 16
+  SafariVapid = 17
 }

--- a/src/models/DeviceRecord.ts
+++ b/src/models/DeviceRecord.ts
@@ -54,16 +54,14 @@ export abstract class DeviceRecord implements Serializable {
     // Unimplemented properties are appId, subscriptionState, and subscription
   }
 
-  isSafari(): boolean {
-    return bowser.safari && window.safari !== undefined && window.safari.pushNotification !== undefined;
-  }
-
   getDeliveryPlatform(): DeliveryPlatformKind {
     // For testing purposes, allows changing the browser user agent
     const browser = OneSignalUtils.redetectBrowserUserAgent();
 
-    if (this.isSafari()) {
+    if (Environment.isNonVapidSafari()) {
       return DeliveryPlatformKind.Safari;
+    } else if (Environment.isSafari()) {
+      return DeliveryPlatformKind.SafariVapid;
     } else if (browser.firefox) {
       return DeliveryPlatformKind.Firefox;
     } else if (browser.msedge) {

--- a/src/models/PushDeviceRecord.ts
+++ b/src/models/PushDeviceRecord.ts
@@ -29,9 +29,7 @@ export class PushDeviceRecord extends DeviceRecord {
     const serializedBundle: SerializedPushDeviceRecord = super.serialize();
 
     if (this.subscription) {
-      serializedBundle.identifier = bowser.safari ?
-        this.subscription.safariDeviceToken :
-        this.subscription.w3cEndpoint ? this.subscription.w3cEndpoint.toString() : null;
+      serializedBundle.identifier = this.subscription.w3cEndpoint ? this.subscription.w3cEndpoint.toString() : this.subscription.safariDeviceToken;
       serializedBundle.web_auth = this.subscription.w3cAuth;
       serializedBundle.web_p256 = this.subscription.w3cP256dh;
     }

--- a/src/utils/LocalStorage.ts
+++ b/src/utils/LocalStorage.ts
@@ -27,7 +27,7 @@ export default class LocalStorage {
     }
 
     public static getStoredPermission(): NotificationPermission {
-        var permission = localStorage.getItem(PermissionManager.STORED_PERMISSION_KEY) || "default";
+        const permission = localStorage.getItem(PermissionManager.STORED_PERMISSION_KEY) || "default";
         switch(permission) {
             case "granted":
                 return NotificationPermission.Granted;

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -78,6 +78,7 @@ export enum BrowserUserAgent {
   SafariUnsupportedMac= "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/538.32 (KHTML, like Gecko) Version/7.0 Safari/538.4",
   SafariSupportedMac= "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/538.32 (KHTML, like Gecko) Version/7.1 Safari/538.4",
   SafariSupportedMac121= "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1 Safari/605.1.15",
+  SafariVapidSupported = "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.3 Safari/605.1.15",
   FacebookBrowseriOS = "Mozilla/5.0 (iPhone; CPU iPhone OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12D508 [FBAN/FBIOS;FBAV/27.0.0.10.12;FBBV/8291884;FBDV/iPhone7,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/8.2;FBSS/3;]",
   FacebookBrowserAndroid = "Mozilla/5.0 (Linux; Android 5.1; Archos Diamond S Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.81 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/87.0.0.17.79;]",
   ChromeAndroidSupported = "Mozilla/5.0 (Linux; Android 4.0.4; Galaxy Nexus Build/IMM76B) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/54 Mobile Safari/535.19",

--- a/test/unit/serviceWorker/pushSubscriptionChange.ts
+++ b/test/unit/serviceWorker/pushSubscriptionChange.ts
@@ -76,7 +76,7 @@ test(`called with an old and new subscription successfully updates the subscript
   let subscription = await Database.getSubscription();
   t.deepEqual(subscription.deviceId, existingDeviceId);
   t.deepEqual(subscription.subscriptionToken, oldSubscription.endpoint);
-  
+
   const event = new MockPushSubscriptionChangeEvent();
   event.oldSubscription = oldSubscription;
   event.newSubscription = newSubscription;

--- a/test/unit/serviceWorker/pushSubscriptionChange.ts
+++ b/test/unit/serviceWorker/pushSubscriptionChange.ts
@@ -67,7 +67,7 @@ test(`called with an old and new subscription successfully updates the subscript
     It's going to fail due to the blocked permission, so let's simulate that here.
    */
   sinonSandbox
-    .stub(SubscriptionManager.prototype, 'subscribeFcmFromWorker')
+    .stub(SubscriptionManager.prototype, 'subscribeFromWorkerWithVapid')
     .throws('some-error');
 
   await setInitialDatabaseState(existingDeviceId, oldSubscription.endpoint);
@@ -154,7 +154,7 @@ test(
   `and updates existing device record to clear subscription`,
   async t => {
     sinonSandbox
-      .stub(SubscriptionManager.prototype, 'subscribeFcmFromWorker')
+      .stub(SubscriptionManager.prototype, 'subscribeFromWorkerWithVapid')
       .throws('some-error');
 
     await setInitialDatabaseState(existingDeviceId, oldSubscription.endpoint);
@@ -177,7 +177,7 @@ test(
 test(`called without an existing device ID, without old and new subscription, custom resubscription fails ` +
 `and local data is cleared`, async t => {
   sinonSandbox
-    .stub(SubscriptionManager.prototype, 'subscribeFcmFromWorker')
+    .stub(SubscriptionManager.prototype, 'subscribeFromWorkerWithVapid')
     .throws('some-error');
 
   // Before pushsubscriptionchange

--- a/yarn.lock
+++ b/yarn.lock
@@ -1065,31 +1065,12 @@ ajv-keywords@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.1.0.tgz#ac2b27939c543e95d2c06e7f7f5c27be4aa543be"
 
-ajv@^6.1.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.4.0.tgz#d3aff78e9277549771daf0164cff48482b754fc6"
-  dependencies:
-    fast-deep-equal "^1.0.0"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.3.0"
-    uri-js "^3.0.2"
-
-ajv@^6.10.0, ajv@^6.12.4:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.12.4, ajv@^6.5.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.4.1"
-    uri-js "^4.2.2"
-
-ajv@^6.5.5:
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
-  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
-  dependencies:
-    fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
@@ -4271,15 +4252,6 @@ fake-indexeddb@^2.1.1:
     realistic-structured-clone "^2.0.1"
     setimmediate "^1.0.5"
 
-fast-deep-equal@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
-
-fast-deep-equal@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
-  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
-
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -4313,11 +4285,7 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
-
-fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -6453,10 +6421,6 @@ json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
   integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
-
-json-schema-traverse@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -8648,8 +8612,9 @@ punycode@^1.2.4, punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
 punycode@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.0.tgz#f67fa67c94da8f4d0cfff981aee4118064199b8f"
+  integrity sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==
 
 pupa@^2.0.1:
   version "2.0.1"
@@ -10474,16 +10439,10 @@ update-notifier@^4.1.0:
     semver-diff "^3.1.1"
     xdg-basedir "^4.0.0"
 
-uri-js@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-3.0.2.tgz#f90b858507f81dea4dcfbb3c4c3dbfa2b557faaa"
-  dependencies:
-    punycode "^2.1.0"
-
 uri-js@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
-  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7304,9 +7304,11 @@ node-dir@^0.1.16:
     minimatch "^3.0.2"
 
 node-fetch@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-gyp@^3.8.0:
   version "3.8.0"
@@ -10715,6 +10717,14 @@ whatwg-url@7.0.0:
 whatwg-url@^4.3.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.8.0.tgz#d2981aa9148c1e00a41c5a6131166ab4683bbcc0"
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"


### PR DESCRIPTION
# Description
## 1 Line Summary
Adds support for Safari 16 (VAPID).

## Details
Safari 16 is introducing the standard [PushAPI ](https://developer.apple.com/documentation/usernotifications/sending_web_push_notifications_in_safari_and_other_browsers)that Chrome, Firefox, and other browsers use today. 

Safari 16 still supports it’s proprietary “Safari Push Notifications” on macOS, but the standard API is preferred since it supports more features. iOS/iPadOS 16.4 also supports the standard PushAPI. Apple will almost certainly drop the old API for macOS, but it may be a number of years before then so we will continue supporting it. We still want to continue supporting macOS 12.x and older, since it requires end users update to macOS 13 to get it.

### Device Type
Introducing `device_type: 17` for W3C version of Safari. Since the two Safari push types are fundamentally different, a new device_type value would clearly separate them and would keep things consistent in our system.

### Data Purge Problem:
Safari has a 7 day window where after the user doesn’t visit the site, it will purge all data like IndexedDB and localStorage. We introduce a way to detect whether the user was previously subscribed to legacy notifications and avoid creating a second subscription.
 
### iOS Support
With the introduction of web push for Safari on iOS, these changes will also work for that feature. However, it _will_ require the site to host a manifest.json file. This PR updates our sandbox environment with that file.

# Systems Affected
   - [x] WebSDK
   - [x] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info
![Screen Shot 2023-03-06 at 2 19 21 PM](https://user-images.githubusercontent.com/11739227/223221453-8d1626ff-7a16-494f-bad8-5d52efc8d0ae.png)
Currently Safari 16 does not display the custom icon. This is an upstream limitation.

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/930)
<!-- Reviewable:end -->
