### PR TITLE
User Model - Fix post load of SDK OneSignalDeferred.push not working

### DIFF
--- a/src/entries/pageSdkInit.ts
+++ b/src/entries/pageSdkInit.ts
@@ -25,6 +25,9 @@ function onesignalSdkInit() {
   //         * Number of internal SDK code expects window.OneSignal
   //         * Keep JS console usage easier for debugging / testing.
   (<any>window).OneSignal = require('../onesignal/OneSignal').default;
-  ReplayCallsOnOneSignal.processOneSignalDeferredArray((<any>window).OneSignalDeferred);
+
+  const existingOneSignalDeferred = (<any>window).OneSignalDeferred;
+  (<any>window).OneSignalDeferred = require('../onesignal/OneSignalDeferred').default;
+  ReplayCallsOnOneSignal.processOneSignalDeferredArray(existingOneSignalDeferred);
 }
 onesignalSdkInit();

--- a/src/onesignal/OneSignalDeferred.ts
+++ b/src/onesignal/OneSignalDeferred.ts
@@ -1,0 +1,11 @@
+import { OneSignalDeferredLoadedCallback } from "../page/models/OneSignalDeferredLoadedCallback";
+import OneSignal from "./OneSignal";
+
+// This class is simply used as a proxy to OneSignal.push when the SDK is fully loaded.
+// This way the site developer can use OneSignalDeferred.push without have to check
+//   if the SDK is loaded or not.
+export default class OneSignalDeferred {
+  static push(item: OneSignalDeferredLoadedCallback) {
+    OneSignal.push(item);
+  }
+}

--- a/src/page/utils/ReplayCallsOnOneSignal.ts
+++ b/src/page/utils/ReplayCallsOnOneSignal.ts
@@ -1,8 +1,10 @@
 import Log from "../../shared/libraries/Log";
+import OneSignal from "../../onesignal/OneSignal";
+import { OneSignalDeferredLoadedCallback } from "../models/OneSignalDeferredLoadedCallback";
 
 // TODO: Renaming ReplayCallsOnOneSignal in a future commit
 export class ReplayCallsOnOneSignal {
-  static processOneSignalDeferredArray(onesignalDeferred: Function[]): void {
+  static processOneSignalDeferredArray(onesignalDeferred: OneSignalDeferredLoadedCallback[]): void {
     for (const item of onesignalDeferred) {
       try {
         OneSignal.push(item);


### PR DESCRIPTION
# Description
## 1 Line Summary
Fixes issue where `OneSignalDeferred.push` was not working after the SDK was fully loaded (OneSignalSDK.page.es6.js).

## Details
# Validation
## Tests
Tested locally to ensure `OneSignalDeferred.push` works from the JS console.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/969)
<!-- Reviewable:end -->
