### PR TITLE
Bug fix: strip aliases except external_id from identity object

### DIFF
--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -95,10 +95,10 @@ export default class LoginManager {
 
       if (isIdentified) {
         // if started off identified, create a new user
-        result = await LoginManager.upsertUser(userData);
+        result = await this.upsertUser(userData);
       } else {
         // promoting anonymous user to identified user
-        result = await LoginManager.identifyUser(userData, subscriptionId);
+        result = await this.identifyUser(userData, subscriptionId);
       }
       return result;
   }


### PR DESCRIPTION
* identity object should only contain external_id
* if logging in from identified user a to identified user b, the identity object would otherwise contain any existing user a aliases

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/961)
<!-- Reviewable:end -->
