### PR TITLE
User model/fix privacy consent block

### DIFF
--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -219,6 +219,8 @@ export default class OneSignal {
       return;
     }
 
+    await OneSignal._initializeCoreModuleAndUserNamespace();
+
     if (OneSignal.config.userConfig.requiresUserPrivacyConsent || LocalStorage.getConsentRequired()) {
       const providedConsent = await Database.getConsentGiven();
       if (!providedConsent) {
@@ -231,7 +233,6 @@ export default class OneSignal {
   }
 
   private static async _delayedInit(): Promise<void> {
-    await OneSignal._initializeCoreModuleAndUserNamespace();
     OneSignal.pendingInit = false;
     // Ignore Promise as doesn't return until the service worker becomes active.
     OneSignal.context.workerMessenger.listen();

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -96,6 +96,13 @@ export default class OneSignal {
   static async login(externalId: string, token?: string): Promise<void> {
     logMethodCall('login', { externalId, token });
 
+    const consentRequired = OneSignal.config?.userConfig.requiresUserPrivacyConsent || LocalStorage.getConsentRequired();
+    const consentGiven = await Database.getConsentGiven();
+
+    if (consentRequired && !consentGiven) {
+      throw new OneSignalError('Login: Consent required but not given, skipping login');
+    }
+
     try {
       // before, logging in, process anything waiting in the delta queue so it's not lost
       this.coreDirector.forceDeltaQueueProcessingOnAllExecutors();


### PR DESCRIPTION
# Description
## 1 Line Summary
Unblocks core module & user namespace initialization even if no privacy consent given & handles login edge case.

## Details
* If a user tries to access the user namespace and perform an operation (e.g: add alias) we should store off that operation and process it once the user provides consent and becomes subscribed.
* If the user is attempted to login _before_ providing consent, it is important we throw to alert the developer it has entered an unsupported state.

More details in commits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/996)
<!-- Reviewable:end -->
