### PR TITLE
[user model] logout

### DIFF
--- a/src/core/CoreModule.ts
+++ b/src/core/CoreModule.ts
@@ -38,8 +38,9 @@ export default class CoreModule {
     await this.initPromise;
   }
 
-  public resetModelRepo() {
+  public async resetModelRepoAndCache() {
     logMethodCall("CoreModule.resetModelRepo");
+    await this.modelCache.reset();
     const modelStores = OSModelStoreFactory.build<SupportedModel>();
     this.modelRepo = new ModelRepo(this.modelCache, modelStores);
     this.operationRepo?.setModelRepoAndResubscribe(this.modelRepo);

--- a/src/core/CoreModuleDirector.ts
+++ b/src/core/CoreModuleDirector.ts
@@ -25,12 +25,16 @@ export class CoreModuleDirector {
 
   /* L O G I N */
 
-  public async resetUser(): Promise<void> {
-    this.core.resetModelRepo();
+  /**
+   * Reset user - used to reset user data when user logs in and out
+   * @param isTempUser - used when creating a local-only temporary user while logging in
+   */
+  public async resetUserWithSetting(isTempUser: boolean): Promise<void> {
+    await this.core.resetModelRepoAndCache();
 
     const user = User.createOrGetInstance();
     user.flushModelReferences();
-    await user.setupNewUser(true);
+    await user.setupNewUser(isTempUser);
     await OneSignal.user.pushSubscription._resubscribeToPushModelChanges();
   }
 

--- a/src/core/caching/ModelCache.ts
+++ b/src/core/caching/ModelCache.ts
@@ -119,4 +119,13 @@ export default class ModelCache {
 
     return models.map(OSModel.decode);
   }
+
+  async reset(): Promise<void> {
+    logMethodCall("ModelCache.reset");
+    const removePromises: Promise<unknown>[] = [];
+    Object.values(ModelName).forEach(async (modelName: ModelName) => {
+      removePromises.push(Database.singletonInstance.remove(modelName));
+    });
+    await Promise.all(removePromises);
+  }
 }

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -117,7 +117,7 @@ export default class OneSignal {
       LoginManager.setExternalId(identityModel, externalId);
 
       const userData = await LoginManager.getAllUserData();
-      await this.coreDirector.resetUser();
+      await this.coreDirector.resetUserWithSetting(true);
 
       LoginManager.identifyOrUpsertUser(userData, isIdentified).then(async result => {
         const { identity } = result;

--- a/src/page/userModel/FuturePushSubscriptionRecord.ts
+++ b/src/page/userModel/FuturePushSubscriptionRecord.ts
@@ -19,7 +19,7 @@ export default class FuturePushSubscriptionRecord implements Serializable {
     const environment = EnvironmentInfoHelper.getEnvironmentInfo();
 
     this.token = this._getToken(rawPushSubscription);
-    this.type = this._getSubscriptionType();
+    this.type = FuturePushSubscriptionRecord.getSubscriptionType();
     // TO DO: enabled
     // this.enabled = true;
     this.notificationTypes = 1;
@@ -37,7 +37,23 @@ export default class FuturePushSubscriptionRecord implements Serializable {
       subscription.w3cEndpoint.toString() : undefined;
   }
 
-  private _getSubscriptionType(): SubscriptionType {
+  serialize(): FutureSubscriptionModel {
+    return {
+      type: this.type,
+      token: this.token,
+      enabled: this.enabled,
+      notification_types: this.notificationTypes,
+      sdk: this.sdk,
+      device_model: this.deviceModel,
+      device_os: this.deviceOs,
+      web_auth: this.webAuth,
+      web_p256: this.webp256,
+    };
+  }
+
+  /* S T A T I C */
+
+  static getSubscriptionType(): SubscriptionType {
     const browser = OneSignalUtils.redetectBrowserUserAgent();
     if (browser.firefox) {
       return SubscriptionType.FirefoxPush;
@@ -53,19 +69,5 @@ export default class FuturePushSubscriptionRecord implements Serializable {
       return SubscriptionType.WindowPush;
     }
     return SubscriptionType.ChromePush;
-  }
-
-  serialize(): FutureSubscriptionModel {
-    return {
-      type: this.type,
-      token: this.token,
-      enabled: this.enabled,
-      notification_types: this.notificationTypes,
-      sdk: this.sdk,
-      device_model: this.deviceModel,
-      device_os: this.deviceOs,
-      web_auth: this.webAuth,
-      web_p256: this.webp256,
-    };
   }
 }


### PR DESCRIPTION
# Description
## 1 Line Summary
Logout function implementation and associated changes including ability to reset model cache.

## Details
### Logout/Login
Calling logout resets the user and clears the model repo and cache.

Change to pass down the `subscriptionId` if one exists on `login` in order to transfer the subscription in case the `externalId` already exists.

### Resetting the user
Changes to also clear the model cache when resetting the user. The user is reset on `login` (to create a temporary user while we wait for the `onesignalId`) and on `logout` (to create a fresh anonymous user).

More details in commits

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/932)
<!-- Reviewable:end -->
