### PR TITLE
User model/push subscription improvements

### DIFF
--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -244,7 +244,7 @@ export default class OneSignal {
   static Notifications = new NotificationsNamespace();
   static Slidedown = new SlidedownNamespace();
   static Session = new SessionNamespace();
-  static User: UserNamespace;
+  static User = new UserNamespace(false);
   static Debug = new DebugNamespace();
   /* END NEW USER MODEL CHANGES */
 

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -40,9 +40,6 @@ import LocalStorage from "../shared/utils/LocalStorage";
 import LoginManager from "../page/managers/LoginManager";
 import { SessionNamespace } from "./SessionNamespace";
 import { OneSignalDeferredLoadedCallback } from "../page/models/OneSignalDeferredLoadedCallback";
-import UserDirector from "./UserDirector";
-import { ModelName, SupportedModel } from "../core/models/SupportedModels";
-import { OSModel } from "../core/modelRepo/OSModel";
 import DebugNamespace from "./DebugNamesapce";
 
 export default class OneSignal {
@@ -266,7 +263,7 @@ export default class OneSignal {
   static environment = Environment;
   static database = Database;
   static event = OneSignalEvent;
-  private static pendingInit: boolean = true;
+  private static pendingInit = true;
 
   static subscriptionPopup: SubscriptionPopup;
   static subscriptionPopupHost: SubscriptionPopupHost;

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -48,7 +48,8 @@ export default class OneSignal {
     await core.initPromise;
     OneSignal.coreDirector = new CoreModuleDirector(core);
     const subscription = await Database.getSubscription();
-    OneSignal.User = new UserNamespace(true, subscription);
+    const permission = await OneSignal.Notifications.getPermissionStatus();
+    OneSignal.User = new UserNamespace(true, subscription, permission);
   }
 
   private static async _initializeConfig(options: AppUserConfig) {

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -47,7 +47,8 @@ export default class OneSignal {
     const core = new CoreModule();
     await core.initPromise;
     OneSignal.coreDirector = new CoreModuleDirector(core);
-    OneSignal.User = new UserNamespace();
+    const subscription = await Database.getSubscription();
+    OneSignal.User = new UserNamespace(true, subscription);
   }
 
   private static async _initializeConfig(options: AppUserConfig) {

--- a/src/onesignal/PushSubscriptionNamespace.ts
+++ b/src/onesignal/PushSubscriptionNamespace.ts
@@ -26,7 +26,7 @@ export default class PushSubscriptionNamespace extends EventListenerBase {
       return;
     }
 
-    this._optedIn = subscription.optedOut;
+    this._optedIn = !subscription.optedOut;
     this._token = subscription.subscriptionToken;
 
     OneSignal.coreDirector.getCurrentPushSubscriptionModel()

--- a/src/onesignal/PushSubscriptionNamespace.ts
+++ b/src/onesignal/PushSubscriptionNamespace.ts
@@ -12,24 +12,22 @@ import { isCompleteSubscriptionObject, isModelStoreHydratedObject } from "../cor
 import { EventListenerBase } from "../page/userModel/EventListenerBase";
 import SubscriptionChangeEvent from "../page/models/SubscriptionChangeEvent";
 import { OSModel } from "../core/modelRepo/OSModel";
+import { Subscription } from "../shared/models/Subscription";
 
 export default class PushSubscriptionNamespace extends EventListenerBase {
   private _id?: string | null;
   private _token?: string | null;
   private _optedIn?: boolean;
 
-  constructor(initialize = true) {
+  constructor(initialize: boolean, subscription?: Subscription) {
     super();
-    if (!initialize) {
+    if (!initialize || !subscription) {
+      Log.warn(`PushSubscriptionNamespace: skipping initialization. One or more required params are falsy: initialize: ${initialize}, subscription: ${subscription}`);
       return;
     }
 
-    Database.getSubscription().then(subscription => {
-      this._optedIn = subscription.optedOut;
-      this._token = subscription.subscriptionToken;
-    }).catch(e => {
-      Log.error(e);
-    });
+    this._optedIn = subscription.optedOut;
+    this._token = subscription.subscriptionToken;
 
     OneSignal.coreDirector.getCurrentPushSubscriptionModel()
       .then((pushModel: OSModel<SupportedSubscription> | undefined) => {

--- a/src/onesignal/PushSubscriptionNamespace.ts
+++ b/src/onesignal/PushSubscriptionNamespace.ts
@@ -18,8 +18,12 @@ export default class PushSubscriptionNamespace extends EventListenerBase {
   private _token?: string | null;
   private _optedIn?: boolean;
 
-  constructor() {
+  constructor(initialize = true) {
     super();
+    if (!initialize) {
+      return;
+    }
+
     Database.getSubscription().then(subscription => {
       this._optedIn = subscription.optedOut;
       this._token = subscription.subscriptionToken;

--- a/src/onesignal/UserNamespace.ts
+++ b/src/onesignal/UserNamespace.ts
@@ -1,15 +1,16 @@
 import User from "./User";
 import PushSubscriptionNamespace from "./PushSubscriptionNamespace";
+import { Subscription } from "../shared/models/Subscription";
 
 export default class UserNamespace {
   private _currentUser?: User;
 
-  public PushSubscription = new PushSubscriptionNamespace(false);
+  readonly PushSubscription = new PushSubscriptionNamespace(false);
 
-  constructor(initialize = true) {
+  constructor(initialize: boolean, subscription?: Subscription) {
     if (initialize) {
       this._currentUser = User.createOrGetInstance();
-      this.PushSubscription = new PushSubscriptionNamespace();
+      this.PushSubscription = new PushSubscriptionNamespace(true, subscription);
     }
   }
 

--- a/src/onesignal/UserNamespace.ts
+++ b/src/onesignal/UserNamespace.ts
@@ -7,10 +7,10 @@ export default class UserNamespace {
 
   readonly PushSubscription = new PushSubscriptionNamespace(false);
 
-  constructor(initialize: boolean, subscription?: Subscription) {
+  constructor(initialize: boolean, subscription?: Subscription, permission?: NotificationPermission) {
     if (initialize) {
       this._currentUser = User.createOrGetInstance();
-      this.PushSubscription = new PushSubscriptionNamespace(true, subscription);
+      this.PushSubscription = new PushSubscriptionNamespace(true, subscription, permission);
     }
   }
 

--- a/src/onesignal/UserNamespace.ts
+++ b/src/onesignal/UserNamespace.ts
@@ -4,10 +4,13 @@ import PushSubscriptionNamespace from "./PushSubscriptionNamespace";
 export default class UserNamespace {
   private _currentUser?: User;
 
-  readonly PushSubscription = new PushSubscriptionNamespace();
+  public PushSubscription = new PushSubscriptionNamespace(false);
 
-  constructor() {
-    this._currentUser = User.createOrGetInstance();
+  constructor(initialize = true) {
+    if (initialize) {
+      this._currentUser = User.createOrGetInstance();
+      this.PushSubscription = new PushSubscriptionNamespace();
+    }
   }
 
   /* P U B L I C   A P I  */


### PR DESCRIPTION
# Description
## 1 Line Summary
This PR modifies classes to allow namespace reflection without full initialization and makes changes so the PushSubscription constructor initializes class properties synchronously

## Details
This pull request includes two commits that address important issues within the codebase.

The first commit modifies classes to allow namespace reflection without initialization. This change was motivated by the need to have namespaces defined from the start, without triggering the full initialization logic. This ensures that namespaces are present in the object prototype when reflecting (testing), avoiding errors.

The second commit changes the PushSubscription constructor to run synchronously. The motivation behind this change was to get the subscription synchronously from the database and pass it down to the namespace constructors. This guarantees that the PushSubscription properties like token, id, and optedIn are available once the init promise resolves, ensuring proper functionality.

Both changes are critical for the stability and performance of the codebase.

More details in commits

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1007)
<!-- Reviewable:end -->
