### PR TITLE
[User model] register push

### DIFF
--- a/src/core/CoreModuleDirector.ts
+++ b/src/core/CoreModuleDirector.ts
@@ -2,7 +2,7 @@ import { logMethodCall } from "../shared/utils/utils";
 import Log from "../shared/libraries/Log";
 import CoreModule from "./CoreModule";
 import { OSModel } from "./modelRepo/OSModel";
-import { IdentityModel } from "./models/IdentityModel";
+import { SupportedIdentity } from "./models/IdentityModel";
 import { ModelStoresMap } from "./models/ModelStoresMap";
 import { SupportedSubscription } from "./models/SubscriptionModels";
 import { ModelName, SupportedModel } from "./models/SupportedModels";
@@ -122,12 +122,12 @@ export class CoreModuleDirector {
     return modelStores.pushSubscriptions.models[key] as OSModel<SupportedSubscription>;
   }
 
-  public async getIdentityModel(): Promise<OSModel<IdentityModel> | undefined> {
+  public async getIdentityModel(): Promise<OSModel<SupportedIdentity> | undefined> {
     logMethodCall("CoreModuleDirector.getIdentityModel");
     await this.initPromise;
     const modelStores = await this.getModelStores();
     const modelKeys = Object.keys(modelStores.identity.models);
-    return modelStores.identity.models[modelKeys[0]] as OSModel<IdentityModel>;
+    return modelStores.identity.models[modelKeys[0]] as OSModel<SupportedIdentity>;
   }
 
   public async getPropertiesModel(): Promise<OSModel<UserPropertiesModel> | undefined> {

--- a/src/core/CoreModuleDirector.ts
+++ b/src/core/CoreModuleDirector.ts
@@ -80,7 +80,7 @@ export class CoreModuleDirector {
 
   /* O P E R A T I O N S */
 
-  public async add(modelName: ModelName, model: OSModel<SupportedModel>, propagate: boolean): Promise<void> {
+  public async add(modelName: ModelName, model: OSModel<SupportedModel>, propagate: boolean = true): Promise<void> {
     logMethodCall("CoreModuleDirector.add", { modelName, model });
     const modelStores = await this.getModelStores();
     modelStores[modelName].add(model, propagate);

--- a/src/core/CoreModuleDirector.ts
+++ b/src/core/CoreModuleDirector.ts
@@ -10,6 +10,7 @@ import { UserPropertiesModel } from "./models/UserPropertiesModel";
 import User from "../onesignal/User";
 import UserData from "./models/UserData";
 import OneSignalError from "../shared/errors/OneSignalError";
+import OneSignal from "../onesignal/OneSignal";
 
 /* Contains OneSignal User-Model-specific logic*/
 
@@ -30,6 +31,7 @@ export class CoreModuleDirector {
     const user = User.createOrGetInstance();
     user.flushModelReferences();
     await user.setupNewUser(true);
+    await OneSignal.user.pushSubscription._resubscribeToPushModelChanges();
   }
 
   public async hydrateUser(user: UserData): Promise<void> {

--- a/src/core/CoreModuleDirector.ts
+++ b/src/core/CoreModuleDirector.ts
@@ -9,6 +9,7 @@ import { ModelName, SupportedModel } from "./models/SupportedModels";
 import { UserPropertiesModel } from "./models/UserPropertiesModel";
 import User from "../onesignal/User";
 import UserData from "./models/UserData";
+import OneSignalError from "../shared/errors/OneSignalError";
 
 /* Contains OneSignal User-Model-specific logic*/
 
@@ -41,6 +42,10 @@ export class CoreModuleDirector {
     properties?.hydrate(user.properties);
 
     const { onesignalId } = user.identity;
+
+    if (!onesignalId) {
+      throw new OneSignalError("OneSignal ID is missing from user data");
+    }
 
     identity?.setOneSignalId(onesignalId);
     properties?.setOneSignalId(onesignalId);

--- a/src/core/models/SubscriptionModels.ts
+++ b/src/core/models/SubscriptionModels.ts
@@ -25,11 +25,7 @@ export interface FutureSubscriptionModel {
   notification_types?: number;
   sdk?: string;
   device_model?: string;
-  device_os?: string;
-  rooted?: boolean;
-  test_type?: number;
-  app_version?: string;
-  net_type?: number;
+  device_os?: number;
   web_auth?: string;
   web_p256?: string;
 }

--- a/src/core/models/SupportedModels.ts
+++ b/src/core/models/SupportedModels.ts
@@ -5,6 +5,7 @@ import { UserPropertiesModel } from "./UserPropertiesModel";
 export enum ModelName {
   Identity = "identity",
   Properties = "properties",
+  // TO DO: make singular
   PushSubscriptions = "pushSubscriptions",
   EmailSubscriptions = "emailSubscriptions",
   SmsSubscriptions = "smsSubscriptions",

--- a/src/core/models/UserData.ts
+++ b/src/core/models/UserData.ts
@@ -1,10 +1,10 @@
-import { IdentityModel } from "./IdentityModel";
+import { SupportedIdentity } from "./IdentityModel";
 import { SupportedSubscription } from "./SubscriptionModels";
 import { UserPropertiesModel } from "./UserPropertiesModel";
 
 type UserData = {
   properties: UserPropertiesModel,
-  identity: IdentityModel,
+  identity: SupportedIdentity,
   subscriptions: SupportedSubscription[]
 };
 

--- a/src/core/requestService/IdentityRequests.ts
+++ b/src/core/requestService/IdentityRequests.ts
@@ -19,7 +19,7 @@ export default class IdentityRequests {
     const { identity, aliasPair } = processIdentityOperation(operation);
 
     const response = await RequestService.identifyUser(aliasPair, identity);
-    return this._processIdentityResponse(response);
+    return IdentityRequests._processIdentityResponse(response);
   }
 
   static async removeIdentity<Model>(operation: Operation<Model>): Promise<ExecutorResult<IdentityModel>> {
@@ -38,7 +38,7 @@ export default class IdentityRequests {
     const { aliasPair } = processIdentityOperation(operation);
 
     const response = await RequestService.deleteAlias(aliasPair, labelToRemove);
-    return this._processIdentityResponse(response);
+    return IdentityRequests._processIdentityResponse(response);
   }
 
   private static _processIdentityResponse(response?: OneSignalApiBaseResponse): ExecutorResult<IdentityModel> {

--- a/src/core/requestService/RequestService.ts
+++ b/src/core/requestService/RequestService.ts
@@ -1,7 +1,7 @@
 import OneSignalApiBaseResponse from "../../shared/api/OneSignalApiBaseResponse";
 import OneSignalError from "../../shared/errors/OneSignalError";
 import OneSignalApiBase from "../../shared/api/OneSignalApiBase";
-import { IdentityModel } from "../models/IdentityModel";
+import { IdentityModel, SupportedIdentity } from "../models/IdentityModel";
 import { FutureSubscriptionModel, SubscriptionModel } from "../models/SubscriptionModels";
 import { isIdentityObject } from "../utils/typePredicates";
 import AliasPair from "./AliasPair";
@@ -51,7 +51,7 @@ export class RequestService {
    * @param identity - identity object
    * @returns identity object
    */
-  static identifyUser(alias: AliasPair, identity: IdentityModel): Promise<OneSignalApiBaseResponse>{
+  static identifyUser(alias: AliasPair, identity: SupportedIdentity): Promise<OneSignalApiBaseResponse>{
     return OneSignalApiBase.put(`user/by/${alias.label}/${alias.id}/identity`, {
       identity
     });
@@ -147,7 +147,7 @@ export class RequestService {
    */
   static transferSubscription(
     subscriptionId: string,
-    identity: IdentityModel,
+    identity: SupportedIdentity,
     retainPreviousOwner: boolean): Promise<OneSignalApiBaseResponse>{
       return OneSignalApiBase.put(`subscriptions/${subscriptionId}/owner`, {
         identity,

--- a/src/core/requestService/SubscriptionRequests.ts
+++ b/src/core/requestService/SubscriptionRequests.ts
@@ -16,7 +16,7 @@ export default class SubscriptionRequests {
     const { subscription, aliasPair } = processSubscriptionOperation(operation);
 
     const response = await RequestService.createSubscription(aliasPair, subscription);
-    return this._processSubscriptionResponse(response);
+    return SubscriptionRequests._processSubscriptionResponse(response);
   }
 
   static async removeSubscription<Model>(operation: Operation<Model>): Promise<ExecutorResult<SupportedSubscription>> {
@@ -25,7 +25,7 @@ export default class SubscriptionRequests {
     const { subscriptionId } = processSubscriptionOperation(operation);
 
     const response = await RequestService.deleteSubscription(subscriptionId);
-    return this._processSubscriptionResponse(response);
+    return SubscriptionRequests._processSubscriptionResponse(response);
   }
 
   static async updateSubscription<Model>(operation: Operation<Model>): Promise<ExecutorResult<SupportedSubscription>> {
@@ -34,7 +34,7 @@ export default class SubscriptionRequests {
     const { subscription, subscriptionId } = processSubscriptionOperation(operation);
 
     const response = await RequestService.updateSubscription(subscriptionId, subscription);
-    return this._processSubscriptionResponse(response);
+    return SubscriptionRequests._processSubscriptionResponse(response);
   }
 
   private static _processSubscriptionResponse(response?: any): ExecutorResult<SupportedSubscription> {

--- a/src/core/requestService/SubscriptionRequests.ts
+++ b/src/core/requestService/SubscriptionRequests.ts
@@ -1,3 +1,4 @@
+import OneSignalError from "../../shared/errors/OneSignalError";
 import { logMethodCall } from "../../shared/utils/utils";
 import ExecutorResult from "../executors/ExecutorResult";
 import { SupportedSubscription } from "../models/SubscriptionModels";
@@ -24,6 +25,10 @@ export default class SubscriptionRequests {
 
     const { subscriptionId } = processSubscriptionOperation(operation);
 
+    if (!subscriptionId) {
+      throw new OneSignalError("removeSubscription: subscriptionId is not defined");
+    }
+
     const response = await RequestService.deleteSubscription(subscriptionId);
     return SubscriptionRequests._processSubscriptionResponse(response);
   }
@@ -32,6 +37,10 @@ export default class SubscriptionRequests {
     logMethodCall("SubscriptionRequests.updateSubscription", operation);
 
     const { subscription, subscriptionId } = processSubscriptionOperation(operation);
+
+    if (!subscriptionId) {
+      throw new OneSignalError("updateSubscription: subscriptionId is not defined");
+    }
 
     const response = await RequestService.updateSubscription(subscriptionId, subscription);
     return SubscriptionRequests._processSubscriptionResponse(response);

--- a/src/core/requestService/UserPropertyRequests.ts
+++ b/src/core/requestService/UserPropertyRequests.ts
@@ -38,7 +38,7 @@ export default class UserPropertyRequests {
       // TO DO: this would just be the session data, link into session service
       deltas: operation.payload as Partial<UserPropertiesModel>
     });
-    return this._processUserPropertyResponse(response);
+    return UserPropertyRequests._processUserPropertyResponse(response);
   }
 
   private static _processUserPropertyResponse(response?: any): ExecutorResult<UserPropertiesModel> {

--- a/src/core/requestService/helpers.ts
+++ b/src/core/requestService/helpers.ts
@@ -1,14 +1,14 @@
 import OneSignalError from "../../shared/errors/OneSignalError";
 import { IdentityModel } from "../models/IdentityModel";
-import { SubscriptionModel } from "../models/SubscriptionModels";
+import { SupportedSubscription } from "../models/SubscriptionModels";
 import { Operation } from "../operationRepo/Operation";
-import { isIdentityObject, isFutureSubscriptionObject } from "../utils/typePredicates";
+import { isIdentityObject, isFutureSubscriptionObject, isCompleteSubscriptionObject } from "../utils/typePredicates";
 import AliasPair from "./AliasPair";
 
 export function processSubscriptionOperation<Model>(operation: Operation<Model>): {
-  subscription: SubscriptionModel;
-  subscriptionId: string;
+  subscription: SupportedSubscription;
   aliasPair: AliasPair;
+  subscriptionId?: string;
 } {
   const subscriptionOSModel = operation.model;
   const subscription = subscriptionOSModel?.data;
@@ -23,7 +23,10 @@ export function processSubscriptionOperation<Model>(operation: Operation<Model>)
     throw new OneSignalError(`processSubscriptionModel: bad subscription object: ${subscription}`);
   }
 
-  const subscriptionId = subscription.id;
+  let subscriptionId;
+  if (isCompleteSubscriptionObject(subscription)) {
+    subscriptionId = subscription?.id;
+  }
 
   // fixes typescript errors
   if (!subscriptionOSModel.onesignalId) {

--- a/src/core/requestService/helpers.ts
+++ b/src/core/requestService/helpers.ts
@@ -32,8 +32,8 @@ export function processSubscriptionOperation<Model>(operation: Operation<Model>)
 
   return {
     subscription,
+    aliasPair: new AliasPair("onesignalId", subscriptionOSModel.onesignalId),
     subscriptionId,
-    aliasPair: new AliasPair("onesignalId", subscriptionOSModel.onesignalId)
   };
 }
 

--- a/src/core/utils/typePredicates.ts
+++ b/src/core/utils/typePredicates.ts
@@ -2,7 +2,8 @@ import { OSModel } from "../modelRepo/OSModel";
 import { OSModelUpdatedArgs } from "../modelRepo/OSModelUpdatedArgs";
 import { CoreDelta, PropertyDelta, ModelDelta } from "../models/CoreDeltas";
 import { IdentityModel } from "../models/IdentityModel";
-import { SubscriptionModel } from "../models/SubscriptionModels";
+import { ModelStoreHydrated } from "../models/ModelStoreChange";
+import { FutureSubscriptionModel, SubscriptionModel } from "../models/SubscriptionModels";
 
 export function isPropertyDelta<Model>(delta: CoreDelta<Model>): delta is PropertyDelta<Model> {
   return (delta as PropertyDelta<Model>).property !== undefined;
@@ -24,10 +25,18 @@ export function isOSModelUpdatedArgs<Model>(obj: any): obj is OSModelUpdatedArgs
   return obj !== null && typeof obj === "object" && obj.constructor === OSModelUpdatedArgs;
 }
 
+export function isModelStoreHydratedObject<Model>(obj: any): obj is ModelStoreHydrated<Model> {
+  return obj !== null && typeof obj === "object" && obj.constructor === ModelStoreHydrated;
+}
+
 export function isIdentityObject(obj: any): obj is IdentityModel {
   return obj.onesignalId !== undefined;
 }
 
-export function isFutureSubscriptionObject(obj: any): obj is SubscriptionModel {
+export function isFutureSubscriptionObject(obj: any): obj is FutureSubscriptionModel {
   return obj.type !== undefined;
+}
+
+export function isCompleteSubscriptionObject(obj: any): obj is SubscriptionModel {
+  return obj.type !== undefined && obj.id !== undefined;
 }

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -147,6 +147,7 @@ export default class OneSignal {
     await InitHelper.polyfillSafariFetch();
     InitHelper.errorIfInitAlreadyCalled();
     await OneSignal._initializeConfig(options);
+    // TODO: move into delayedInit
     await OneSignal._initializeCoreModuleAndUserNamespace();
 
     if (!OneSignal.config) {
@@ -356,7 +357,7 @@ export default class OneSignal {
     // only new notifs that ought to be attributed
     const newNotifsToAttributeWithOutcome = await outcomesHelper.getNotifsToAttributeWithUniqueOutcome(notificationIds);
 
-    if(!outcomesHelper.shouldSendUnique(outcomeAttribution, newNotifsToAttributeWithOutcome)) {
+    if (!outcomesHelper.shouldSendUnique(outcomeAttribution, newNotifsToAttributeWithOutcome)) {
       Log.warn(`'${outcomeName}' was already reported for all notifications.`);
       return;
     }
@@ -371,7 +372,7 @@ export default class OneSignal {
   static coreDirector: CoreModuleDirector;
   static notifications = new NotificationsNamespace();
   static slidedown = new SlidedownNamespace();
-  static user : UserNamespace;
+  static user: UserNamespace;
   /* END NEW USER MODEL CHANGES */
 
   static __doNotShowWelcomeNotification: boolean;
@@ -405,7 +406,7 @@ export default class OneSignal {
   static indexedDb = IndexedDb;
   static mainHelper = MainHelper;
   static subscriptionHelper = SubscriptionHelper;
-  static httpHelper =  HttpHelper;
+  static httpHelper = HttpHelper;
   static eventHelper = EventHelper;
   static initHelper = InitHelper;
   private static pendingInit: boolean = true;

--- a/src/onesignal/PushSubscriptionNamespace.ts
+++ b/src/onesignal/PushSubscriptionNamespace.ts
@@ -1,0 +1,67 @@
+import { ValidatorUtils } from "../page/utils/ValidatorUtils";
+import OneSignalApi from "../shared/api/OneSignalApi";
+import { InvalidArgumentError, InvalidArgumentReason } from "../shared/errors/InvalidArgumentError";
+import { InvalidStateError, InvalidStateReason } from "../shared/errors/InvalidStateError";
+import { NotSubscribedError, NotSubscribedReason } from "../shared/errors/NotSubscribedError";
+import EventHelper from "../shared/helpers/EventHelper";
+import MainHelper from "../shared/helpers/MainHelper";
+import Log from "../shared/libraries/Log";
+import { UpdatePlayerOptions } from "../shared/models/UpdatePlayerOptions";
+import Database from "../shared/services/Database";
+import { awaitOneSignalInitAndSupported, logMethodCall } from "../shared/utils/utils";
+
+export default class PushSubscriptionNamespace {
+  private _id?: string | null;
+  private _token?: string | null;
+  private _optedIn: boolean = false;
+
+  constructor() {
+    Database.getSubscription().then(subscription => {
+      this._optedIn = !subscription.optedOut;
+      this._token = subscription.subscriptionToken;
+    }).catch(e => {
+      Log.error(e);
+    });
+  }
+
+  async disabled(disabled: boolean): Promise<void> {
+    await awaitOneSignalInitAndSupported();
+    logMethodCall('disable', disabled);
+    const appConfig = await Database.getAppConfig();
+    const { appId } = appConfig;
+    const subscription = await Database.getSubscription();
+    const { deviceId } = subscription;
+    if (!appConfig.appId)
+      throw new InvalidStateError(InvalidStateReason.MissingAppId);
+    if (!ValidatorUtils.isValidBoolean(disabled))
+      throw new InvalidArgumentError('disabled', InvalidArgumentReason.Malformed);
+    if (!deviceId) {
+      // TODO: Throw an error here in future v2; for now it may break existing client implementations.
+      Log.info(new NotSubscribedError(NotSubscribedReason.NoDeviceId));
+      return;
+    }
+    const options : UpdatePlayerOptions = {
+      notification_types: MainHelper.getNotificationTypeFromOptIn(!disabled)
+    };
+
+    const authHash = await Database.getExternalUserIdAuthHash();
+    if (!!authHash) {
+      options.external_user_id_auth_hash = authHash;
+    }
+
+    subscription.optedOut = disabled;
+    await OneSignalApi.updatePlayer(appId, deviceId, options);
+    await Database.setSubscription(subscription);
+    EventHelper.onInternalSubscriptionSet(subscription.optedOut).catch(e => {
+      Log.error(e);
+    });
+    EventHelper.checkAndTriggerSubscriptionChanged().catch(e => {
+      Log.error(e);
+    });
+  }
+
+  /*
+  TO DO:
+  on(event: 'subscriptionChange', listener: (isSubscribed: boolean) => void): void;
+  */
+}

--- a/src/onesignal/User.ts
+++ b/src/onesignal/User.ts
@@ -18,7 +18,7 @@ export default class User {
     public userProperties?: OSModel<UserPropertiesModel>,
     // TO DO: explore option to consolidate into a single subscriptions property
     // Might have to make changes to avoid iteration to find correct model we want to modify
-    public pushSubscriptions?: OSModel<SupportedSubscription>,
+    public pushSubscription?: OSModel<SupportedSubscription>,
     public smsSubscriptions?: { [key: string]: OSModel<SupportedSubscription> },
     public emailSubscriptions?: { [key: string]: OSModel<SupportedSubscription> },
   ) {
@@ -70,7 +70,7 @@ export default class User {
   public flushModelReferences(): void {
     this.identity = undefined;
     this.userProperties = undefined;
-    this.pushSubscriptions = undefined;
+    this.pushSubscription = undefined;
     this.smsSubscriptions = undefined;
     this.emailSubscriptions = undefined;
   }
@@ -88,7 +88,7 @@ export default class User {
     // initialize user properties
     if (!this.userProperties) {
       this._createUserProperties(isTemporaryLocal);
-   }
+    }
   }
 
   /**

--- a/src/onesignal/User.ts
+++ b/src/onesignal/User.ts
@@ -147,8 +147,7 @@ export default class User {
     this.userProperties = new OSModel<UserPropertiesModel>(ModelName.Properties, properties);
 
     if (!isTemporaryLocal) {
-      // TO DO: fix user id
-      this.userProperties.setOneSignalId("00000000-0000-0000-0000-000000000000");
+      this.userProperties.setOneSignalId(this.identity?.onesignalId);
     }
 
     OneSignal.coreDirector.add(ModelName.Properties, this.userProperties as OSModel<SupportedModel>, false)

--- a/src/onesignal/UserNamespace.ts
+++ b/src/onesignal/UserNamespace.ts
@@ -6,10 +6,13 @@ import { InvalidArgumentError, InvalidArgumentReason } from "../shared/errors/In
 import { isValidEmail, logMethodCall } from "../shared/utils/utils";
 import User from "./User";
 import OneSignalError from "../shared/errors/OneSignalError";
+import PushSubscriptionNamespace from "./PushSubscriptionNamespace";
 
 export default class UserNamespace {
   private _currentUser?: User;
   public userLoaded: Promise<void>;
+
+  readonly pushSubscription = new PushSubscriptionNamespace();
 
   constructor(private coreDirector: CoreModuleDirector) {
     this.userLoaded = this._loadUser();

--- a/src/page/bell/Bell.ts
+++ b/src/page/bell/Bell.ts
@@ -175,6 +175,9 @@ export default class Bell {
         })
         .then(() => {
           return this.updateState();
+        })
+        .catch(e => {
+          throw e;
         });
     });
 

--- a/src/page/bell/Bell.ts
+++ b/src/page/bell/Bell.ts
@@ -159,7 +159,7 @@ export default class Bell {
     OneSignal.emitter.on(Bell.EVENTS.SUBSCRIBE_CLICK, () => {
       this.dialog.subscribeButton.disabled = true;
       this._ignoreSubscriptionState = true;
-      OneSignal.notifications.disable(false)
+      OneSignal.user.pushSubscription.optIn()
         .then(() => {
           this.dialog.subscribeButton.disabled = false;
           return this.dialog.hide();
@@ -183,7 +183,7 @@ export default class Bell {
 
     OneSignal.emitter.on(Bell.EVENTS.UNSUBSCRIBE_CLICK, () => {
       this.dialog.unsubscribeButton.disabled = true;
-      OneSignal.notifications.disable(true)
+      OneSignal.user.pushSubscription.optOut()
         .then(() => {
           this.dialog.unsubscribeButton.disabled = false;
           return this.dialog.hide();

--- a/src/page/bell/Button.ts
+++ b/src/page/bell/Button.ts
@@ -4,6 +4,7 @@ import ActiveAnimatedElement from "./ActiveAnimatedElement";
 import Bell from "./Bell";
 import LimitStore from "../../shared/services/LimitStore";
 import Message from "./Message";
+import InitHelper from "../../shared/helpers/InitHelper";
 
 
 export default class Button extends ActiveAnimatedElement {
@@ -25,26 +26,26 @@ export default class Button extends ActiveAnimatedElement {
         this.onHovering();
         this.onTap();
       }, { passive: true });
-  
+
       element.addEventListener('mouseenter', () => {
         this.onHovering();
       });
-  
+
       element.addEventListener('mouseleave', () => {
         this.onHovered();
       });
       element.addEventListener('touchmove', () => {
         this.onHovered();
       }, { passive: true });
-  
+
       element.addEventListener('mousedown', () => {
         this.onTap();
       });
-  
+
       element.addEventListener('mouseup', () => {
         this.onEndTap();
       });
-  
+
       element.addEventListener('click', () => {
         this.onHovered();
         this.onClick();
@@ -94,7 +95,7 @@ export default class Button extends ActiveAnimatedElement {
       }
       else {
         // The user is actually subscribed, register him for notifications
-        OneSignal.registerForPushNotifications();
+        InitHelper.registerForPushNotifications();
         this.bell._ignoreSubscriptionState = true;
         OneSignal.emitter.once(OneSignal.EVENTS.SUBSCRIPTION_CHANGED, () => {
           this.bell.message.display(
@@ -114,7 +115,7 @@ export default class Button extends ActiveAnimatedElement {
     else if (this.bell.blocked) {
       if (isUsingSubscriptionWorkaround()) {
         // Show the HTTP popup so users can re-allow notifications
-        OneSignal.registerForPushNotifications();
+        InitHelper.registerForPushNotifications();
       } else {
         this.bell.launcher.activateIfInactive().then(() => {
           this.bell.showDialogProcedure();

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -6,10 +6,10 @@ import { RequestService } from "../../core/requestService/RequestService";
 import AliasPair from "../../core/requestService/AliasPair";
 import Log from "../../shared/libraries/Log";
 import { OSModel } from "../../core/modelRepo/OSModel";
-import { IdentityModel } from "../../core/models/IdentityModel";
+import { SupportedIdentity } from "../../core/models/IdentityModel";
 
 export default class LoginManager {
-  static setExternalId(identityOSModel: OSModel<IdentityModel>, externalId: string): void {
+  static setExternalId(identityOSModel: OSModel<SupportedIdentity>, externalId: string): void {
     logMethodCall("LoginManager.setExternalId", { externalId });
 
     if (!identityOSModel) {
@@ -19,7 +19,7 @@ export default class LoginManager {
     identityOSModel.set('externalId', externalId, false);
   }
 
-  static isIdentified(identity: IdentityModel): boolean {
+  static isIdentified(identity: SupportedIdentity): boolean {
     logMethodCall("LoginManager.isIdentified");
 
     return identity.externalId !== undefined;
@@ -55,7 +55,7 @@ export default class LoginManager {
     return result;
   }
 
-  static async identifyUser(identity: IdentityModel): Promise<Partial<UserData>> {
+  static async identifyUser(identity: SupportedIdentity): Promise<Partial<UserData>> {
     logMethodCall("LoginManager.identifyUser", { identity });
 
     const { externalId } = identity;

--- a/src/page/modules/frames/SubscriptionModalHost.ts
+++ b/src/page/modules/frames/SubscriptionModalHost.ts
@@ -105,7 +105,7 @@ export default class SubscriptionModalHost implements Disposable {
     MainHelper.triggerCustomPromptClicked('granted');
     Log.debug('Calling setSubscription(true)');
     await SubscriptionHelper.registerForPush();
-    await OneSignal.notifications.disable(false);
+    await OneSignal.user.pushSubscription.optIn();
   }
 
   onModalRejected(_: MessengerMessageEvent) {

--- a/src/page/modules/frames/SubscriptionModalHost.ts
+++ b/src/page/modules/frames/SubscriptionModalHost.ts
@@ -35,7 +35,7 @@ export default class SubscriptionModalHost implements Disposable {
    * forever for the first handshake message.
    */
   async load(): Promise<void> {
-    const isPushEnabled = await OneSignal.isPushNotificationsEnabled();
+    const isPushEnabled = await OneSignal.context.subscriptionManager.isPushNotificationsEnabled();
     const notificationPermission = await OneSignal.notifications.getPermissionStatus();
     this.url = SdkEnvironment.getOneSignalApiUrl();
     this.url.pathname = 'webPushModal';

--- a/src/page/userModel/FuturePushSubscriptionRecord.ts
+++ b/src/page/userModel/FuturePushSubscriptionRecord.ts
@@ -1,0 +1,67 @@
+import { Serializable } from "../models/Serializable";
+import { FutureSubscriptionModel, SubscriptionType } from "../../core/models/SubscriptionModels";
+import { EnvironmentInfoHelper } from "../helpers/EnvironmentInfoHelper";
+import { RawPushSubscription } from "src/shared/models/RawPushSubscription";
+import OneSignalUtils from "../../shared/utils/OneSignalUtils";
+
+export default class FuturePushSubscriptionRecord implements Serializable {
+  readonly type: SubscriptionType;
+  readonly token?: string; // maps to legacy player.identifier
+  readonly enabled?: boolean;
+  readonly notificationTypes?: number;
+  readonly sdk: string;
+  readonly deviceModel: string;
+  readonly deviceOs: number;
+  readonly webAuth?: string;
+  readonly webp256?: string;
+
+  constructor(rawPushSubscription: RawPushSubscription) {
+    const environment = EnvironmentInfoHelper.getEnvironmentInfo();
+
+    this.token = this._getToken(rawPushSubscription);
+    this.type = this._getSubscriptionType();
+    this.sdk = __VERSION__;
+    this.deviceModel = navigator.platform;
+    this.deviceOs = isNaN(environment.browserVersion) ? -1 : environment.browserVersion;
+    this.webAuth = rawPushSubscription.w3cAuth;
+    this.webp256 = rawPushSubscription.w3cP256dh;
+  }
+
+  private _getToken(subscription: RawPushSubscription): string | undefined {
+    const browser = OneSignalUtils.redetectBrowserUserAgent();
+    const isLegacySafari = browser.safari && browser.version < 16;
+    return isLegacySafari ? subscription.safariDeviceToken : subscription.w3cEndpoint ?
+      subscription.w3cEndpoint.toString() : undefined;
+  }
+
+  private _getSubscriptionType(): SubscriptionType {
+    const browser = OneSignalUtils.redetectBrowserUserAgent();
+    if (browser.firefox) {
+      return SubscriptionType.FirefoxPush;
+    }
+    if (browser.safari && browser.version >= 16) {
+      return SubscriptionType.SafariPush;
+    }
+    if (browser.safari && browser.version < 16) {
+      return SubscriptionType.SafariLegacyPush;
+    }
+    if (browser.msedge) {
+      return SubscriptionType.WindowPush;
+    }
+    return SubscriptionType.ChromePush;
+  }
+
+  serialize(): FutureSubscriptionModel {
+    return {
+      type: this.type,
+      token: this.token,
+      enabled: this.enabled,
+      notification_types: this.notificationTypes,
+      sdk: this.sdk,
+      device_model: this.deviceModel,
+      device_os: this.deviceOs,
+      web_auth: this.webAuth,
+      web_p256: this.webp256,
+    };
+  }
+}

--- a/src/page/userModel/FuturePushSubscriptionRecord.ts
+++ b/src/page/userModel/FuturePushSubscriptionRecord.ts
@@ -20,6 +20,8 @@ export default class FuturePushSubscriptionRecord implements Serializable {
 
     this.token = this._getToken(rawPushSubscription);
     this.type = this._getSubscriptionType();
+    // TO DO: enabled
+    // this.enabled = true;
     this.sdk = __VERSION__;
     this.deviceModel = navigator.platform;
     this.deviceOs = isNaN(environment.browserVersion) ? -1 : environment.browserVersion;

--- a/src/page/userModel/FuturePushSubscriptionRecord.ts
+++ b/src/page/userModel/FuturePushSubscriptionRecord.ts
@@ -22,6 +22,7 @@ export default class FuturePushSubscriptionRecord implements Serializable {
     this.type = this._getSubscriptionType();
     // TO DO: enabled
     // this.enabled = true;
+    this.notificationTypes = 1;
     this.sdk = __VERSION__;
     this.deviceModel = navigator.platform;
     this.deviceOs = isNaN(environment.browserVersion) ? -1 : environment.browserVersion;

--- a/src/page/userModel/FuturePushSubscriptionRecord.ts
+++ b/src/page/userModel/FuturePushSubscriptionRecord.ts
@@ -42,6 +42,7 @@ export default class FuturePushSubscriptionRecord implements Serializable {
     if (browser.firefox) {
       return SubscriptionType.FirefoxPush;
     }
+    // TO DO: update to use feature detection
     if (browser.safari && browser.version >= 16) {
       return SubscriptionType.SafariPush;
     }

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -30,11 +30,17 @@ export default class EventHelper {
       lastKnownPushEnabled === null ||
       isPushEnabled !== lastKnownPushEnabled
     );
-    if (!didStateChange) return;
+    if (!didStateChange) {
+      return;
+    }
     Log.info(
       `The user's subscription state changed from ` +
         `${lastKnownPushEnabled === null ? '(not stored)' : lastKnownPushEnabled} ⟶ ${subscriptionState.subscribed}`
     );
+    // update notification_types via core module
+    const newNotificationTypes = subscriptionState.optedOut ? -2 : 1;
+    await context.subscriptionManager.updatePushSubscriptionNotificationTypes(newNotificationTypes);
+
     LocalStorage.setIsPushNotificationsEnabled(isPushEnabled);
     appState.lastKnownPushEnabled = isPushEnabled;
     await Database.setAppState(appState);

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -136,7 +136,7 @@ export default class EventHelper {
     }
   }
 
-  static triggerSubscriptionChanged(to) {
+  static triggerSubscriptionChanged(to: boolean) {
     OneSignalEvent.trigger(OneSignal.EVENTS.SUBSCRIPTION_CHANGED, to);
   }
 

--- a/src/shared/helpers/SubscriptionHelper.ts
+++ b/src/shared/helpers/SubscriptionHelper.ts
@@ -47,13 +47,6 @@ export default class SubscriptionHelper {
       return null;
     }
 
-    if (typeof OneSignal !== "undefined") {
-      if (OneSignal._isRegisteringForPush)
-        return null;
-      else
-        OneSignal._isRegisteringForPush = true;
-    }
-
     switch (SdkEnvironment.getWindowEnv()) {
       case WindowEnvironmentKind.Host:
       case WindowEnvironmentKind.OneSignalSubscriptionModal:
@@ -141,13 +134,8 @@ export default class SubscriptionHelper {
         );
         break;
       default:
-        if (typeof OneSignal !== "undefined")
-          OneSignal._isRegisteringForPush = false;
         throw new InvalidStateError(InvalidStateReason.UnsupportedEnvironment);
     }
-
-    if (typeof OneSignal !== "undefined")
-      OneSignal._isRegisteringForPush = false;
 
     return subscription;
   }

--- a/src/shared/managers/CustomLinkManager.ts
+++ b/src/shared/managers/CustomLinkManager.ts
@@ -130,7 +130,7 @@ export class CustomLinkManager {
 
   private async handleClick(element: HTMLElement): Promise<void> {
     if (CustomLinkManager.isPushEnabled()) {
-      await OneSignal.notifications.disable(true);
+      await OneSignal.user.pushSubscription.optOut();
       await this.setTextFromPushStatus(element);
     } else {
       if (!CustomLinkManager.isOptedOut()) {
@@ -143,7 +143,7 @@ export class CustomLinkManager {
         }
         return;
       }
-      await OneSignal.notifications.disable(false);
+      await OneSignal.user.pushSubscription.optIn();
       // once subscribed, prevent unsubscribe by hiding customlinks
       if (!this.config?.unsubscribeEnabled && CustomLinkManager.isPushEnabled()) {
         this.hideCustomLinkContainers();

--- a/src/shared/managers/CustomLinkManager.ts
+++ b/src/shared/managers/CustomLinkManager.ts
@@ -2,7 +2,7 @@ import { ResourceLoadState } from "../../page/services/DynamicResourceLoader";
 import { CUSTOM_LINK_CSS_CLASSES, CUSTOM_LINK_CSS_SELECTORS } from "../slidedown/constants";
 import { addCssClass } from "../utils/utils";
 import LocalStorage from "../utils/LocalStorage";
-import { RegisterOptions } from "../helpers/InitHelper";
+import InitHelper, { RegisterOptions } from "../helpers/InitHelper";
 import Log from "../libraries/Log";
 import { AppUserConfigCustomLinkOptions } from "../models/Prompts";
 
@@ -136,7 +136,7 @@ export class CustomLinkManager {
       if (!CustomLinkManager.isOptedOut()) {
         const autoAccept = !OneSignal.environmentInfo.requiresUserInteraction;
         const options: RegisterOptions = { autoAccept };
-        await OneSignal.registerForPushNotifications(options);
+        await InitHelper.registerForPushNotifications(options);
         // once subscribed, prevent unsubscribe by hiding customlinks
         if (!this.config?.unsubscribeEnabled && CustomLinkManager.isPushEnabled()) {
           this.hideCustomLinkContainers();

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -162,7 +162,9 @@ export class SubscriptionManager {
 
       for (let i=0; i<keys.length; i++) {
         const key = keys[i];
-        pushModel.set(key, serializedSubscriptionRecord[key]);
+        if (serializedSubscriptionRecord[key]) {
+          pushModel.set(key, serializedSubscriptionRecord[key]);
+        }
       }
     }
   }

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -373,12 +373,10 @@ export class SubscriptionManager {
         case NotificationPermission.Default:
           Log.debug('Exiting subscription and not registering worker because the permission was dismissed.');
           OneSignal._sessionInitAlreadyRunning = false;
-          OneSignal._isRegisteringForPush = false;
           throw new PushPermissionNotGrantedError(PushPermissionNotGrantedErrorReason.Dismissed);
         case NotificationPermission.Denied:
           Log.debug('Exiting subscription and not registering worker because the permission was blocked.');
           OneSignal._sessionInitAlreadyRunning = false;
-          OneSignal._isRegisteringForPush = false;
           throw new PushPermissionNotGrantedError(PushPermissionNotGrantedErrorReason.Blocked);
       }
     }

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -28,6 +28,11 @@ import SubscriptionError, { SubscriptionErrorReason } from "../errors/Subscripti
 import Log from "../libraries/Log";
 import { RawPushSubscription } from "../models/RawPushSubscription";
 import OneSignalApiShared from "../api/OneSignalApiShared";
+import OneSignal from "../../onesignal/OneSignal";
+import { ModelName, SupportedModel } from "../../core/models/SupportedModels";
+import { OSModel } from "../../core/modelRepo/OSModel";
+import FuturePushSubscriptionRecord from "../../page/userModel/FuturePushSubscriptionRecord";
+import User from "../../onesignal/User";
 
 export interface SubscriptionManagerConfig {
   safariWebId?: string;
@@ -123,6 +128,13 @@ export class SubscriptionManager {
 
         } else {
           rawPushSubscription = await this.subscribeFcmFromPage(subscriptionStrategy);
+          const pushModel = new OSModel<SupportedModel>(
+            ModelName.PushSubscriptions,
+            new FuturePushSubscriptionRecord(rawPushSubscription)
+          );
+          const user = User.createOrGetInstance();
+          pushModel.setOneSignalId(user.identity?.onesignalId);
+          await OneSignal.coreDirector.add(ModelName.PushSubscriptions, pushModel);
         }
         break;
       default:

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -33,6 +33,9 @@ import { ModelName, SupportedModel } from "../../core/models/SupportedModels";
 import { OSModel } from "../../core/modelRepo/OSModel";
 import FuturePushSubscriptionRecord from "../../page/userModel/FuturePushSubscriptionRecord";
 import User from "../../onesignal/User";
+import { FutureSubscriptionModel, SupportedSubscription } from "../../core/models/SubscriptionModels";
+import { StringKeys } from "../../core/models/StringKeys";
+import OneSignalError from "../errors/OneSignalError";
 
 export interface SubscriptionManagerConfig {
   safariWebId?: string;
@@ -128,13 +131,7 @@ export class SubscriptionManager {
 
         } else {
           rawPushSubscription = await this.subscribeFcmFromPage(subscriptionStrategy);
-          const pushModel = new OSModel<SupportedModel>(
-            ModelName.PushSubscriptions,
-            new FuturePushSubscriptionRecord(rawPushSubscription)
-          );
-          const user = User.createOrGetInstance();
-          pushModel.setOneSignalId(user.identity?.onesignalId);
-          await OneSignal.coreDirector.add(ModelName.PushSubscriptions, pushModel);
+          await this._updatePushSubscriptionModelWithRawSubscription(rawPushSubscription);
         }
         break;
       default:
@@ -142,6 +139,42 @@ export class SubscriptionManager {
     }
 
     return rawPushSubscription;
+  }
+
+  private async _updatePushSubscriptionModelWithRawSubscription(rawPushSubscription: RawPushSubscription) {
+    let pushModel = await OneSignal.coreDirector.getPushSubscriptionModel();
+
+    if (!pushModel) {
+      // new subscription
+      pushModel = new OSModel<SupportedSubscription>(
+        ModelName.PushSubscriptions,
+        new FuturePushSubscriptionRecord(rawPushSubscription).serialize()
+      );
+
+      const user = User.createOrGetInstance();
+      pushModel.setOneSignalId(user.identity?.onesignalId);
+      await OneSignal.coreDirector.add(ModelName.PushSubscriptions, pushModel as OSModel<SupportedModel>);
+      return;
+    } else {
+      // resubscribing. update existing push subscription model
+      const serializedSubscriptionRecord = new FuturePushSubscriptionRecord(rawPushSubscription).serialize();
+      const keys = Object.keys(serializedSubscriptionRecord) as StringKeys<FutureSubscriptionModel>[];
+
+      for (let i=0; i<keys.length; i++) {
+        const key = keys[i];
+        pushModel.set(key, serializedSubscriptionRecord[key]);
+      }
+    }
+  }
+
+  async updatePushSubscriptionNotificationTypes(notificationTypes: number): Promise<void> {
+    const pushModel = await OneSignal.coreDirector.getPushSubscriptionModel();
+    if (!pushModel) {
+      throw new OneSignalError(
+        `Cannot update notification_types for push subscription model because it does not exist.`
+        );
+    }
+    pushModel.set("notification_types", notificationTypes);
   }
 
   /**
@@ -228,12 +261,6 @@ export class SubscriptionManager {
       throw new NotImplementedError();
     } else if (strategy === UnsubscriptionStrategy.MarkUnsubscribed) {
       if (SdkEnvironment.getWindowEnv() === WindowEnvironmentKind.ServiceWorker) {
-        const { deviceId } = await Database.getSubscription();
-
-        await OneSignalApiShared.updatePlayer(this.context.appConfig.appId, deviceId, {
-          notification_types: SubscriptionStateKind.MutedByApi
-        });
-
         await Database.put('Options', { key: 'optedOut', value: true });
       } else {
         throw new NotImplementedError();

--- a/src/shared/models/DeliveryPlatformKind.ts
+++ b/src/shared/models/DeliveryPlatformKind.ts
@@ -1,6 +1,6 @@
 export enum DeliveryPlatformKind {
   ChromeLike = 5,
-  Safari = 7,
+  SafariLegacy = 7,
   Firefox = 8,
   Email = 11,
   Edge = 12,

--- a/src/shared/models/DeviceRecord.ts
+++ b/src/shared/models/DeviceRecord.ts
@@ -7,6 +7,7 @@ import OneSignalUtils from '../utils/OneSignalUtils';
 import { DeliveryPlatformKind } from './DeliveryPlatformKind';
 import { SubscriptionStateKind } from './SubscriptionStateKind';
 
+// TO DO: deprecate after user-model if possible
 export interface FlattenedDeviceRecord {
   device_type: DeliveryPlatformKind;
   language: string;

--- a/src/shared/models/DeviceRecord.ts
+++ b/src/shared/models/DeviceRecord.ts
@@ -63,7 +63,7 @@ export abstract class DeviceRecord implements Serializable {
     const browser = OneSignalUtils.redetectBrowserUserAgent();
 
     if (this.isSafari()) {
-      return DeliveryPlatformKind.Safari;
+      return DeliveryPlatformKind.SafariLegacy;
     } else if (browser.firefox) {
       return DeliveryPlatformKind.Firefox;
     } else if (browser.msedge) {

--- a/src/shared/models/PushDeviceRecord.ts
+++ b/src/shared/models/PushDeviceRecord.ts
@@ -5,6 +5,7 @@ import { RawPushSubscription } from './RawPushSubscription';
 import { SubscriptionStateKind } from './SubscriptionStateKind';
 import { DeviceRecord, FlattenedDeviceRecord } from './DeviceRecord';
 
+// TO DO: deprecate in favor of FuturePushSubscriptionRecord.ts
 export interface SerializedPushDeviceRecord extends FlattenedDeviceRecord {
   identifier?: string | null;
   web_auth?: string;

--- a/src/shared/models/RawPushSubscription.ts
+++ b/src/shared/models/RawPushSubscription.ts
@@ -35,7 +35,7 @@ export class RawPushSubscription implements Serializable {
       if (!!this.existingW3cPushSubscription.w3cEndpoint !== !!this.w3cEndpoint) {
         return true;
       }
-      if (!!this.existingW3cPushSubscription.w3cEndpoint && !!this.w3cEndpoint && 
+      if (!!this.existingW3cPushSubscription.w3cEndpoint && !!this.w3cEndpoint &&
         this.existingW3cPushSubscription.w3cEndpoint.toString() !== this.w3cEndpoint.toString()) {
           return true;
       }

--- a/test/unit/models/deliveryPlatformKind.ts
+++ b/test/unit/models/deliveryPlatformKind.ts
@@ -4,7 +4,7 @@ import { DeliveryPlatformKind } from '../../../src/shared/models/DeliveryPlatfor
 
 test(`delivery platform constants should be correct`, async t => {
   t.is(DeliveryPlatformKind.ChromeLike, 5);
-  t.is(DeliveryPlatformKind.Safari, 7);
+  t.is(DeliveryPlatformKind.SafariLegacy, 7);
   t.is(DeliveryPlatformKind.Firefox, 8);
   t.is(DeliveryPlatformKind.Edge, 12);
 });

--- a/test/unit/onesignal/registerForPushNotifications.ts
+++ b/test/unit/onesignal/registerForPushNotifications.ts
@@ -39,6 +39,6 @@ test('registerForPushNotifications: after OneSignal.initialized', async t => {
   (global as any).OneSignal._initCalled = false;
 
   const spy = sandbox.stub(InitHelper, 'registerForPushNotifications').resolves();
-  await OneSignal.registerForPushNotifications();
+  await InitHelper.registerForPushNotifications();
   t.is(spy.calledOnce, true);
 });


### PR DESCRIPTION
# Description
## 1 Line Summary
Implements `pushSubscription` namespace on `user` and connects push subscription to core module.

## Details
### `pushSubscription` namespace
The `pushSubscription` namespace contains push subscription data and functions to enable/disable the push subscription.

```ts
class PushSubscriptionNamespace {
   id?: string;
   token?: string;
   optedIn?: boolean;

   optIn(): Promise<void>;
   optOut(): Promise<void>;
}
```

More details in commits

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/931)
<!-- Reviewable:end -->
