### PR TITLE
Add `ngrok` script to faciliate easily serving localhost to the web

### DIFF
--- a/build/scripts/ngrok.sh
+++ b/build/scripts/ngrok.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Check if ngrok is installed
+if ! [ -x "$(command -v ngrok)" ]; then
+  echo 'ngrok is not installed.'
+  echo 'Please install ngrok to use this script.'
+  exit 1
+fi
+
+echo 'ngrok is installed. Continuing with script execution.'
+
+# Kill any existing ngrok processes
+killall ngrok
+
+# Start ngrok
+ngrok http https://localhost:4001 --log=ngrok.log > /dev/null &
+echo "starting ngrok..."
+
+# Wait for ngrok to start
+sleep 5
+
+# Get the ngrok url
+read -r rawurl < <(grep -o "https://[^ ]*\.ngrok\.io" ngrok.log)
+url=$(echo $rawurl | sed 's/https:\/\///')
+echo "ngrok url: $url"
+
+rm ngrok.log
+
+# Build the service worker file
+echo "building service worker file"
+./build/scripts/buildServiceWorker.sh $url
+
+# Build the SDK
+echo "building SDK with build origin $url"
+docker-compose exec onesignal-web-sdk-dev yarn build:dev-prod -b $url --no-port
+echo "Done."
+
+echo "Last step: update the SDK script src to https://$url/sdks/Dev-OneSignalSDK.js"
+
+# Open the ngrok url
+open "https://$url"

--- a/express_webpack/README.md
+++ b/express_webpack/README.md
@@ -106,18 +106,12 @@ you need a quick and easy way to test your changes on a different machine or sha
 ngrok is a programmable reverse proxy that lets you instantly serve your localhost environment to the web.
 
 #### Steps:
-1. Serve your localhost via ngrok:
+1. Start the ngrok script.
 ```
-ngrok http https://localhost:4001
+yarn ngrok
 ```
-2. Modify public files to use the displayed ngrok url instead of localhost (e.g: service worker file, index file)
-```
-importScripts("https://651d-72-109-246-88.ngrok.io/sdks/Dev-OneSignalSDKWorker.js");
-```
-3. Build the SDK in your sandbox environment:
-```
-yarn build:dev-prod -b 651d-72-109-246-88.ngrok.io --no-port
-```
+2. Modify index.html file to use the newly created ngrok origin.
+3. Update your app settings via the dashboard to use the newly created ngrok origin.
 
 ## Troubleshooting
 ### Custom origin mismatch

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "validator": "https://registry.npmjs.org/validator/-/validator-6.0.0.tgz"
   },
   "scripts": {
+    "ngrok": "./build/scripts/ngrok.sh",
     "clean": "rm -rf build/ts-to-es6 && rm -rf build/bundles",
     "transpile:sources": "$(yarn bin)/tsc --project build/config/tsconfig.json",
     "transpile:tests": "$(yarn bin)/tsc --project build/config/tsconfig.tests.json",


### PR DESCRIPTION
Motivation: Problem: you need a quick and easy way to test your changes on a different machine or share the sandbox environment with others.

Solution: ngrok is a programmable reverse proxy that lets you instantly serve your localhost environment to the web.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/onesignal/onesignal-website-sdk/975)
<!-- Reviewable:end -->
