### PR TITLE
Fix CD builds and correct node version in Dockerfile

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,6 +17,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '2.7' 
       - name: "[Setup] Install dependencies"
         run: yarn
       - name: "[Test] Run all tests"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18.0
+FROM node:14.21.1
 WORKDIR /sdk
 COPY package.json .
 RUN yarn


### PR DESCRIPTION
# Description
Updated docker node version to match CD, and fixes CD builds by adding missing required Python.

## Details

# Validation
## Tests
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/958)
<!-- Reviewable:end -->
