### PR TITLE
feat: refactor images location for static assets

### DIFF
--- a/src/bell/Dialog.ts
+++ b/src/bell/Dialog.ts
@@ -90,7 +90,7 @@ export default class Dialog extends AnimatedElement {
 
         let instructionsHtml = '';
         if (imageUrl) {
-          imageUrl = SdkEnvironment.getOneSignalApiUrl().origin + imageUrl;
+          imageUrl = SdkEnvironment.getOneSignalStaticResourcesUrl() + imageUrl;
           instructionsHtml = `<a href="${imageUrl}" target="_blank"><img src="${imageUrl}"></a></div>`;
         }
 

--- a/src/managers/SdkEnvironment.ts
+++ b/src/managers/SdkEnvironment.ts
@@ -39,7 +39,7 @@ export default class SdkEnvironment {
 
   /**
    * Returns development staging, or production.
-   * 
+   *
    * Refers to which API environment should be used. These constants are set when building the SDK
    */
   public static getApiEnv(): EnvironmentKind {
@@ -121,7 +121,7 @@ export default class SdkEnvironment {
           (location.hostname === 'localhost' || location.hostname === '127.0.0.1')) {
           return IntegrationKind.Secure;
         }
-        
+
         /* The case of HTTP and not using a proxy origin isn't possible, because the SDK will throw
         an initialization error stating a proxy origin is required for HTTP sites. */
         return IntegrationKind.InsecureProxy;
@@ -278,6 +278,13 @@ export default class SdkEnvironment {
       default:
         throw new InvalidArgumentError('buildEnv', InvalidArgumentReason.EnumOutOfRange);
     }
+  }
+
+  /**
+   * Returns the URL object pointing to our static resources location
+   */
+  public static getOneSignalStaticResourcesUrl(): URL {
+    return new URL('https://media.onesignal.com/web-sdk');
   }
 
   public static getOneSignalResourceUrlPath(buildEnv: EnvironmentKind = SdkEnvironment.getBuildEnv()): URL {


### PR DESCRIPTION
# Description

Point to our new static assets location `media.onesignal.com/web-sdk` to retrieve static assets like, for example, our bell images.

Depending on https://github.com/OneSignal/media.onesignal.com/pull/5

## Details

# Systems Affected
   - [x] WebSDK
   - [x] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/990)
<!-- Reviewable:end -->
