### PR TITLE
[user-model] fixes issue that results in a bad import

### DIFF
--- a/build/config/page-sdk-es6.config.js
+++ b/build/config/page-sdk-es6.config.js
@@ -19,7 +19,6 @@ const sdkVersion = process.env.npm_package_config_sdkVersion;
 async function getWebpackPlugins() {
   const plugins = [
     new MiniCssExtractPlugin({ filename: 'OneSignalSDK.page.styles.css' }),
-    new webpack.optimize.ModuleConcatenationPlugin(),
     new webpack.DefinePlugin({
       __BUILD_TYPE__: JSON.stringify(env),
       __BUILD_ORIGIN__: JSON.stringify(buildOrigin),

--- a/build/config/sdk.config.js
+++ b/build/config/sdk.config.js
@@ -53,7 +53,6 @@ async function getStylesheetsHash() {
 
 async function getWebpackPlugins() {
   const plugins = [
-      new webpack.optimize.ModuleConcatenationPlugin(),
       new webpack.DefinePlugin({
         __BUILD_TYPE__: JSON.stringify(env),
         __BUILD_ORIGIN__: JSON.stringify(buildOrigin),

--- a/build/config/serviceworker.config.js
+++ b/build/config/serviceworker.config.js
@@ -16,7 +16,6 @@ const sdkVersion = process.env.npm_package_config_sdkVersion;
 
 function getWebpackPlugins() {
   const plugins = [
-    new webpack.optimize.ModuleConcatenationPlugin(),
     new webpack.DefinePlugin({
       __BUILD_TYPE__: JSON.stringify(env),
       __BUILD_ORIGIN__: JSON.stringify(buildOrigin),


### PR DESCRIPTION
# Description
## 1 Line Summary
Removes `ModuleConcatenationPlugin` from all webpack config files.

## Details
Same issue as https://github.com/webpack/webpack/issues/8996

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1027)
<!-- Reviewable:end -->
