### PR TITLE
Bug fix: separate operations by model name when loading from cache

### DIFF
--- a/src/core/caching/OperationCache.ts
+++ b/src/core/caching/OperationCache.ts
@@ -1,6 +1,6 @@
 import Log from "../../shared/libraries/Log";
 import { logMethodCall } from "../../shared/utils/utils";
-import { SupportedModel } from "../models/SupportedModels";
+import { ModelName, SupportedModel } from "../models/SupportedModels";
 import { Operation } from "../operationRepo/Operation";
 
 export default class OperationCache {
@@ -12,7 +12,7 @@ export default class OperationCache {
     localStorage.setItem("operationCache", JSON.stringify(operations));
   }
 
-  static async getOperations(): Promise<Operation<SupportedModel>[]> {
+  static async getOperationsWithModelName(modelName: ModelName): Promise<Operation<SupportedModel>[]> {
     logMethodCall("OperationCache.getOperations");
     const fromCache = localStorage.getItem("operationCache");
     const rawOperations: Operation<SupportedModel>[] = fromCache ? Object.values(JSON.parse(fromCache)) : [];
@@ -33,7 +33,8 @@ export default class OperationCache {
         this.delete(rawOperation.operationId);
       }
     }
-    return operations.sort((a, b) => a.timestamp - b.timestamp);
+    const sorted = operations.sort((a, b) => a.timestamp - b.timestamp);
+    return sorted.filter(operation => operation.modelName === modelName);
   }
 
   static delete(id: string): void {

--- a/src/core/executors/ExecutorBase.ts
+++ b/src/core/executors/ExecutorBase.ts
@@ -96,8 +96,10 @@ export default abstract class ExecutorBase {
     return finalChangeType;
   }
 
+  abstract getOperationsFromCache(): Promise<Operation<SupportedModel>[]>;
+
   protected async _processOperationQueue(): Promise<void> {
-    const cachedOperations = await OperationCache.getOperations();
+    const cachedOperations = await this.getOperationsFromCache();
     this._operationQueue = [...cachedOperations, ...this._operationQueue];
 
     while (this._operationQueue.length > 0) {

--- a/src/core/executors/IdentityExecutor.ts
+++ b/src/core/executors/IdentityExecutor.ts
@@ -1,3 +1,4 @@
+import OperationCache from "../caching/OperationCache";
 import { CoreChangeType } from "../models/CoreChangeType";
 import { PropertyDelta } from "../models/CoreDeltas";
 import { ExecutorConfig } from "../models/ExecutorConfig";
@@ -11,7 +12,7 @@ export class IdentityExecutor extends ExecutorBase {
     super(executorConfig);
   }
 
-  public processDeltaQueue(): void {
+  processDeltaQueue(): void {
     if (this._deltaQueue.length === 0) {
       return;
     }
@@ -43,5 +44,9 @@ export class IdentityExecutor extends ExecutorBase {
     }
 
     this._flushDeltas();
+  }
+
+  async getOperationsFromCache(): Promise<Operation<SupportedModel>[]> {
+      return await OperationCache.getOperationsWithModelName(ModelName.Identity);
   }
 }

--- a/src/core/executors/PropertiesExecutor.ts
+++ b/src/core/executors/PropertiesExecutor.ts
@@ -3,18 +3,23 @@ import { Operation } from "../operationRepo/Operation";
 import { CoreChangeType } from "../models/CoreChangeType";
 import { ExecutorConfig } from "../models/ExecutorConfig";
 import { ModelName, SupportedModel } from "../models/SupportedModels";
+import OperationCache from "../caching/OperationCache";
 
 export class PropertiesExecutor extends ExecutorBase {
   constructor(executorConfig: ExecutorConfig<SupportedModel>) {
     super(executorConfig);
   }
 
-  public processDeltaQueue(): void {
+  processDeltaQueue(): void {
     if (this._deltaQueue.length === 0) {
       return;
     }
 
     this._enqueueOperation(new Operation(CoreChangeType.Update, ModelName.Properties, this._deltaQueue));
     this._flushDeltas();
+  }
+
+  async getOperationsFromCache(): Promise<Operation<SupportedModel>[]> {
+    return await OperationCache.getOperationsWithModelName(ModelName.Properties);
   }
 }

--- a/src/core/executors/SubscriptionExecutor.ts
+++ b/src/core/executors/SubscriptionExecutor.ts
@@ -1,7 +1,8 @@
+import OperationCache from "../caching/OperationCache";
 import { CoreChangeType } from "../models/CoreChangeType";
 import { CoreDelta } from "../models/CoreDeltas";
 import { ExecutorConfig } from "../models/ExecutorConfig";
-import { SupportedModel } from "../models/SupportedModels";
+import { ModelName, SupportedModel } from "../models/SupportedModels";
 import { Operation } from "../operationRepo/Operation";
 import ExecutorBase from "./ExecutorBase";
 
@@ -10,7 +11,7 @@ export class SubscriptionExecutor extends ExecutorBase {
     super(executorConfig);
   }
 
-  public processDeltaQueue(): void {
+  processDeltaQueue(): void {
     const modelSpecificDeltasArrays = this.separateDeltasByModelId();
 
     modelSpecificDeltasArrays.forEach(deltasArray => {
@@ -25,6 +26,14 @@ export class SubscriptionExecutor extends ExecutorBase {
     });
 
     this._flushDeltas();
+  }
+
+  async getOperationsFromCache(): Promise<Operation<SupportedModel>[]> {
+    const smsOperations = await OperationCache.getOperationsWithModelName(ModelName.SmsSubscriptions);
+    const emailOperations = await OperationCache.getOperationsWithModelName(ModelName.EmailSubscriptions);
+    const pushSubOperations = await OperationCache.getOperationsWithModelName(ModelName.PushSubscriptions);
+
+    return [...smsOperations, ...emailOperations, ...pushSubOperations];
   }
 
   private separateDeltasByChangeType(deltas: CoreDelta<SupportedModel>[]):

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -73,7 +73,7 @@ export default class EventHelper {
 
     const prompts = OneSignal.context.appConfig.userConfig.promptOptions?.slidedown?.prompts;
     if (PromptsHelper.isCategorySlidedownConfigured(prompts)) {
-      await OneSignal.context.tagManager.sendTags(false);
+      await OneSignal.context.tagManager.sendTags();
     }
   }
 

--- a/test/unit/core/OperationCache.ts
+++ b/test/unit/core/OperationCache.ts
@@ -22,17 +22,17 @@ test.beforeEach(async () => {
 test("Add operation to cache -> operation queue +1", async t => {
   const operation = new Operation(CoreChangeType.Add, ModelName.Identity, getMockDeltas());
   OperationCache.enqueue(operation);
-  const operations = await OperationCache.getOperations();
+  const operations = await OperationCache.getOperationsWithModelName(ModelName.Identity);
   t.is(operations.length, 1);
 });
 
 test("Remove operation from cache -> operation queue -1", async t => {
   const operation = new Operation(CoreChangeType.Add, ModelName.Identity, getMockDeltas());
   OperationCache.enqueue(operation);
-  let operations = await OperationCache.getOperations();
+  let operations = await OperationCache.getOperationsWithModelName(ModelName.Identity);
   t.is(operations.length, 1);
   OperationCache.delete(operation.operationId);
-  operations = await OperationCache.getOperations();
+  operations = await OperationCache.getOperationsWithModelName(ModelName.Identity);
   t.is(operations.length, 0);
 });
 
@@ -40,10 +40,10 @@ test("Add multiple operations to cache -> operation queue +2", async t => {
   const operation = new Operation(CoreChangeType.Add, ModelName.Identity, getMockDeltas());
   const operation2 = new Operation(CoreChangeType.Add, ModelName.Identity, getMockDeltas());
   OperationCache.enqueue(operation);
-  let operations = await OperationCache.getOperations();
+  let operations = await OperationCache.getOperationsWithModelName(ModelName.Identity);
   t.is(operations.length, 1);
   OperationCache.enqueue(operation2);
-  operations = await OperationCache.getOperations();
+  operations = await OperationCache.getOperationsWithModelName(ModelName.Identity);
   t.is(operations.length, 2);
 });
 
@@ -51,12 +51,12 @@ test("Flush operation cache -> operation queue 0", async t => {
   const operation = new Operation(CoreChangeType.Add, ModelName.Identity, getMockDeltas());
   const operation2 = new Operation(CoreChangeType.Add, ModelName.Identity, getMockDeltas());
   OperationCache.enqueue(operation);
-  let operations = await OperationCache.getOperations();
+  let operations = await OperationCache.getOperationsWithModelName(ModelName.Identity);
   t.is(operations.length, 1);
   OperationCache.enqueue(operation2);
-  operations = await OperationCache.getOperations();
+  operations = await OperationCache.getOperationsWithModelName(ModelName.Identity);
   t.is(operations.length, 2);
   OperationCache.flushOperations();
-  operations = await OperationCache.getOperations();
+  operations = await OperationCache.getOperationsWithModelName(ModelName.Identity);
   t.is(operations.length, 0);
 });


### PR DESCRIPTION
Motivation: need to only load the operations of the particular model type (identity, properties, etc...) for that specific executor.

Fix by declaring an abstract class `getOperationsFromCache` implemented uniquely in each Executor

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/960)
<!-- Reviewable:end -->
