### PR TITLE
User model - Path and filenames changes for 16 major release 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,8 @@ build/size-analysis.html
 *.key
 *.crt
 yarn-error.log
-dist/Dev-OneSignalSDK.js
-dist/Dev-OneSignalSDK.js.map
+dist/Dev-OneSignalSDK.page.js
+dist/Dev-OneSignalSDK.page.js.map
 .vscode/**
 !.vscode/launch.json
 

--- a/build/config/page-sdk-es6.config.js
+++ b/build/config/page-sdk-es6.config.js
@@ -20,7 +20,7 @@ async function getWebpackPlugins() {
   const plugins = [
     new CheckerPlugin(),
       new webpack.optimize.ModuleConcatenationPlugin(),
-      new ExtractTextPlugin("OneSignalSDKStyles.css"),
+      new ExtractTextPlugin("OneSignalSDK.page.styles.css"),
       new webpack.DefinePlugin({
         __BUILD_TYPE__: JSON.stringify(env),
         __BUILD_ORIGIN__: JSON.stringify(buildOrigin),

--- a/build/config/page-sdk-es6.config.js
+++ b/build/config/page-sdk-es6.config.js
@@ -73,7 +73,7 @@ async function generateWebpackConfig() {
   return {
     target: 'web',
     entry: {
-      'OneSignalPageSDKES6.js': path.resolve('build/ts-to-es6/src/entries/pageSdkInit.js'),
+      'OneSignalSDK.page.es6.js': path.resolve('build/ts-to-es6/src/entries/pageSdkInit.js'),
     },
     output: {
       path: path.resolve('build/bundles'),

--- a/build/config/sdk.config.js
+++ b/build/config/sdk.config.js
@@ -111,7 +111,7 @@ async function generateWebpackConfig() {
   return {
     target: 'web',
     entry: {
-      'OneSignalSDK.js': path.resolve('build/ts-to-es6/src/entries/sdk.js'),
+      'OneSignalSDK.page.js': path.resolve('build/ts-to-es6/src/entries/sdk.js'),
       'OneSignalSDKStyles.css': path.resolve('src/entries/stylesheet.scss')
     },
     output: {
@@ -140,8 +140,7 @@ async function generateWebpackConfig() {
                 'PushNotSupportedError',
                 'PushPermissionNotGrantedError',
                 'SdkInitError',
-                'TimeoutError',
-                'OneSignalStubES6'
+                'TimeoutError'
               ]
             } : false,
             output: {

--- a/build/config/sdk.config.js
+++ b/build/config/sdk.config.js
@@ -57,7 +57,7 @@ async function getWebpackPlugins() {
   const plugins = [
     new CheckerPlugin(),
       new webpack.optimize.ModuleConcatenationPlugin(),
-      new ExtractTextPlugin("OneSignalSDKStyles.css"),
+      new ExtractTextPlugin("OneSignalSDK.page.styles.css"),
       new webpack.DefinePlugin({
         __BUILD_TYPE__: JSON.stringify(env),
         __BUILD_ORIGIN__: JSON.stringify(buildOrigin),
@@ -112,7 +112,7 @@ async function generateWebpackConfig() {
     target: 'web',
     entry: {
       'OneSignalSDK.page.js': path.resolve('build/ts-to-es6/src/entries/sdk.js'),
-      'OneSignalSDKStyles.css': path.resolve('src/entries/stylesheet.scss')
+      'OneSignalSDK.page.styles.css': path.resolve('src/entries/stylesheet.scss')
     },
     output: {
       path: path.resolve('build/bundles'),

--- a/build/config/serviceworker.config.js
+++ b/build/config/serviceworker.config.js
@@ -71,7 +71,7 @@ async function generateWebpackConfig() {
   return {
     target: "web",
     entry: {
-      "OneSignalSDKWorker.js": path.resolve("build/ts-to-es6/src/entries/worker.js"),
+      "OneSignalSDK.sw.js": path.resolve("build/ts-to-es6/src/entries/worker.js"),
     },
     output: {
       path: path.resolve("build/bundles"),

--- a/build/config/webpack.config.js
+++ b/build/config/webpack.config.js
@@ -69,7 +69,7 @@ async function generateWebpackConfig() {
   return {
     target: 'web',
     entry: {
-      'OneSignalSDK.js': path.resolve('build/ts-to-es6/src/entries/sdk.js'),
+      'OneSignalSDK.page.js': path.resolve('build/ts-to-es6/src/entries/sdk.js'),
       'OneSignalSDKWorker.js': path.resolve('build/ts-to-es6/src/entries/worker.js'),
       'OneSignalSDKStyles.css': path.resolve('src/entries/stylesheet.scss'),
     },

--- a/build/config/webpack.config.js
+++ b/build/config/webpack.config.js
@@ -70,7 +70,7 @@ async function generateWebpackConfig() {
     target: 'web',
     entry: {
       'OneSignalSDK.page.js': path.resolve('build/ts-to-es6/src/entries/sdk.js'),
-      'OneSignalSDKWorker.js': path.resolve('build/ts-to-es6/src/entries/worker.js'),
+      'OneSignalSDK.sw.js': path.resolve('build/ts-to-es6/src/entries/worker.js'),
       'OneSignalSDK.page.styles.css': path.resolve('src/entries/stylesheet.scss'),
     },
     output: {

--- a/build/config/webpack.config.js
+++ b/build/config/webpack.config.js
@@ -27,7 +27,7 @@ async function getWebpackPlugins() {
   const plugins = [
     new CheckerPlugin(),
     new webpack.optimize.ModuleConcatenationPlugin(),
-    new ExtractTextPlugin('OneSignalSDKStyles.css'),
+    new ExtractTextPlugin('OneSignalSDK.page.styles.css'),
     new webpack.DefinePlugin(await getBuildDefines()),
   ];
   if (!!process.env.ANALYZE) {
@@ -71,7 +71,7 @@ async function generateWebpackConfig() {
     entry: {
       'OneSignalSDK.page.js': path.resolve('build/ts-to-es6/src/entries/sdk.js'),
       'OneSignalSDKWorker.js': path.resolve('build/ts-to-es6/src/entries/worker.js'),
-      'OneSignalSDKStyles.css': path.resolve('src/entries/stylesheet.scss'),
+      'OneSignalSDK.page.styles.css': path.resolve('src/entries/stylesheet.scss'),
     },
     output: {
       path: path.resolve('build/bundles'),

--- a/build/scripts/buildServiceWorker.sh
+++ b/build/scripts/buildServiceWorker.sh
@@ -2,4 +2,4 @@
 
 # Builds the local service worker file for express_webpack for use in local dev env
 echo "Building local service worker file with arguments: ${1} ${2}"
-echo "importScripts(\"https://${1}${2}/sdks/Dev-OneSignalSDKWorker.js\");" > express_webpack/push/onesignal/OneSignalSDKWorker.js
+echo "importScripts(\"https://${1}${2}/sdks/Dev-OneSignalSDK.sw.js\");" > express_webpack/push/onesignal/OneSignalSDK.sw.js

--- a/build/scripts/buildServiceWorker.sh
+++ b/build/scripts/buildServiceWorker.sh
@@ -2,4 +2,4 @@
 
 # Builds the local service worker file for express_webpack for use in local dev env
 echo "Building local service worker file with arguments: ${1} ${2}"
-echo "importScripts(\"https://${1}${2}/sdks/Dev-OneSignalSDK.sw.js\");" > express_webpack/push/onesignal/OneSignalSDK.sw.js
+echo "importScripts(\"https://${1}${2}/sdks/web/v16/Dev-OneSignalSDK.sw.js\");" > express_webpack/push/onesignal/OneSignalSDK.sw.js

--- a/build/scripts/publish.sh
+++ b/build/scripts/publish.sh
@@ -24,8 +24,8 @@ cp build/bundles/OneSignalSDK.page.es6.js.map build/releases/$PREFIX"OneSignalSD
 cp build/bundles/OneSignalSDKWorker.js build/releases/$PREFIX"OneSignalSDKWorker.js"
 cp build/bundles/OneSignalSDKWorker.js.map build/releases/$PREFIX"OneSignalSDKWorker.js.map"
 
-cp build/bundles/OneSignalSDKStyles.css build/releases/$PREFIX"OneSignalSDKStyles.css"
-cp build/bundles/OneSignalSDKStyles.css.map build/releases/$PREFIX"OneSignalSDKStyles.css.map"
+cp build/bundles/OneSignalSDK.page.styles.css build/releases/$PREFIX"OneSignalSDK.page.styles.css"
+cp build/bundles/OneSignalSDK.page.styles.css.map build/releases/$PREFIX"OneSignalSDK.page.styles.css.map"
 
 if [ "$ENV" = "staging" ]; then
   sed -i 's/sourceMappingURL=OneSignal/sourceMappingURL=Staging-OneSignal/' build/releases/Staging-*.js

--- a/build/scripts/publish.sh
+++ b/build/scripts/publish.sh
@@ -18,8 +18,8 @@ mkdir build/releases
 
 cp build/bundles/OneSignalSDK.page.js build/releases/$PREFIX"OneSignalSDK.page.js"
 cp build/bundles/OneSignalSDK.page.js.map build/releases/$PREFIX"OneSignalSDK.page.js.map"
-cp build/bundles/OneSignalPageSDKES6.js build/releases/$PREFIX"OneSignalPageSDKES6.js"
-cp build/bundles/OneSignalPageSDKES6.js.map build/releases/$PREFIX"OneSignalPageSDKES6.js.map"
+cp build/bundles/OneSignalSDK.page.es6.js build/releases/$PREFIX"OneSignalSDK.page.es6.js"
+cp build/bundles/OneSignalSDK.page.es6.js.map build/releases/$PREFIX"OneSignalSDK.page.es6.js.map"
 
 cp build/bundles/OneSignalSDKWorker.js build/releases/$PREFIX"OneSignalSDKWorker.js"
 cp build/bundles/OneSignalSDKWorker.js.map build/releases/$PREFIX"OneSignalSDKWorker.js.map"

--- a/build/scripts/publish.sh
+++ b/build/scripts/publish.sh
@@ -21,8 +21,8 @@ cp build/bundles/OneSignalSDK.page.js.map build/releases/$PREFIX"OneSignalSDK.pa
 cp build/bundles/OneSignalSDK.page.es6.js build/releases/$PREFIX"OneSignalSDK.page.es6.js"
 cp build/bundles/OneSignalSDK.page.es6.js.map build/releases/$PREFIX"OneSignalSDK.page.es6.js.map"
 
-cp build/bundles/OneSignalSDKWorker.js build/releases/$PREFIX"OneSignalSDKWorker.js"
-cp build/bundles/OneSignalSDKWorker.js.map build/releases/$PREFIX"OneSignalSDKWorker.js.map"
+cp build/bundles/OneSignalSDK.sw.js build/releases/$PREFIX"OneSignalSDK.sw.js"
+cp build/bundles/OneSignalSDK.sw.js.map build/releases/$PREFIX"OneSignalSDK.sw.js.map"
 
 cp build/bundles/OneSignalSDK.page.styles.css build/releases/$PREFIX"OneSignalSDK.page.styles.css"
 cp build/bundles/OneSignalSDK.page.styles.css.map build/releases/$PREFIX"OneSignalSDK.page.styles.css.map"

--- a/build/scripts/publish.sh
+++ b/build/scripts/publish.sh
@@ -16,8 +16,8 @@ pwd
 
 mkdir build/releases
 
-cp build/bundles/OneSignalSDK.js build/releases/$PREFIX"OneSignalSDK.js"
-cp build/bundles/OneSignalSDK.js.map build/releases/$PREFIX"OneSignalSDK.js.map"
+cp build/bundles/OneSignalSDK.page.js build/releases/$PREFIX"OneSignalSDK.page.js"
+cp build/bundles/OneSignalSDK.page.js.map build/releases/$PREFIX"OneSignalSDK.page.js.map"
 cp build/bundles/OneSignalPageSDKES6.js build/releases/$PREFIX"OneSignalPageSDKES6.js"
 cp build/bundles/OneSignalPageSDKES6.js.map build/releases/$PREFIX"OneSignalPageSDKES6.js.map"
 

--- a/express_webpack/OneSignalSDK.sw.js
+++ b/express_webpack/OneSignalSDK.sw.js
@@ -1,1 +1,1 @@
-importScripts("https://localhost:4001/sdks/Dev-OneSignalSDK.sw.js");
+importScripts("https://localhost:4001/sdks/web/v16/Dev-OneSignalSDK.sw.js");

--- a/express_webpack/OneSignalSDK.sw.js
+++ b/express_webpack/OneSignalSDK.sw.js
@@ -1,0 +1,1 @@
+importScripts("https://localhost:4001/sdks/Dev-OneSignalSDK.sw.js");

--- a/express_webpack/OneSignalSDKWorker.js
+++ b/express_webpack/OneSignalSDKWorker.js
@@ -1,1 +1,0 @@
-importScripts("https://localhost:4001/sdks/Dev-OneSignalSDKWorker.js");

--- a/express_webpack/README.md
+++ b/express_webpack/README.md
@@ -58,12 +58,12 @@ If no custom origins are set, defaults will be used: `localhost` for build and `
 ```
 yarn build:dev-prod -b texas
 ```
-This sets the BUILD environment origin to `texas` which will result in SDK files being fetched from `https://texas:4001/sdks/` and the API environment origin to production which will make all onesignal api calls to the production origin `https://onesignal.com/api/v1/apps/<app>`
+This sets the BUILD environment origin to `texas` which will result in SDK files being fetched from `https://texas:4001/sdks/web/v##/` and the API environment origin to production which will make all onesignal api calls to the production origin `https://onesignal.com/api/v1/apps/<app>`
 
 ```
 yarn build:dev-dev -b localhost -a texas
 ```
-This sets the BUILD environment origin to `localhost` which will result in SDK files being fetched from `https://localhost:4001/sdks/` and the API environment origin to the default `https://texas:3001/api/v1/apps/<app_id>`
+This sets the BUILD environment origin to `localhost` which will result in SDK files being fetched from `https://localhost:4001/sdks/web/v##/` and the API environment origin to the default `https://texas:3001/api/v1/apps/<app_id>`
 
 ### HTTP
 All builds default to `https` unless `--http` is passed to the end of the build command...

--- a/express_webpack/amp/OneSignalSDK.sw.js
+++ b/express_webpack/amp/OneSignalSDK.sw.js
@@ -1,1 +1,1 @@
-importScripts('https://localhost:4001/sdks/Dev-OneSignalSDK.sw.js');
+importScripts('https://localhost:4001/sdks/web/v16/Dev-OneSignalSDK.sw.js');

--- a/express_webpack/amp/OneSignalSDK.sw.js
+++ b/express_webpack/amp/OneSignalSDK.sw.js
@@ -1,0 +1,1 @@
+importScripts('https://localhost:4001/sdks/Dev-OneSignalSDK.sw.js');

--- a/express_webpack/amp/OneSignalSDKWorker.js
+++ b/express_webpack/amp/OneSignalSDKWorker.js
@@ -1,1 +1,0 @@
-importScripts('https://localhost:4001/sdks/Dev-OneSignalSDKWorker.js');

--- a/express_webpack/amp/index.html
+++ b/express_webpack/amp/index.html
@@ -24,7 +24,7 @@
       onesignal.init({ 
         appId,
         serviceWorkerParam: { scope: "/" + SERVICE_WORKER_PATH },
-        serviceWorkerPath: SERVICE_WORKER_PATH + "OneSignalSDKWorker.js",
+        serviceWorkerPath: SERVICE_WORKER_PATH + "OneSignalSDK.sw.js",
       });
     });
   </script>
@@ -105,7 +105,7 @@
     const ampWebPushElement = document.getElementById("amp-web-push");
     ampWebPushElement.setAttribute("helper-iframe-url", "https://localhost:4001/amp/amp-helper-frame.html?appId=" + appId);;
     ampWebPushElement.setAttribute("permission-dialog-url", "https://localhost:4001/amp/amp-permission-dialog.html?appId=" + appId);
-    ampWebPushElement.setAttribute("service-worker-url", "https://localhost:4001/amp/OneSignalSDKWorker.js?appId=" + appId);
+    ampWebPushElement.setAttribute("service-worker-url", "https://localhost:4001/amp/OneSignalSDK.sw.js?appId=" + appId);
   </script>
 
   <!-- Contents -->

--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -3,7 +3,7 @@
 <!-- Some sites use this HTML base tag to change the origin for all relative links.
     Ensure OneSignal SDK correctly handles this. -->
 <base href="https://www.example.com/">
-<script src="https://localhost:4001/sdks/Dev-OneSignalSDK.page.js" defer></script>
+<script src="https://localhost:4001/sdks/web/v16/Dev-OneSignalSDK.page.js" defer></script>
 <script>
     const SERVICE_WORKER_PATH = "push/onesignal/";
 

--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -3,7 +3,7 @@
 <!-- Some sites use this HTML base tag to change the origin for all relative links.
     Ensure OneSignal SDK correctly handles this. -->
 <base href="https://www.example.com/">
-<script src="https://localhost:4001/sdks/Dev-OneSignalSDK.js" defer></script>
+<script src="https://localhost:4001/sdks/Dev-OneSignalSDK.page.js" defer></script>
 <script>
     const SERVICE_WORKER_PATH = "push/onesignal/";
 

--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -26,7 +26,7 @@
        onesignal.init({
           appId,
           serviceWorkerParam: { scope: "/" + SERVICE_WORKER_PATH },
-          serviceWorkerPath: SERVICE_WORKER_PATH + "OneSignalSDKWorker.js",
+          serviceWorkerPath: SERVICE_WORKER_PATH + "OneSignalSDK.sw.js",
           notifyButton: {
               enable: true
           },

--- a/express_webpack/push/onesignal/OneSignalSDK.sw.js
+++ b/express_webpack/push/onesignal/OneSignalSDK.sw.js
@@ -1,1 +1,1 @@
-importScripts("https://localhost:4001/sdks/Dev-OneSignalSDK.sw.js");
+importScripts("https://localhost:4001/sdks/web/v16/Dev-OneSignalSDK.sw.js");

--- a/express_webpack/push/onesignal/OneSignalSDK.sw.js
+++ b/express_webpack/push/onesignal/OneSignalSDK.sw.js
@@ -1,0 +1,1 @@
+importScripts("https://localhost:4001/sdks/Dev-OneSignalSDK.sw.js");

--- a/express_webpack/push/onesignal/OneSignalSDKWorker.js
+++ b/express_webpack/push/onesignal/OneSignalSDKWorker.js
@@ -1,1 +1,0 @@
-importScripts("https://localhost:4001/sdks/Dev-OneSignalSDKWorker.js");

--- a/express_webpack/server.js
+++ b/express_webpack/server.js
@@ -16,7 +16,7 @@ app.get('/', (req, res) => {
     res.sendFile(HTML_FILE);
 })
 
-app.get('/sdks/:file', (req, res) => {
+app.get('/sdks/web/v16/:file', (req, res) => {
     res.sendFile(SDK_FILES + req.params.file);
 });
 

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
       "compression": "gzip"
     },
     {
-      "path": "./build/bundles/OneSignalPageSDKES6.js",
+      "path": "./build/bundles/OneSignalSDK.page.es6.js",
       "maxSize": "72 kB",
       "compression": "gzip"
     },

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
       "compression": "gzip"
     },
     {
-      "path": "./build/bundles/OneSignalSDKWorker.js",
+      "path": "./build/bundles/OneSignalSDK.sw.js",
       "maxSize": "42 kB",
       "compression": "gzip"
     },

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
       "compression": "gzip"
     },
     {
-      "path": "./build/bundles/OneSignalSDKStyles.css",
+      "path": "./build/bundles/OneSignalSDK.page.styles.css",
       "maxSize": "9 kB",
       "compression": "gzip"
     }

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
   },
   "bundlesize": [
     {
-      "path": "./build/bundles/OneSignalSDK.js",
+      "path": "./build/bundles/OneSignalSDK.page.js",
       "maxSize": "3 kB",
       "compression": "gzip"
     },

--- a/src/entries/pageSdkInit.ts
+++ b/src/entries/pageSdkInit.ts
@@ -1,6 +1,6 @@
 /**
  * This is OneSignalPageSDKES6.js (ES6)
- * Loaded from OneSignalSDK.js only if the browser supports push.
+ * Loaded from OneSignalSDK.page.js only if the browser supports push.
  */
 
 import { incrementSdkLoadCount, getSdkLoadCount } from "../shared/utils/utils";

