### PR TITLE
User model/log level

### DIFF
--- a/src/onesignal/DebugNamesapce.ts
+++ b/src/onesignal/DebugNamesapce.ts
@@ -1,0 +1,11 @@
+import Log from "../shared/libraries/Log";
+
+export default class DebugNamespace {
+  /**
+   * @PublicApi
+   * @param logLevel - string
+   */
+  setLogLevel(logLevel: string) {
+    Log.setLevel(logLevel);
+  }
+}

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -46,6 +46,7 @@ import UserDirector from "./UserDirector";
 import { ModelName, SupportedModel } from "../core/models/SupportedModels";
 import { OSModel } from "../core/modelRepo/OSModel";
 import UserData from "../core/models/UserData";
+import DebugNamespace from "./DebugNamesapce";
 
 export default class OneSignal {
   private static async _initializeCoreModuleAndUserNamespace() {
@@ -321,6 +322,7 @@ export default class OneSignal {
   static Slidedown = new SlidedownNamespace();
   static Session = new SessionNamespace();
   static User: UserNamespace;
+  static Debug = new DebugNamespace();
   /* END NEW USER MODEL CHANGES */
 
   static __doNotShowWelcomeNotification: boolean;
@@ -341,7 +343,6 @@ export default class OneSignal {
   static environment = Environment;
   static database = Database;
   static event = OneSignalEvent;
-  static log = Log;
   private static pendingInit: boolean = true;
 
   static subscriptionPopup: SubscriptionPopup;


### PR DESCRIPTION
# Description
## 1 Line Summary
change log level API to match other SDKs

## Details
In order to match other SDKs, we will introduce a new function `setLogLevel` around the now internal `Log.setLevel` function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/986)
<!-- Reviewable:end -->
