### PR TITLE
User model/api changes

### DIFF
--- a/__test__/unit/user/login.test.ts
+++ b/__test__/unit/user/login.test.ts
@@ -11,6 +11,7 @@ import { DUMMY_EXTERNAL_ID, DUMMY_ONESIGNAL_ID } from "../../support/constants";
 import { IdentityExecutor } from "../../../src/core/executors/IdentityExecutor";
 import { PropertiesExecutor } from "../../../src/core/executors/PropertiesExecutor";
 import { SubscriptionExecutor } from "../../../src/core/executors/SubscriptionExecutor";
+import LocalStorage from "../../../src/shared/utils/LocalStorage";
 
 // suppress all internal logging
 jest.mock("../../../src/shared/libraries/Log");
@@ -31,8 +32,8 @@ describe('Login tests', () => {
   test('If privacy consent is required but not given, do not login', async () => {
     await TestEnvironment.initialize({
       useMockIdentityModel: true,
-      userConfig: { requiresUserPrivacyConsent: true }
     });
+    LocalStorage.setConsentRequired(true);
 
     test.stub(Database, "getConsentGiven", Promise.resolve(false));
 

--- a/src/onesignal/NotificationsNamespace.ts
+++ b/src/onesignal/NotificationsNamespace.ts
@@ -6,6 +6,7 @@ import OneSignalError from "../../src/shared/errors/OneSignalError";
 import OneSignal from "./OneSignal";
 import { EventListenerBase } from "../page/userModel/EventListenerBase";
 import NotificationEventName from "../page/models/NotificationEventName";
+import { NotificationClicked } from "../../src/shared/models/Notification";
 
 export default class NotificationsNamespace extends EventListenerBase {
   constructor(private _permissionNative?: NotificationPermission) {
@@ -147,7 +148,7 @@ export default class NotificationsNamespace extends EventListenerBase {
   }
 
   /* Function overloads */
-  addEventListener(event: NotificationEventName.Click, listener: (obj: StructuredNotification) => void): void;
+  addEventListener(event: NotificationEventName.Click, listener: (obj: NotificationClicked) => void): void;
   addEventListener(event: NotificationEventName.WillDisplay, listener: (obj: StructuredNotification) => void): void;
   addEventListener(event: NotificationEventName.Dismiss, listener: (obj: StructuredNotification) => void): void;
   addEventListener(event: NotificationEventName.PermissionChange,
@@ -159,7 +160,7 @@ export default class NotificationsNamespace extends EventListenerBase {
   }
 
   /* Function overloads */
-  removeEventListener(event: NotificationEventName.Click, listener: (obj: StructuredNotification) => void): void;
+  removeEventListener(event: NotificationEventName.Click, listener: (event: NotificationClicked) => void): void;
   removeEventListener(event: NotificationEventName.WillDisplay, listener: (obj: StructuredNotification) => void): void;
   removeEventListener(event: NotificationEventName.Dismiss, listener: (obj: StructuredNotification) => void): void;
   removeEventListener(event: NotificationEventName.PermissionChange,

--- a/src/onesignal/NotificationsNamespace.ts
+++ b/src/onesignal/NotificationsNamespace.ts
@@ -126,8 +126,9 @@ export default class NotificationsNamespace extends EventListenerBase {
         OneSignal.config!.safariWebId
       );
 
-    if (onComplete)
+    if (onComplete) {
       onComplete(permission);
+    }
 
     return permission;
   }

--- a/src/onesignal/NotificationsNamespace.ts
+++ b/src/onesignal/NotificationsNamespace.ts
@@ -8,8 +8,16 @@ import { EventListenerBase } from "../page/userModel/EventListenerBase";
 import NotificationEventName from "../page/models/NotificationEventName";
 
 export default class NotificationsNamespace extends EventListenerBase {
-  constructor() {
+  constructor(private _permissionNative?: NotificationPermission) {
     super();
+
+    OneSignal.emitter.on(OneSignal.EVENTS.NATIVE_PROMPT_PERMISSIONCHANGED, (permission: NotificationPermission) => {
+      this._permissionNative = permission;
+    });
+  }
+
+  get permissionNative(): NotificationPermission | undefined {
+    return this._permissionNative;
   }
 
   /**
@@ -143,7 +151,7 @@ export default class NotificationsNamespace extends EventListenerBase {
   addEventListener(event: NotificationEventName.WillDisplay, listener: (obj: StructuredNotification) => void): void;
   addEventListener(event: NotificationEventName.Dismiss, listener: (obj: StructuredNotification) => void): void;
   addEventListener(event: NotificationEventName.PermissionChange,
-    listener: (obj: { to: NotificationPermission }) => void): void;
+    listener: (permission: boolean) => void): void;
   addEventListener(event: NotificationEventName.PermissionPromptDisplay, listener: () => void): void;
 
   addEventListener(event: string, listener: (obj: any) => void): void {
@@ -155,7 +163,7 @@ export default class NotificationsNamespace extends EventListenerBase {
   removeEventListener(event: NotificationEventName.WillDisplay, listener: (obj: StructuredNotification) => void): void;
   removeEventListener(event: NotificationEventName.Dismiss, listener: (obj: StructuredNotification) => void): void;
   removeEventListener(event: NotificationEventName.PermissionChange,
-    listener: (obj: { to: NotificationPermission }) => void): void;
+    listener: (permission: boolean) => void): void;
   removeEventListener(event: NotificationEventName.PermissionPromptDisplay, listener: () => void): void;
 
   removeEventListener(event: string, listener: (obj: any) => void): void {

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -146,7 +146,7 @@ export default class OneSignal {
 
     await OneSignal._initializeCoreModuleAndOSNamespaces();
 
-    if (OneSignal.config.userConfig.requiresUserPrivacyConsent || LocalStorage.getConsentRequired()) {
+    if (LocalStorage.getConsentRequired()) {
       const providedConsent = await Database.getConsentGiven();
       if (!providedConsent) {
         OneSignal.pendingInit = true;

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -47,13 +47,14 @@ import { ONESIGNAL_EVENTS } from "./OneSignalEvents";
 export default class OneSignal {
   static EVENTS = ONESIGNAL_EVENTS;
 
-  private static async _initializeCoreModuleAndUserNamespace() {
+  private static async _initializeCoreModuleAndOSNamespaces() {
     const core = new CoreModule();
     await core.initPromise;
     OneSignal.coreDirector = new CoreModuleDirector(core);
     const subscription = await Database.getSubscription();
     const permission = await OneSignal.Notifications.getPermissionStatus();
     OneSignal.User = new UserNamespace(true, subscription, permission);
+    this.Notifications = new NotificationsNamespace(permission);
   }
 
   private static async _initializeConfig(options: AppUserConfig) {
@@ -143,7 +144,7 @@ export default class OneSignal {
       return;
     }
 
-    await OneSignal._initializeCoreModuleAndUserNamespace();
+    await OneSignal._initializeCoreModuleAndOSNamespaces();
 
     if (OneSignal.config.userConfig.requiresUserPrivacyConsent || LocalStorage.getConsentRequired()) {
       const providedConsent = await Database.getConsentGiven();

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -42,8 +42,11 @@ import { SessionNamespace } from "./SessionNamespace";
 import { OneSignalDeferredLoadedCallback } from "../page/models/OneSignalDeferredLoadedCallback";
 import DebugNamespace from "./DebugNamesapce";
 import { InvalidArgumentError, InvalidArgumentReason } from "../shared/errors/InvalidArgumentError";
+import { ONESIGNAL_EVENTS } from "./OneSignalEvents";
 
 export default class OneSignal {
+  static EVENTS = ONESIGNAL_EVENTS;
+
   private static async _initializeCoreModuleAndUserNamespace() {
     const core = new CoreModule();
     await core.initPromise;
@@ -272,15 +275,6 @@ export default class OneSignal {
     ProcessOneSignalPushCalls.processItem(OneSignal, item);
   }
 
-  /* NEW USER MODEL CHANGES */
-  static coreDirector: CoreModuleDirector;
-  static Notifications = new NotificationsNamespace();
-  static Slidedown = new SlidedownNamespace();
-  static Session = new SessionNamespace();
-  static User = new UserNamespace(false);
-  static Debug = new DebugNamespace();
-  /* END NEW USER MODEL CHANGES */
-
   static __doNotShowWelcomeNotification: boolean;
   static VERSION = Environment.version();
   static _VERSION = Environment.version();
@@ -315,6 +309,15 @@ export default class OneSignal {
   static __initAlreadyCalled = false;
   static context: Context;
   static DeviceRecord = DeviceRecord;
+
+  /* NEW USER MODEL CHANGES */
+  static coreDirector: CoreModuleDirector;
+  static Notifications = new NotificationsNamespace();
+  static Slidedown = new SlidedownNamespace();
+  static Session = new SessionNamespace();
+  static User = new UserNamespace(false);
+  static Debug = new DebugNamespace();
+  /* END NEW USER MODEL CHANGES */
 
   /**
    * Used by Rails-side HTTP popup. Must keep the same name.
@@ -367,85 +370,6 @@ export default class OneSignal {
     SESSION_DEACTIVATE: 'postmam.sessionDeactivate',
     ARE_YOU_VISIBLE_REQUEST: 'postmam.areYouVisibleRequest',
     ARE_YOU_VISIBLE_RESPONSE: 'postmam.areYouVisibleResponse',
-  };
-
-  static EVENTS = {
-    /**
-     * Occurs when the user clicks the "Continue" or "No Thanks" button on the HTTP popup or HTTPS modal prompt.
-     * For HTTP sites (and HTTPS sites using the modal prompt), this event is fired before the native permission
-     * prompt is shown. This event is mostly used for HTTP sites.
-     */
-    CUSTOM_PROMPT_CLICKED: 'customPromptClick',
-    /**
-     * Occurs when the user clicks "Allow" or "Block" on the native permission prompt on Chrome, Firefox, or Safari.
-     * This event is used for both HTTP and HTTPS sites and occurs after the user actually grants notification
-     * permissions for the site. Occurs before the user is actually subscribed to push notifications.
-     */
-    NATIVE_PROMPT_PERMISSIONCHANGED: 'permissionChange',
-    /**
-     * Occurs after the user is officially subscribed to push notifications. The service worker is fully registered
-     * and activated and the user is eligible to receive push notifications at any point after this.
-     */
-    SUBSCRIPTION_CHANGED: 'subscriptionChange',
-    /**
-     * Occurs after a POST call to OneSignal's server to send the welcome notification has completed. The actual
-     * notification arrives shortly after.
-     */
-    WELCOME_NOTIFICATION_SENT: 'sendWelcomeNotification',
-    /**
-     * Occurs when a notification is displayed.
-     */
-    NOTIFICATION_WILL_DISPLAY: 'willDisplay',
-    /**
-     * Occurs when a notification is dismissed by the user either clicking 'X' or clearing all notifications
-     * (available in Android). This event is NOT called if the user clicks the notification's body or any of the
-     * action buttons.
-     */
-    NOTIFICATION_DISMISSED: 'dismiss',
-    /**
-     * New event replacing legacy addNotificationOpenedHandler(). Used when the notification was clicked.
-     */
-    NOTIFICATION_CLICKED: 'click',
-    /**
-     * Occurs after the document ready event fires and, for HTTP sites, the iFrame to subdomain.onesignal.com has
-     * loaded.
-     * Before this event, IndexedDB access is not possible for HTTP sites.
-     */
-    SDK_INITIALIZED: 'initializeInternal',
-    /**
-     * Occurs after the SDK finishes its final internal initialization. The final initialization event.
-     */
-    SDK_INITIALIZED_PUBLIC: 'initialize',
-    /**
-     * Occurs after the user subscribes to push notifications and a new user entry is created on OneSignal's server,
-     * and also occurs when the user begins a new site session and the last_session and last_active is updated on
-     * OneSignal's server.
-     */
-    REGISTERED: 'register',
-    /**
-     * Occurs as the HTTP popup is closing.
-     */
-    POPUP_CLOSING: 'popupClose',
-    /**
-     * Occurs when the native permission prompt is displayed.
-     */
-    PERMISSION_PROMPT_DISPLAYED: 'permissionPromptDisplay',
-    /**
-     * Occurs when the email subscription changes
-     */
-    EMAIL_SUBSCRIPTION_CHANGED: 'emailSubscriptionChanged',
-    /**
-     * Occurs when the SMS subscription changes
-     */
-    SMS_SUBSCRIPTION_CHANGED: 'smsSubscriptionChanged',
-    /**
-     * For internal testing only. Used for all sorts of things.
-     */
-    TEST_INIT_OPTION_DISABLED: 'testInitOptionDisabled',
-    TEST_WOULD_DISPLAY: 'testWouldDisplay',
-    TEST_FINISHED_ALLOW_CLICK_HANDLING: 'testFinishedAllowClickHandling',
-    POPUP_WINDOW_TIMEOUT: 'popupWindowTimeout',
-    SESSION_STARTED: "os.sessionStarted",
   };
 }
 

--- a/src/onesignal/OneSignalEvents.ts
+++ b/src/onesignal/OneSignalEvents.ts
@@ -1,0 +1,78 @@
+export const ONESIGNAL_EVENTS = {
+  /**
+   * Occurs when the user clicks the "Continue" or "No Thanks" button on the HTTP popup or HTTPS modal prompt.
+   * For HTTP sites (and HTTPS sites using the modal prompt), this event is fired before the native permission
+   * prompt is shown. This event is mostly used for HTTP sites.
+   */
+  CUSTOM_PROMPT_CLICKED: 'customPromptClick',
+  /**
+   * Occurs when the user clicks "Allow" or "Block" on the native permission prompt on Chrome, Firefox, or Safari.
+   * This event is used for both HTTP and HTTPS sites and occurs after the user actually grants notification
+   * permissions for the site. Occurs before the user is actually subscribed to push notifications.
+   */
+  NATIVE_PROMPT_PERMISSIONCHANGED: 'permissionChange',
+  /**
+   * Occurs after the user is officially subscribed to push notifications. The service worker is fully registered
+   * and activated and the user is eligible to receive push notifications at any point after this.
+   */
+  SUBSCRIPTION_CHANGED: 'subscriptionChange',
+  /**
+   * Occurs after a POST call to OneSignal's server to send the welcome notification has completed. The actual
+   * notification arrives shortly after.
+   */
+  WELCOME_NOTIFICATION_SENT: 'sendWelcomeNotification',
+  /**
+   * Occurs when a notification is displayed.
+   */
+  NOTIFICATION_WILL_DISPLAY: 'willDisplay',
+  /**
+   * Occurs when a notification is dismissed by the user either clicking 'X' or clearing all notifications
+   * (available in Android). This event is NOT called if the user clicks the notification's body or any of the
+   * action buttons.
+   */
+  NOTIFICATION_DISMISSED: 'dismiss',
+  /**
+   * New event replacing legacy addNotificationOpenedHandler(). Used when the notification was clicked.
+   */
+  NOTIFICATION_CLICKED: 'click',
+  /**
+   * Occurs after the document ready event fires and, for HTTP sites, the iFrame to subdomain.onesignal.com has
+   * loaded.
+   * Before this event, IndexedDB access is not possible for HTTP sites.
+   */
+  SDK_INITIALIZED: 'initializeInternal',
+  /**
+   * Occurs after the SDK finishes its final internal initialization. The final initialization event.
+   */
+  SDK_INITIALIZED_PUBLIC: 'initialize',
+  /**
+   * Occurs after the user subscribes to push notifications and a new user entry is created on OneSignal's server,
+   * and also occurs when the user begins a new site session and the last_session and last_active is updated on
+   * OneSignal's server.
+   */
+  REGISTERED: 'register',
+  /**
+   * Occurs as the HTTP popup is closing.
+   */
+  POPUP_CLOSING: 'popupClose',
+  /**
+   * Occurs when the native permission prompt is displayed.
+   */
+  PERMISSION_PROMPT_DISPLAYED: 'permissionPromptDisplay',
+  /**
+   * Occurs when the email subscription changes
+   */
+  EMAIL_SUBSCRIPTION_CHANGED: 'emailSubscriptionChanged',
+  /**
+   * Occurs when the SMS subscription changes
+   */
+  SMS_SUBSCRIPTION_CHANGED: 'smsSubscriptionChanged',
+  /**
+   * For internal testing only. Used for all sorts of things.
+   */
+  TEST_INIT_OPTION_DISABLED: 'testInitOptionDisabled',
+  TEST_WOULD_DISPLAY: 'testWouldDisplay',
+  TEST_FINISHED_ALLOW_CLICK_HANDLING: 'testFinishedAllowClickHandling',
+  POPUP_WINDOW_TIMEOUT: 'popupWindowTimeout',
+  SESSION_STARTED: "os.sessionStarted",
+};

--- a/src/onesignal/PushSubscriptionNamespace.ts
+++ b/src/onesignal/PushSubscriptionNamespace.ts
@@ -48,8 +48,8 @@ export default class PushSubscriptionNamespace extends EventListenerBase {
       this._token = await MainHelper.getCurrentPushToken();
     });
 
-    OneSignal.emitter.on(OneSignal.EVENTS.NATIVE_PROMPT_PERMISSIONCHANGED, async (event: { to: NotificationPermission }) => {
-      this._permission = event.to;
+    OneSignal.emitter.on(OneSignal.EVENTS.NATIVE_PROMPT_PERMISSIONCHANGED, async (permission: NotificationPermission) => {
+      this._permission = permission;
     });
   }
 

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -18,7 +18,7 @@ import { ModelName, SupportedModel } from "../../core/models/SupportedModels";
 
 export default class LoginManager {
   static async login(externalId: string, token?: string): Promise<void> {
-    const consentRequired = OneSignal.config?.userConfig.requiresUserPrivacyConsent || LocalStorage.getConsentRequired();
+    const consentRequired = LocalStorage.getConsentRequired();
     const consentGiven = await Database.getConsentGiven();
 
     if (consentRequired && !consentGiven) {

--- a/src/shared/helpers/ConfigHelper.ts
+++ b/src/shared/helpers/ConfigHelper.ts
@@ -463,7 +463,6 @@ export class ConfigHelper {
             serverConfig.config.notificationBehavior.click.action : undefined,
           allowLocalhostAsSecureOrigin: serverConfig.config.setupBehavior ?
             serverConfig.config.setupBehavior.allowLocalhostAsSecureOrigin : undefined,
-          requiresUserPrivacyConsent: userConfig.requiresUserPrivacyConsent,
           outcomes: {
             direct: serverConfig.config.outcomes.direct,
             indirect: {

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -183,7 +183,7 @@ export default class EventHelper {
    * subdomain.onesignal.com URL.
    */
   static async fireStoredNotificationClicks(url: string = document.URL) {
-    async function fireEventWithNotification(clickedNotificationInfo) {
+    async function fireEventWithNotification(clickedNotificationInfo: { url: string, data: any, timestamp: number }) {
       // Remove the notification from the recently clicked list
       // Once this page processes this retroactively provided clicked event, nothing should get the same event
       const appState = await Database.getAppState();

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -209,6 +209,7 @@ export default class EventHelper {
         const minutesSinceNotificationClicked = (Date.now() - timestamp) / 1000 / 60;
         if (minutesSinceNotificationClicked > 5) return;
       }
+
       OneSignalEvent.trigger(OneSignal.EVENTS.NOTIFICATION_CLICKED, notification);
     }
 

--- a/src/shared/models/AppConfig.ts
+++ b/src/shared/models/AppConfig.ts
@@ -100,7 +100,6 @@ export interface AppUserConfig {
   notificationClickHandlerMatch?: NotificationClickMatchBehavior;
   notificationClickHandlerAction?: NotificationClickActionBehavior;
   allowLocalhostAsSecureOrigin?: boolean;
-  requiresUserPrivacyConsent?: boolean;
   pageUrl?: string;
   outcomes?: OutcomesConfig;
 }

--- a/src/shared/models/Notification.ts
+++ b/src/shared/models/Notification.ts
@@ -85,6 +85,7 @@ export interface NotificationReceived {
 
 export interface NotificationClicked {
     notificationId: string;
+    action: string;
     appId: string;
     url: string;
     timestamp: number;

--- a/src/shared/utils/PermissionUtils.ts
+++ b/src/shared/utils/PermissionUtils.ts
@@ -3,8 +3,8 @@ import OneSignalEvent from '../services/OneSignalEvent';
 
 export class PermissionUtils {
   public static async triggerNotificationPermissionChanged(updateIfIdentical = false) {
-    const newPermission = await OneSignal.Notifications.getPermissionStatus();
-    const previousPermission = await Database.get('Options', 'notificationPermission');
+    const newPermission: NotificationPermission = await OneSignal.Notifications.getPermissionStatus();
+    const previousPermission: NotificationPermission = await Database.get('Options', 'notificationPermission');
 
     const shouldBeUpdated = newPermission !== previousPermission || updateIfIdentical;
     if (!shouldBeUpdated) {
@@ -12,6 +12,6 @@ export class PermissionUtils {
     }
 
     await Database.put('Options', { key: 'notificationPermission', value: newPermission });
-    OneSignalEvent.trigger(OneSignal.EVENTS.NATIVE_PROMPT_PERMISSIONCHANGED, { to: newPermission });
+    OneSignalEvent.trigger(OneSignal.EVENTS.NATIVE_PROMPT_PERMISSIONCHANGED, newPermission);
   }
 }

--- a/src/sw/serviceWorker/ServiceWorker.ts
+++ b/src/sw/serviceWorker/ServiceWorker.ts
@@ -775,11 +775,12 @@ export class ServiceWorker {
     // Close the notification first here, before we do anything that might fail
     event.notification.close();
 
-    const notificationData = event.notification.data;
+    const { data } = event.notification;
 
     // Chrome 48+: Get the action button that was clicked
-    if (event.action)
-      notificationData.action = event.action;
+    if (event.action) {
+      data.action = event.action;
+    }
 
     let notificationClickHandlerMatch = 'exact';
     let notificationClickHandlerAction = 'navigate';
@@ -792,14 +793,15 @@ export class ServiceWorker {
     if (actionPreference)
       notificationClickHandlerAction = actionPreference;
 
-    const launchUrl: string = await ServiceWorker.getNotificationUrlToOpen(notificationData);
+    const launchUrl: string = await ServiceWorker.getNotificationUrlToOpen(data);
     const notificationOpensLink: boolean = ServiceWorker.shouldOpenNotificationUrl(launchUrl);
     const appId = await ServiceWorker.getAppId();
     const deviceType = DeviceRecord.prototype.getDeliveryPlatform();
 
     let saveNotificationClickedPromise: Promise<void> | undefined;
     const notificationClicked: NotificationClicked = {
-      notificationId: notificationData.id,
+      notificationId: data.id,
+      action: data.action,
       appId,
       url: launchUrl,
       timestamp: new Date().getTime(),
@@ -827,7 +829,7 @@ export class ServiceWorker {
     // Start making REST API requests BEFORE self.clients.openWindow is called.
     // It will cause the service worker to stop on Chrome for Android when site is added to the home screen.
     const { deviceId } = await Database.getSubscription();
-    const convertedAPIRequests = ServiceWorker.sendConvertedAPIRequests(appId, deviceId, notificationData, deviceType);
+    const convertedAPIRequests = ServiceWorker.sendConvertedAPIRequests(appId, deviceId, data, deviceType);
 
     /*
      Check if we can focus on an existing tab instead of opening a new url.
@@ -866,7 +868,7 @@ export class ServiceWorker {
         if ((client['isSubdomainIframe'] && clientUrl === launchUrl) ||
             (!client['isSubdomainIframe'] && client.url === launchUrl) ||
           (notificationClickHandlerAction === 'focus' && clientOrigin === launchOrigin)) {
-          ServiceWorker.workerMessenger.unicast(WorkerMessengerCommand.NotificationClicked, notificationData, client);
+          ServiceWorker.workerMessenger.unicast(WorkerMessengerCommand.NotificationClicked, data, client);
             try {
               if (client instanceof WindowClient)
                 await client.focus();
@@ -890,7 +892,7 @@ export class ServiceWorker {
             }
             if (notificationOpensLink) {
               Log.debug(`Redirecting HTTP site to ${launchUrl}.`);
-              await Database.put("NotificationOpened", { url: launchUrl, data: notificationData, timestamp: Date.now() });
+              await Database.put("NotificationOpened", { url: launchUrl, data, timestamp: Date.now() });
               ServiceWorker.workerMessenger.unicast(WorkerMessengerCommand.RedirectPage, launchUrl, client);
             } else {
               Log.debug('Not navigating because link is special.');
@@ -907,7 +909,7 @@ export class ServiceWorker {
             try {
               if (notificationOpensLink) {
                 Log.debug(`Redirecting HTTPS site to (${launchUrl}).`);
-                await Database.put("NotificationOpened", { url: launchUrl, data: notificationData, timestamp: Date.now() });
+                await Database.put("NotificationOpened", { url: launchUrl, data, timestamp: Date.now() });
                 await client.navigate(launchUrl);
               } else {
                 Log.debug('Not navigating because link is special.');
@@ -917,7 +919,7 @@ export class ServiceWorker {
             }
           } else {
             // If client.navigate() isn't available, we have no other option but to open a new tab to the URL.
-            await Database.put("NotificationOpened", { url: launchUrl, data: notificationData, timestamp: Date.now() });
+            await Database.put("NotificationOpened", { url: launchUrl, data, timestamp: Date.now() });
             await ServiceWorker.openUrl(launchUrl);
           }
         }
@@ -927,7 +929,7 @@ export class ServiceWorker {
     }
 
     if (notificationOpensLink && !doNotOpenLink) {
-      await Database.put("NotificationOpened", { url: launchUrl, data: notificationData, timestamp: Date.now() });
+      await Database.put("NotificationOpened", { url: launchUrl, data, timestamp: Date.now() });
       await ServiceWorker.openUrl(launchUrl);
     }
     if (saveNotificationClickedPromise) {

--- a/src/sw/serviceWorker/ServiceWorker.ts
+++ b/src/sw/serviceWorker/ServiceWorker.ts
@@ -798,7 +798,6 @@ export class ServiceWorker {
     const appId = await ServiceWorker.getAppId();
     const deviceType = DeviceRecord.prototype.getDeliveryPlatform();
 
-    let saveNotificationClickedPromise: Promise<void> | undefined;
     const notificationClicked: NotificationClicked = {
       notificationId: data.id,
       action: data.action,
@@ -807,7 +806,7 @@ export class ServiceWorker {
       timestamp: new Date().getTime(),
     };
     Log.info("NotificationClicked", notificationClicked);
-    saveNotificationClickedPromise = (async notificationClicked => {
+    const saveNotificationClickedPromise = (async notificationClicked => {
       try {
         const existingSession = await Database.getCurrentSession();
         if (existingSession && existingSession.status === SessionStatus.Active) {


### PR DESCRIPTION
# PR Summary

## 1-line summary:
Several improvements and fixes related to OneSignal, native permissions, ServiceWorker, and IndexedDB

## Details:
- Moved OneSignal EVENTS into a separate file and moved namespace instances down so that Emitter is defined in time.
- Added a new getter `permissionNative` to retrieve native permission value and removed the `to` prop in favor of returning the native string value. Motivation: we are already passing it to the user namespace, we can also pass it down to the notification namespace.
- Exposed notification action taken on click in ServiceWorker. Motivation: somehow we weren't exposing the `action` as part of the notification click event object.
- Removed `requiresPrivacyConsent` from user config options to avoid confusion. Motivation: confusing to have it in init options as well as a setter function.
- Made various "nits" (minor improvements) related to IndexedDB fixes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1022)
<!-- Reviewable:end -->