--- a/src/entries/pageSdkInit.ts
+++ b/src/entries/pageSdkInit.ts
@@ -1,5 +1,5 @@
 /**
- * This is OneSignalPageSDKES6.js (ES6)
+ * This is OneSignalSDK.page.es6.js(ES6)
  * Loaded from OneSignalSDK.page.js only if the browser supports push.
  */
 

--- a/src/entries/sdk.ts
+++ b/src/entries/sdk.ts
@@ -1,9 +1,9 @@
 /**
- * This is OneSignalSDK.js (ES5)
+ * This is OneSignalSDK.page.js (ES5)
  *   * This is an entry point for pages
  * This is a shim to detect if the browser supports the full OneSignal SDK before loading it.
  *   * Full PageSDK (ES6) - OneSignalPageSDKES6.js
- *   * Shim PageSDK (ES5) - OneSignalSDK.js (This File)
+ *   * Shim PageSDK (ES5) - OneSignalSDK.page.js (This File)
  */
 
 // NOTE: Careful if adding imports, ES5 targets can't clean up functions never called.

--- a/src/entries/sdk.ts
+++ b/src/entries/sdk.ts
@@ -2,7 +2,7 @@
  * This is OneSignalSDK.page.js (ES5)
  *   * This is an entry point for pages
  * This is a shim to detect if the browser supports the full OneSignal SDK before loading it.
