### PR TITLE
Feat/safari vapid

### DIFF
--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -3,8 +3,12 @@
 <!-- Some sites use this HTML base tag to change the origin for all relative links.
     Ensure OneSignal SDK correctly handles this. -->
 <base href="https://www.example.com/">
-<script src="sdks/Dev-OneSignalSDK.js" async=""></script>
+<script src="sdks/Dev-OneSignalSDK.js" defer=""></script>
 <script>
+    // NOTE: Uncomment and open site in Safari on macOS 13+ to simulate
+    // a similar JS API as an iOS 16.4 WebApp.
+    // window.safari = undefined;
+
     const SERVICE_WORKER_PATH = "push/onesignal/";
 
     function getUrlQueryParam(name) {

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -1,6 +1,7 @@
 import SdkEnvironment from './managers/SdkEnvironment';
 import { WindowEnvironmentKind } from './models/WindowEnvironmentKind';
 import bowser from 'bowser';
+import { supportsVapidPush } from './context/browser/utils/BrowserSupportsPush';
 
 export default class Environment {
   /**
@@ -10,8 +11,16 @@ export default class Environment {
     return typeof window !== 'undefined';
   }
 
-  public static isSafari(): boolean {
-    return Environment.isBrowser() && bowser.safari;
+  // Prefer Legacy Safari if API is available over VAPID until Safari
+  // fixes issues with it.
+  public static useSafariLegacyPush(): boolean {
+    return window.safari?.pushNotification != undefined
+  }
+
+  // This is the counter part to useSafariLegacyPush(); as it notes only use
+  // Safari VAPID if it doesn't have legacy Safari push.
+  public static useSafariVapidPush(): boolean {
+    return bowser.safari && supportsVapidPush() && !this.useSafariLegacyPush();
   }
 
   public static version() {

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -14,7 +14,7 @@ export default class Environment {
   // Prefer Legacy Safari if API is available over VAPID until Safari
   // fixes issues with it.
   public static useSafariLegacyPush(): boolean {
-    return window.safari?.pushNotification != undefined
+    return this.isBrowser() && window.safari?.pushNotification != undefined
   }
 
   // This is the counter part to useSafariLegacyPush(); as it notes only use

--- a/src/context/browser/utils/BrowserSupportsPush.ts
+++ b/src/context/browser/utils/BrowserSupportsPush.ts
@@ -20,7 +20,7 @@ function supportsSafariPush(): boolean {
 }
 
 // Does the browser support the standard Push API
-function supportsVapidPush(): boolean {
+export function supportsVapidPush(): boolean {
   return typeof PushSubscriptionOptions !== "undefined" &&
          PushSubscriptionOptions.prototype.hasOwnProperty("applicationServerKey");
 }

--- a/src/managers/PermissionManager.ts
+++ b/src/managers/PermissionManager.ts
@@ -1,9 +1,9 @@
 import OneSignalUtils from '../utils/OneSignalUtils';
-import bowser from 'bowser';
 import { InvalidArgumentError, InvalidArgumentReason } from '../errors/InvalidArgumentError';
 import { NotificationPermission } from '../models/NotificationPermission';
 import SdkEnvironment from '../managers/SdkEnvironment';
 import LocalStorage from '../utils/LocalStorage';
+import Environment from '../../src/Environment';
 
 /**
  * A permission manager to consolidate the different quirks of obtaining and evaluating permissions
@@ -69,7 +69,7 @@ export default class PermissionManager {
    * @param safariWebId The Safari web ID necessary to access the permission state on Safari.
    */
   public async getReportedNotificationPermission(safariWebId?: string): Promise<NotificationPermission>{
-    if (bowser.safari)
+    if (Environment.useSafariLegacyPush())
       return PermissionManager.getSafariNotificationPermission(safariWebId);
 
     // Is this web push setup using subdomain.os.tc or subdomain.onesignal.com?

--- a/src/managers/SdkEnvironment.ts
+++ b/src/managers/SdkEnvironment.ts
@@ -85,8 +85,8 @@ export default class SdkEnvironment {
    * @param usingProxyOrigin Using a subdomain of os.tc or onesignal.com for subscribing to push.
    */
   public static async getIntegration(usingProxyOrigin?: boolean): Promise<IntegrationKind> {
-    if (Environment.isSafari()) {
-      /* HTTP doesn't apply to Safari sites */
+    if (Environment.useSafariLegacyPush()) {
+      /* Safari Legacy works on HTTP sites */
       return IntegrationKind.Secure;
     }
 

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -57,10 +57,6 @@ export class SubscriptionManager {
     this.config = config;
   }
 
-  static isSafari(): boolean {
-    return Environment.isSafari();
-  }
-
   /**
    * Subscribes for a web push subscription.
    *
@@ -102,7 +98,7 @@ export class SubscriptionManager {
         if ((await OneSignal.privateGetNotificationPermission()) === NotificationPermission.Denied)
           throw new PushPermissionNotGrantedError(PushPermissionNotGrantedErrorReason.Blocked);
 
-        if (SubscriptionManager.isSafari()) {
+        if (Environment.useSafariLegacyPush()) {
           rawPushSubscription = await this.subscribeSafari();
           /* Now that permissions have been granted, install the service worker */
           Log.info("Installing SW on Safari");
@@ -174,7 +170,7 @@ export class SubscriptionManager {
     subscription.deviceId = newDeviceId;
     subscription.optedOut = false;
     if (pushSubscription) {
-      if (SubscriptionManager.isSafari()) {
+      if (Environment.useSafariLegacyPush()) {
         subscription.subscriptionToken = pushSubscription.safariDeviceToken;
       } else {
         subscription.subscriptionToken = pushSubscription.w3cEndpoint ? pushSubscription.w3cEndpoint.toString() : null;
@@ -727,7 +723,7 @@ export class SubscriptionManager {
   private async getSubscriptionStateForSecure(): Promise<PushSubscriptionState> {
     const { deviceId, optedOut } = await Database.getSubscription();
 
-    if (SubscriptionManager.isSafari()) {
+    if (Environment.useSafariLegacyPush()) {
       const subscriptionState: SafariRemoteNotificationPermission =
         window.safari.pushNotification.permission(this.config.safariWebId);
       const isSubscribedToSafari = !!(

--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -680,8 +680,8 @@ export class SubscriptionManager {
    * Returns an object describing the user's actual push subscription state and opt-out status.
    */
   public async getSubscriptionState(): Promise<PushSubscriptionState> {
-    /* Safari should always return Secure because HTTP doesn't apply on Safari */
-    if (SubscriptionManager.isSafari()) {
+    /* Safari Legacy supports HTTP so we don't have to use the subdomain workaround. */
+    if (Environment.useSafariLegacyPush()) {
       return this.getSubscriptionStateForSecure();
     }
 

--- a/src/models/DeliveryPlatformKind.ts
+++ b/src/models/DeliveryPlatformKind.ts
@@ -5,4 +5,5 @@ export enum DeliveryPlatformKind {
   Email = 11,
   Edge = 12,
   SMS = 14,
+  SafariVapid = 17,
 }

--- a/src/models/DeliveryPlatformKind.ts
+++ b/src/models/DeliveryPlatformKind.ts
@@ -1,6 +1,6 @@
 export enum DeliveryPlatformKind {
   ChromeLike = 5,
-  Safari = 7,
+  SafariLegacy = 7,
   Firefox = 8,
   Email = 11,
   Edge = 12,

--- a/src/models/DeviceRecord.ts
+++ b/src/models/DeviceRecord.ts
@@ -63,7 +63,7 @@ export abstract class DeviceRecord implements Serializable {
     const browser = OneSignalUtils.redetectBrowserUserAgent();
 
     if (this.isSafari()) {
-      return DeliveryPlatformKind.Safari;
+      return DeliveryPlatformKind.SafariLegacy;
     } else if (browser.firefox) {
       return DeliveryPlatformKind.Firefox;
     } else if (browser.msedge) {

--- a/src/models/DeviceRecord.ts
+++ b/src/models/DeviceRecord.ts
@@ -54,16 +54,14 @@ export abstract class DeviceRecord implements Serializable {
     // Unimplemented properties are appId, subscriptionState, and subscription
   }
 
-  isSafari(): boolean {
-    return bowser.safari && window.safari !== undefined && window.safari.pushNotification !== undefined;
-  }
-
   getDeliveryPlatform(): DeliveryPlatformKind {
     // For testing purposes, allows changing the browser user agent
     const browser = OneSignalUtils.redetectBrowserUserAgent();
-
-    if (this.isSafari()) {
+  
+    if (Environment.useSafariLegacyPush()) {
       return DeliveryPlatformKind.SafariLegacy;
+    } else if (Environment.useSafariVapidPush()) {
+      return DeliveryPlatformKind.SafariVapid;
     } else if (browser.firefox) {
       return DeliveryPlatformKind.Firefox;
     } else if (browser.msedge) {

--- a/src/models/PushDeviceRecord.ts
+++ b/src/models/PushDeviceRecord.ts
@@ -1,9 +1,8 @@
-import bowser from 'bowser';
-
 import NotImplementedError from '../errors/NotImplementedError';
 import { RawPushSubscription } from './RawPushSubscription';
 import { SubscriptionStateKind } from './SubscriptionStateKind';
 import { DeviceRecord, FlattenedDeviceRecord } from './DeviceRecord';
+import Environment from '../Environment';
 
 export interface SerializedPushDeviceRecord extends FlattenedDeviceRecord {
   identifier?: string | null;
@@ -29,7 +28,7 @@ export class PushDeviceRecord extends DeviceRecord {
     const serializedBundle: SerializedPushDeviceRecord = super.serialize();
 
     if (this.subscription) {
-      serializedBundle.identifier = bowser.safari ?
+      serializedBundle.identifier = Environment.useSafariLegacyPush() ?
         this.subscription.safariDeviceToken :
         this.subscription.w3cEndpoint ? this.subscription.w3cEndpoint.toString() : null;
       serializedBundle.web_auth = this.subscription.w3cAuth;

--- a/test/unit/managers/SubscriptionManager.ts
+++ b/test/unit/managers/SubscriptionManager.ts
@@ -26,6 +26,7 @@ import { Subscription } from "../../../src/models/Subscription";
 import { PushDeviceRecord } from "../../../src/models/PushDeviceRecord";
 import { MockPushManager } from "../../support/mocks/service-workers/models/MockPushManager";
 import { MockPushSubscription } from "../../support/mocks/service-workers/models/MockPushSubscription";
+import Environment from '../../../src/Environment';
 
 const sandbox: SinonSandbox= sinon.sandbox.create();
 
@@ -292,7 +293,7 @@ test("registerSubscription with an existing subsription sends player update", as
 
   sandbox.stub(Database, "getSubscription").resolves({ deviceId } as Subscription);
   sandbox.stub(subscriptionManager, "associateSubscriptionWithEmail").resolves();
-  sandbox.stub(SubscriptionManager, "isSafari").returns(false);
+  sandbox.stub(Environment, "useSafariLegacyPush").returns(false);
   sandbox.stub(Database, "setSubscription").resolves();
 
   const playerUpdateSpy = sandbox.stub(OneSignal.context.updateManager, "sendPushDeviceRecordUpdate");
@@ -329,7 +330,7 @@ test("registerSubscription without an existing subsription sends player create",
   sandbox.stub(Database, "getSubscription").resolves({ } as Subscription);
   sandbox.stub(subscriptionManager, "associateSubscriptionWithEmail").resolves();
   sandbox.stub(PushDeviceRecord, "createFromPushSubscription").returns(deviceRecord);
-  sandbox.stub(SubscriptionManager, "isSafari").returns(false);
+  sandbox.stub(Environment, "useSafariLegacyPush").returns(false);
   sandbox.stub(Database, "setSubscription").resolves();
 
   const playerUpdateSpy = sandbox.stub(OneSignal.context.updateManager, "sendPushDeviceRecordUpdate");
@@ -734,7 +735,7 @@ test(
     const error403 = new ServiceWorkerRegistrationError(403, "403 Forbidden");
     sandbox.stub(serviceWorkerManager, "installWorker").rejects(error403);
     sandbox.stub(SdkEnvironment, "getWindowEnv").returns(WindowEnvironmentKind.Host);
-    sandbox.stub(SubscriptionManager, "isSafari").returns(false);
+    sandbox.stub(Environment, "useSafariLegacyPush").returns(false);
 
     const smSpyRegisterFailed = sandbox.spy(subscriptionManager, "registerFailedSubscription");
     const smSpyRegister = sandbox.spy(subscriptionManager, "registerSubscription");
@@ -760,7 +761,7 @@ test(
     const error403 = new ServiceWorkerRegistrationError(403, "403 Forbidden");
     sandbox.stub(serviceWorkerManager, "installWorker").throws(error403);
     sandbox.stub(SdkEnvironment, "getWindowEnv").returns(WindowEnvironmentKind.Host);
-    sandbox.stub(SubscriptionManager, "isSafari").returns(false);
+    sandbox.stub(Environment, "useSafariLegacyPush").returns(false);
 
     const smSpyRegisterFailed = sandbox.spy(subscriptionManager, "registerFailedSubscription");
     const smSpyRegister = sandbox.spy(subscriptionManager, "registerSubscription");
@@ -786,7 +787,7 @@ test(
     const error404 = new ServiceWorkerRegistrationError(404, "404 Not Found");
     sandbox.stub(serviceWorkerManager, "installWorker").rejects(error404);
     sandbox.stub(SdkEnvironment, "getWindowEnv").returns(WindowEnvironmentKind.Host);
-    sandbox.stub(SubscriptionManager, "isSafari").returns(false);
+    sandbox.stub(Environment, "useSafariLegacyPush").returns(false);
 
     const smSpyRegisterFailed = sandbox.spy(subscriptionManager, "registerFailedSubscription");
     const smSpyRegister = sandbox.spy(subscriptionManager, "registerSubscription");
@@ -812,7 +813,7 @@ test(
     const error404 = new ServiceWorkerRegistrationError(404, "404 Not Found");
     sandbox.stub(serviceWorkerManager, "installWorker").throws(error404);
     sandbox.stub(SdkEnvironment, "getWindowEnv").returns(WindowEnvironmentKind.Host);
-    sandbox.stub(SubscriptionManager, "isSafari").returns(false);
+    sandbox.stub(Environment, "useSafariLegacyPush").returns(false);
 
     const smSpyRegisterFailed = sandbox.spy(subscriptionManager, "registerFailedSubscription");
     const smSpyRegister = sandbox.spy(subscriptionManager, "registerSubscription");

--- a/test/unit/models/deliveryPlatformKind.ts
+++ b/test/unit/models/deliveryPlatformKind.ts
@@ -4,7 +4,7 @@ import { DeliveryPlatformKind } from '../../../src/models/DeliveryPlatformKind';
 
 test(`delivery platform constants should be correct`, async t => {
   t.is(DeliveryPlatformKind.ChromeLike, 5);
-  t.is(DeliveryPlatformKind.Safari, 7);
+  t.is(DeliveryPlatformKind.SafariLegacy, 7);
   t.is(DeliveryPlatformKind.Firefox, 8);
   t.is(DeliveryPlatformKind.Edge, 12);
   t.is(DeliveryPlatformKind.SafariVapid, 17);

--- a/test/unit/models/deliveryPlatformKind.ts
+++ b/test/unit/models/deliveryPlatformKind.ts
@@ -7,5 +7,6 @@ test(`delivery platform constants should be correct`, async t => {
   t.is(DeliveryPlatformKind.Safari, 7);
   t.is(DeliveryPlatformKind.Firefox, 8);
   t.is(DeliveryPlatformKind.Edge, 12);
+  t.is(DeliveryPlatformKind.SafariVapid, 17);
 });
 

--- a/typings/globals/missing.d.ts
+++ b/typings/globals/missing.d.ts
@@ -1,19 +1,21 @@
 /**
  * START: window.safari definition
- * https://developer.apple.com/documentation/safariextensions
+ * Types and names collected from:
+ *   - https://developer.apple.com/documentation/safariextensions/safariremotenotification
+ *   - https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/NotificationProgrammingGuideForWebsites/PushNotifications/PushNotifications.html
  */
 interface SafariRemoteNotificationPermission {
-  readonly deviceToken: string | null | undefined;
-  readonly permission: string;
+  readonly deviceToken: string | null;
+  readonly permission: "default" | "granted" | "denied";
 }
 
 interface SafariRemoteNotification {
-  permission(bundleIdentifier: string): SafariRemoteNotificationPermission;
+  permission(websitePushID: string): SafariRemoteNotificationPermission;
   requestPermission(
     webAPIURL: string,
-    websiteIdentifier: string,
-    queryParameterDictionary: any,
-    callback: Function
+    websitePushID: string,
+    queryParameterDictionary: unknown,
+    callback: (permissionData: SafariRemoteNotificationPermission) => void
   ): void;
 }
 


### PR DESCRIPTION
# Description
## One Line Summary
Add support for Safari browsers that only support the VAPID PushAPI (iOS), Legacy Safari push will continue to be preferred where it is available (macOS).

## Details
# Validation
## Tests
macOS 13.1 with Safari 16.2
* Subscribed with Safari Legacy APIs and it receives notifications
* Tested with `window.safari = undefined` to simulate an iOS WebApp env, ensured it used VAPID push and received pushes
* Tested with `delete PushSubscriptionOptions` to simulate Safari on pre-macOS13, ensured it subscribed and received notifications

iOS 16.4 beta 3
* SDK didn't prompt until it was A2HS, as expected.
* Notification prompting worked and notification was received.

macOS 12.6.3 with Safari 15.6.1
* Prompted and notification received

Windows 11 22H2 Chrome 110.0.5481.105
* Prompted and notification received 


### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets
Due to Safari on macOS 13+ bugs we are holding off on PR #930, which attempted to use VAPID by default and migrate existing Legacy Safari players to it.

This also resolves issue ["Chrome Desktop with Dev iOS View - TypeError: Cannot read property 'pushNotification' of undefined" #560](https://github.com/OneSignal/OneSignal-Website-SDK/issues/560)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1002)
<!-- Reviewable:end -->
