### PR TITLE
[Sandbox] Add web app manifest for ios push testing

### DIFF
--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
+<!-- This Web Application Manifest is required for iOS 16.4 WebPush -->
+<link rel="manifest" href="manifest.json" />
+
 <!-- Some sites use this HTML base tag to change the origin for all relative links.
     Ensure OneSignal SDK correctly handles this. -->
 <base href="https://www.example.com/">

--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -5,8 +5,11 @@
 
 <!-- Some sites use this HTML base tag to change the origin for all relative links.
     Ensure OneSignal SDK correctly handles this. -->
-<base href="https://www.example.com/">
+<!-- NOTE: This does not work with the relative pathed manifest.json above. -->
+<!--<base href="https://www.example.com/"> -->
+
 <script src="https://localhost:4001/sdks/Dev-OneSignalSDK.js" async=""></script>
+
 <script>
     const SERVICE_WORKER_PATH = "push/onesignal/";
 

--- a/express_webpack/manifest.json
+++ b/express_webpack/manifest.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/web-manifest-combined.json",
+  "name": "OneSignal Sandbox WebSDK WebApp",
+  "short_name": "OSWebAppSandbox",
+  "display": "standalone",
+  "background_color": "#ff0000",
+  "description": "Add this WebApp to your iOS 16.4 homescreen then open it to test WebPush!"
+}


### PR DESCRIPTION
# Description
## One Line Summary
Required changes to our Sandbox localhost testing to try out iOS WebPush.

## Details

# Validation
## Tests
Tested on iPadOS 16.4 beta 2 (a) with these steps:
1. Open site in an HTTPS URL
2. Press the Share button > "Add to HomeScreen"
3. Open new homescreen web app
4. Ensured notification prompting and receiving worked.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed
      - No visual changes

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/997)
<!-- Reviewable:end -->