- *   * Full PageSDK (ES6) - OneSignalPageSDKES6.js
+ *   * Full PageSDK (ES6) - OneSignalSDK.page.es6.js
  *   * Shim PageSDK (ES5) - OneSignalSDK.page.js (This File)
  */
 

--- a/src/page/utils/BrowserSupportsPush.ts
+++ b/src/page/utils/BrowserSupportsPush.ts
@@ -1,4 +1,4 @@
-// This is used by the OneSignalSDK.js shim
+// This is used by the OneSignalSDK.page.js shim
 // DO NOT add other imports since it is an ES5 target and dead code imports can't be clean up.
 
 // Checks if the browser supports push notifications by checking if specific

--- a/src/page/utils/OneSignalShimLoader.ts
+++ b/src/page/utils/OneSignalShimLoader.ts
@@ -40,7 +40,7 @@ export class OneSignalShimLoader {
 
   private static loadFullPageSDK(): void {
     OneSignalShimLoader.addScriptToPage(
-      `${OneSignalShimLoader.getPathAndPrefix()}OneSignalPageSDKES6.js?v=${OneSignalShimLoader.VERSION}`
+      `${OneSignalShimLoader.getPathAndPrefix()}OneSignalSDK.page.es6.js?v=${OneSignalShimLoader.VERSION}`
     );
   }
 

--- a/src/page/utils/OneSignalShimLoader.ts
+++ b/src/page/utils/OneSignalShimLoader.ts
@@ -18,7 +18,7 @@ export class OneSignalShimLoader {
   // Same logic from SdkEnvironment
   private static getPathAndPrefix(): string {
     const buildOrigin = (typeof __BUILD_ORIGIN__ !== "undefined") ? __BUILD_ORIGIN__ || "localhost" : "localhost";
-    const productionOrigin = "https://cdn.onesignal.com/sdks/";
+    const productionOrigin = "https://cdn.onesignal.com/sdks/web/v16/";
 
     if (typeof __BUILD_TYPE__ === "undefined") {
       return productionOrigin;
@@ -30,9 +30,9 @@ export class OneSignalShimLoader {
 
     switch(__BUILD_TYPE__){
       case "development":
-        return __NO_DEV_PORT__ ? `${protocol}://${buildOrigin}/sdks/Dev-` : `${protocol}://${buildOrigin}:${port}/sdks/Dev-`;
+        return __NO_DEV_PORT__ ? `${protocol}://${buildOrigin}/sdks/web/v16/Dev-` : `${protocol}://${buildOrigin}:${port}/sdks/web/v16/Dev-`;
       case "staging":
-        return `https://${buildOrigin}/sdks/Staging-`;
+        return `https://${buildOrigin}/sdks/web/v16/Staging-`;
       default:
         return productionOrigin;
     }

--- a/src/shared/helpers/ConfigHelper.ts
+++ b/src/shared/helpers/ConfigHelper.ts
@@ -481,7 +481,7 @@ export class ConfigHelper {
           Except injecting some default values for prompts.
         */
         const defaultServiceWorkerParam = { scope: '/' };
-        const defaultServiceWorkerPath = 'OneSignalSDKWorker.js';
+        const defaultServiceWorkerPath = 'OneSignalSDK.sw.js';
 
         const config = {
           ...userConfig,

--- a/src/shared/helpers/ContextHelper.ts
+++ b/src/shared/helpers/ContextHelper.ts
@@ -11,7 +11,7 @@ export class ContextHelper {
 
     const envPrefix = SdkEnvironment.getBuildEnvPrefix();
     const serviceWorkerManagerConfig = {
-      workerPath: new Path(`/${envPrefix}OneSignalSDKWorker.js`),
+      workerPath: new Path(`/${envPrefix}OneSignalSDK.sw.js`),
       registrationOptions: { scope: '/' }
     };
 

--- a/src/shared/helpers/ServiceWorkerHelper.ts
+++ b/src/shared/helpers/ServiceWorkerHelper.ts
@@ -248,11 +248,11 @@ export default class ServiceWorkerHelper {
 
 export enum ServiceWorkerActiveState {
   /**
-   * OneSignalSDKWorker.js, or the equivalent custom file name, is active.
+   * OneSignalSDK.sw.js, or the equivalent custom file name, is active.
    */
   OneSignalWorker = 'OneSignal Worker',
   /**
-   * A service worker is active, but it is not OneSignalSDKWorker.js
+   * A service worker is active, but it is not OneSignalSDK.sw.js
    * (or the equivalent custom file names as provided by user config).
    */
   ThirdParty = '3rd Party',
@@ -270,7 +270,7 @@ export enum ServiceWorkerActiveState {
 
 export interface ServiceWorkerManagerConfig {
   /**
-   * The path and filename of the "main" worker (e.g. '/OneSignalSDKWorker.js');
+   * The path and filename of the "main" worker (e.g. '/OneSignalSDK.sw.js');
    */
   workerPath: Path;
   /**

--- a/src/shared/managers/SdkEnvironment.ts
+++ b/src/shared/managers/SdkEnvironment.ts
@@ -243,7 +243,7 @@ export default class SdkEnvironment {
    * service worker.
    *
    * For example, in staging the registered service worker filename is
-   * Staging-OneSignalSDKWorker.js.
+   * Staging-OneSignalSDK.sw.js.
    */
   public static getBuildEnvPrefix(buildEnv: EnvironmentKind = SdkEnvironment.getBuildEnv()) : string {
     switch (buildEnv) {

--- a/src/shared/managers/SdkEnvironment.ts
+++ b/src/shared/managers/SdkEnvironment.ts
@@ -305,7 +305,7 @@ export default class SdkEnvironment {
   }
 
   public static getOneSignalCssFileName(buildEnv: EnvironmentKind = SdkEnvironment.getBuildEnv()): string {
-    const baseFileName = "OneSignalSDKStyles.css";
+    const baseFileName = "OneSignalSDK.page.styles.css";
 
     switch (buildEnv) {
       case EnvironmentKind.Development:

--- a/src/shared/managers/SdkEnvironment.ts
+++ b/src/shared/managers/SdkEnvironment.ts
@@ -301,7 +301,7 @@ export default class SdkEnvironment {
         throw new InvalidArgumentError('buildEnv', InvalidArgumentReason.EnumOutOfRange);
     }
 
-    return new URL(`${origin}/sdks`);
+    return new URL(`${origin}/sdks/web/v16`);
   }
 
   public static getOneSignalCssFileName(buildEnv: EnvironmentKind = SdkEnvironment.getBuildEnv()): string {

--- a/src/shared/managers/ServiceWorkerManager.ts
+++ b/src/shared/managers/ServiceWorkerManager.ts
@@ -353,7 +353,7 @@ export class ServiceWorkerManager {
    * We have a couple different models of installing service workers:
    *
    * a) Originally, we provided users with two worker files:
-   * OneSignalSDKWorker.js and OneSignalSDKUpdaterWorker.js. Two workers were
+   * OneSignalSDK.sw.js and OneSignalSDKUpdaterWorker.js. Two workers were
    * provided so each could be swapped with the other when the worker needed to
    * update. The contents of both workers were identical; only the filenames
    * were different, which is enough to update the worker.
@@ -363,22 +363,22 @@ export class ServiceWorkerManager {
    * version as a query parameter. This is enough for the browser to detect a
    * change and re-install the worker.
    *
-   * b) With AMP web push, users specify the worker file OneSignalSDKWorker.js
+   * b) With AMP web push, users specify the worker file OneSignalSDK.sw.js
    * with an app ID parameter ?appId=12345. AMP web push
    * is vendor agnostic and doesn't know about OneSignal, so all relevant
    * information has to be passed to the service worker, which is the only
    * vendor-specific file.
    *
    * If AMP web push sees another worker like OneSignalSDKUpdaterWorker.js (deprecated), or
-   * even the same OneSignalSDKWorker.js without the app ID query parameter, the
+   * even the same OneSignalSDK.sw.js without the app ID query parameter, the
    * user is considered unsubscribed.
    *
    * c) Due to b's restriction, we must always install
-   * OneSignalSDKWorker.js?appId=xxx. We also have to appropriately handle the
+   * OneSignalSDK.sw.js?appId=xxx. We also have to appropriately handle the
    * legacy case:
    *
    *    c-1) Where developers running progressive web apps force-register
-   *    OneSignalSDKWorker.js
+   *    OneSignalSDK.sw.js
    *
    * Actually, users can customize the file names of the Service Worker but
    * it's up to them to be consistent with their naming. For AMP web push, users

--- a/test/support/sdk/TestEnvironment.ts
+++ b/test/support/sdk/TestEnvironment.ts
@@ -536,7 +536,7 @@ export class TestEnvironment {
           serviceWorker: {
             customizationEnabled: false,
             path: "/",
-            workerName: "OneSignalSDKWorker.js",
+            workerName: "OneSignalSDK.sw.js",
             registrationScope: "/",
           },
           welcomeNotification: {

--- a/test/unit/modules/entryInitialization.ts
+++ b/test/unit/modules/entryInitialization.ts
@@ -70,7 +70,7 @@ test("Test ReplayCallsOnOneSignal fires functions ", async t => {
   await promise;
 });
 
-test("OneSignalSDK.js add OneSignalPageSDKES6 script tag on a browser supports push", async t => {
+test("OneSignalSDK.page.js add OneSignalSDK.page.es6.js script tag on a browser supports push", async t => {
 
   setupBrowserWithPushAPIWithVAPIDEnv(sandbox);
   // Setup spy for OneSignalShimLoader.addScriptToPage
@@ -80,7 +80,7 @@ test("OneSignalSDK.js add OneSignalPageSDKES6 script tag on a browser supports p
   t.is(addScriptToPageSpy.callCount, 1);
 });
 
-test("OneSignalSDK.js is loaded on a page on a browser that does NOT support push", async t => {
+test("OneSignalSDK.page.js is loaded on a page on a browser that does NOT support push", async t => {
   // Setup spy for OneSignalShimLoader.addScriptToPage
   const addScriptToPageSpy = sandbox.spy(OneSignalShimLoader, <any>'addScriptToPage');
 
@@ -90,7 +90,7 @@ test("OneSignalSDK.js is loaded on a page on a browser that does NOT support pus
   t.is(addScriptToPageSpy.callCount, 0);
 });
 
-test("OneSignalSDK.js load from service worker context that supports push", async t => {
+test("OneSignalSDK.page.js load from service worker context that supports push", async t => {
   sandbox.stub((<any>global), "window").value(undefined);
   setupBrowserWithPushAPIWithVAPIDEnv(sandbox);
 

--- a/test/unit/modules/entryInitialization.ts
+++ b/test/unit/modules/entryInitialization.ts
@@ -101,5 +101,5 @@ test("OneSignalSDK.page.js load from service worker context that supports push",
   OneSignalShimLoader.start();
 
   // Ensure we load the worker build of the SDK with self.importScripts(<string>)
-  t.true(importScriptsSpy.getCall(0).calledWithExactly("https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js?v=1"));
+  t.true(importScriptsSpy.getCall(0).calledWithExactly("https://cdn.onesignal.com/sdks/OneSignalSDK.sw.js?v=1"));
 });

--- a/test/unit/modules/entryInitialization.ts
+++ b/test/unit/modules/entryInitialization.ts
@@ -101,5 +101,5 @@ test("OneSignalSDK.page.js load from service worker context that supports push",
   OneSignalShimLoader.start();
 
   // Ensure we load the worker build of the SDK with self.importScripts(<string>)
-  t.true(importScriptsSpy.getCall(0).calledWithExactly("https://cdn.onesignal.com/sdks/OneSignalSDK.sw.js?v=1"));
+  t.true(importScriptsSpy.getCall(0).calledWithExactly("https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.sw.js?v=1"));
 });

--- a/test/unit/modules/loadSdkStyles.ts
+++ b/test/unit/modules/loadSdkStyles.ts
@@ -73,7 +73,7 @@ test("loadIfNew called twice should not load the same stylesheet or script more 
   const resourceLoadAttempts = [];
   for (let i = 0; i < 5; i++) {
     resourceLoadAttempts.push(
-      dynamicResourceLoader.loadIfNew(ResourceType.Stylesheet, new URL('https://cdn.onesignal.com/sdks/OneSignalSDK.page.styles.css'))
+      dynamicResourceLoader.loadIfNew(ResourceType.Stylesheet, new URL('https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.page.styles.css'))
     );
   }
   await Promise.all(resourceLoadAttempts);
@@ -81,7 +81,7 @@ test("loadIfNew called twice should not load the same stylesheet or script more 
 
   t.not(Object.keys(cache).length, 5);
   t.is(Object.keys(cache).length, 1);
-  t.is(Object.keys(cache)[0], 'https://cdn.onesignal.com/sdks/OneSignalSDK.page.styles.css');
+  t.is(Object.keys(cache)[0], 'https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.page.styles.css');
 });
 
 test("load successfully fetches and installs stylesheet", async t => {

--- a/test/unit/modules/loadSdkStyles.ts
+++ b/test/unit/modules/loadSdkStyles.ts
@@ -73,7 +73,7 @@ test("loadIfNew called twice should not load the same stylesheet or script more 
   const resourceLoadAttempts = [];
   for (let i = 0; i < 5; i++) {
     resourceLoadAttempts.push(
-      dynamicResourceLoader.loadIfNew(ResourceType.Stylesheet, new URL('https://cdn.onesignal.com/sdks/OneSignalSDKStyles.css'))
+      dynamicResourceLoader.loadIfNew(ResourceType.Stylesheet, new URL('https://cdn.onesignal.com/sdks/OneSignalSDK.page.styles.css'))
     );
   }
   await Promise.all(resourceLoadAttempts);
@@ -81,7 +81,7 @@ test("loadIfNew called twice should not load the same stylesheet or script more 
 
   t.not(Object.keys(cache).length, 5);
   t.is(Object.keys(cache).length, 1);
-  t.is(Object.keys(cache)[0], 'https://cdn.onesignal.com/sdks/OneSignalSDKStyles.css');
+  t.is(Object.keys(cache)[0], 'https://cdn.onesignal.com/sdks/OneSignalSDK.page.styles.css');
 });
 
 test("load successfully fetches and installs stylesheet", async t => {

--- a/test/unit/modules/mergedLegacyConfig.ts
+++ b/test/unit/modules/mergedLegacyConfig.ts
@@ -27,13 +27,13 @@ test('should not overwrite a provided service worker parameters', async t => {
     {
       path: '/existing-path',
       serviceWorkerParam: { scope: '/existing-path' },
-      serviceWorkerPath: '/existing-path/OneSignalSDKWorker.js',
+      serviceWorkerPath: '/existing-path/OneSignalSDK.sw.js',
     },
     TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom)
   );
   t.is(result.userConfig.path, '/existing-path');
   t.deepEqual(result.userConfig.serviceWorkerParam, { scope: '/existing-path' });
-  t.is(result.userConfig.serviceWorkerPath, '/existing-path/OneSignalSDKWorker.js');
+  t.is(result.userConfig.serviceWorkerPath, '/existing-path/OneSignalSDK.sw.js');
 });
 
 test('should assign the default service worker registration params if not provided', async t => {
@@ -68,7 +68,7 @@ test('should assign the default service worker A filename if not provided', asyn
     {},
     TestEnvironment.getFakeServerAppConfig(ConfigIntegrationKind.Custom)
   );
-  t.is(result.userConfig.serviceWorkerPath, 'OneSignalSDKWorker.js');
+  t.is(result.userConfig.serviceWorkerPath, 'OneSignalSDK.sw.js');
 });
 
 test("should not use server's subdomain if subdomain not specified in user config on HTTPS site", async t => {


### PR DESCRIPTION
# Description
Introducing a new filename standard and new path for the major release 16 of the WebSDK.

## Details
For consistency start all files with `OneSignalSDK`, followed by a dot, then the context they will run (page or sw), followed by any other specifics if needed. Example: `OneSignalSDK.page.es6.js`
We added add `web/v##` so the URL indicates the type of SDK and the major version of the files. `##` being the major version, example `16`.

**Files Today**
https://cdn.onesignal.com/sdks/OneSignalSDK.js
https://cdn.onesignal.com/sdks/OneSignalPageSDKES6.js?v=151514
https://cdn.onesignal.com/sdks/OneSignalSDKStyles.css?v=2
https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js

**Files - For Major Release 16**
https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.page.js
https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.page.es6.js?v=160000
https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.page.styles.css?v=2
https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.sw.js

# Validation
## Tests
Tested on the sandbox included in this repo.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/954)
<!-- Reviewable:end -->
