### PR TITLE
[user model ] - Update RequestService to not retry 400 level errors

### DIFF
--- a/src/core/requestService/IdentityRequests.ts
+++ b/src/core/requestService/IdentityRequests.ts
@@ -58,6 +58,12 @@ export default class IdentityRequests {
 
       return new ExecutorResult(true, true, identity);
     }
+
+    // shouldn't impact login since doesn't go through core module (special 409 case)
+    if (status >= 400 && status < 500) {
+      return new ExecutorResult(false, false);
+    }
+
     return new ExecutorResult(false, true);
   }
 }

--- a/src/core/requestService/SubscriptionRequests.ts
+++ b/src/core/requestService/SubscriptionRequests.ts
@@ -73,6 +73,11 @@ export default class SubscriptionRequests {
 
         return new ExecutorResult<SupportedSubscription>(true, true, subscription);
       }
+
+      if (status >= 400 && status < 500) {
+        return new ExecutorResult(false, false);
+      }
+
       return new ExecutorResult(false, true);
   }
 }

--- a/src/core/requestService/UserPropertyRequests.ts
+++ b/src/core/requestService/UserPropertyRequests.ts
@@ -49,6 +49,11 @@ export default class UserPropertyRequests {
       if (status >= 200 && status < 300) {
         return new ExecutorResult(true, true, result?.properties);
       }
+
+      if (status >= 400 && status < 500) {
+        return new ExecutorResult(false, false);
+      }
+
       return new ExecutorResult(false, true);
   }
 }


### PR DESCRIPTION
The `ExecutorResult` object is used by the base executor to decide whether or not to retry the operation. The object looks like this:

```ts
new ExecutorResult<IdentityModel>(success: boolean, retriable: boolean, result?: IdentityModel | undefined)
```

Here, we're updating the RequestService functions to _not_ retry the operation at all if the status code is 4** level.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1012)
<!-- Reviewable:end -->
