### PR TITLE
Fix query param bug for single-url service worker install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Use Python 2.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: '2.7'
       - name: "[Setup] Install dependencies"
         run: yarn
       - name: "[Test] Run linters"

--- a/src/helpers/ServiceWorkerHelper.ts
+++ b/src/helpers/ServiceWorkerHelper.ts
@@ -29,7 +29,7 @@ export default class ServiceWorkerHelper {
     const fullPath = new URL(workerFullPath, OneSignalUtils.getBaseUrl()).href;
     const appIdAsQueryParam      = Utils.encodeHashAsUriComponent({ appId });
     const sdkVersionAsQueryParam = Utils.encodeHashAsUriComponent({ sdkVersion });
-    return `${fullPath}?${appIdAsQueryParam}?${sdkVersionAsQueryParam}`;
+    return `${fullPath}?${appIdAsQueryParam}&${sdkVersionAsQueryParam}`;
   }
 
   public static async upsertSession(

--- a/test/unit/managers/ServiceWorkerManager.ts
+++ b/test/unit/managers/ServiceWorkerManager.ts
@@ -177,7 +177,7 @@ test('installWorker() installs worker A with the correct file name and query par
 
     const serviceWorker = MockServiceWorkerContainerWithAPIBan.getControllerForTests();
     t.true(serviceWorker!.scriptURL.endsWith(
-      `/Worker.js?appId=${OneSignal.context.appConfig.appId}?sdkVersion=1`)
+      `/Worker.js?appId=${OneSignal.context.appConfig.appId}&sdkVersion=1`)
     );
 });
 
@@ -233,7 +233,7 @@ test('installWorker() installs worker 1 -> simulate SDK upgrade -> install worke
 
   const appConfig = OneSignal.context.appConfig;
   const registerOptions =  { scope: `${location.origin}/` };
-  const serviceWorker2Path = `${location.origin}/Worker.js?appId=${appConfig.appId}?sdkVersion=2`;
+  const serviceWorker2Path = `${location.origin}/Worker.js?appId=${appConfig.appId}&sdkVersion=2`;
 
   // 4. Ensure we installed ServiceWorker 2
   let spyCall = spy.getCall(0);
@@ -279,7 +279,7 @@ test('installWorker() installs Worker new scope when it changes', async t => {
   const appId = OneSignal.context.appConfig.appId;
   t.deepEqual(spyRegister.getCalls().map(call => call.args), [
     [
-      `https://localhost:3001/Worker.js?appId=${appId}?sdkVersion=1`,
+      `https://localhost:3001/Worker.js?appId=${appId}&sdkVersion=1`,
       { scope: 'https://localhost:3001/push/onesignal/' }
     ]
   ]);
@@ -306,7 +306,7 @@ test('Service worker register URL correct when service worker path is an absolut
   await manager.installWorker();
 
   sandbox.assert.alwaysCalledWithExactly(serviceWorkerStub,
-    `${location.origin}/Worker.js?appId=${OneSignal.context.appConfig.appId}?sdkVersion=1`,
+    `${location.origin}/Worker.js?appId=${OneSignal.context.appConfig.appId}&sdkVersion=1`,
     { scope: `${location.origin}/` }
   );
   t.pass();


### PR DESCRIPTION
To separate query params, we should be using `&` and not `?`

Fixes #973

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/981)
<!-- Reviewable:end -->
