### PR TITLE
`setAppId` function implementation

### DIFF
--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -188,6 +188,15 @@ export default class OneSignal {
     await OneSignal.delayedInit();
   }
 
+  /**
+   * Initializes OneSignal with the given app id and no additional user options
+   * @param appId - The OneSignal app ID
+   */
+  static async setAppId(appId: string) {
+    logMethodCall('setAppId', { appId });
+    await OneSignal.init({ appId });
+  }
+
   private static async delayedInit(): Promise<void> {
     OneSignal.pendingInit = false;
     // Ignore Promise as doesn't return until the service worker becomes active.


### PR DESCRIPTION
Motivation: to match mobile, we want to provide `setAppId` function that simply calls `OneSignal.init(<app_id>);`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/935)
<!-- Reviewable:end -->
