### PR TITLE
Add cdn. to migration guide script URLs

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -56,23 +56,23 @@ Use the new script import on both your pages and your Service Worker file.
 
 From:
 ```html
-<script src="https://onesignal.com/sdks/OneSignalSDK.js" async/>
+<script src="https://cdn.onesignal.com/sdks/OneSignalSDK.js" async/>
 ```
 
 To:
 ```html
-<script src="https://onesignal.com/sdks/web/v16/OneSignalSDK.page.js" defer></script>
+<script src="https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.page.js" defer></script>
 ```
 ### Service Worker
 
 From:
 ```js
-importScripts("https://onesignal.com/sdks/OneSignalSDKWorker.js");
+importScripts("https://cdn.onesignal.com/sdks/OneSignalSDKWorker.js");
 ```
 
 To:
 ```js
-importScripts("https://onesignal.com/sdks/web/v16/OneSignalSDK.sw.js");
+importScripts("https://cdn.onesignal.com/sdks/web/v16/OneSignalSDK.sw.js");
 ```
 
 


### PR DESCRIPTION
# Description
## 1 Line Summary
Add missing .cdn subdomain to script URL paths in migration guide.

## Details

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---
