### PR TITLE
User model/fix notification types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
   root: true,
+  rules: {
+    'no-extra-boolean-cast': false,
+  },
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',

--- a/__test__/support/environment/TestEnvironment.ts
+++ b/__test__/support/environment/TestEnvironment.ts
@@ -17,6 +17,7 @@ declare var global: any;
 export interface TestEnvironmentConfig {
   userConfig?: AppUserConfig;
   initOptions?: any;
+  initUserAndPushSubscription?: boolean;   // default: false - initializes User & PushSubscription in UserNamespace (e.g. creates an anonymous user)
   environment?: string;
   permission?: NotificationPermission;
   addPrompts?: boolean;

--- a/__test__/support/environment/TestEnvironmentHelpers.ts
+++ b/__test__/support/environment/TestEnvironmentHelpers.ts
@@ -14,6 +14,9 @@ import TestContext from "./TestContext";
 import { CoreModuleDirector } from "../../../src/core/CoreModuleDirector";
 import CoreModule from "../../../src/core/CoreModule";
 import Context from "../../../src/page/models/Context";
+import NotificationsNamespace from "../../../src/onesignal/NotificationsNamespace";
+import UserNamespace from "../../../src/onesignal/UserNamespace";
+import { ONESIGNAL_EVENTS } from "../../../src/onesignal/OneSignalEvents";
 
 declare const global: any;
 
@@ -25,6 +28,7 @@ export function resetDatabase() {
 
 export async function initOSGlobals(config: TestEnvironmentConfig = {}) {
   global.OneSignal = OneSignal;
+  global.OneSignal.EVENTS = ONESIGNAL_EVENTS;
   global.OneSignal.config = TestContext.getFakeMergedConfig(config);
   global.OneSignal.context = new Context(global.OneSignal.config);
   global.OneSignal.initialized = true;
@@ -32,6 +36,8 @@ export async function initOSGlobals(config: TestEnvironmentConfig = {}) {
   const core = new CoreModule();
   await core.init();
   global.OneSignal.coreDirector = new CoreModuleDirector(core);
+  global.OneSignal.User = new UserNamespace(!!config.initUserAndPushSubscription); // TO DO: pass in subscription, and permission
+  global.OneSignal.Notifications = new NotificationsNamespace(config.permission);
 
   return global.OneSignal;
 }

--- a/__test__/unit/pushSubscription/helpers.ts
+++ b/__test__/unit/pushSubscription/helpers.ts
@@ -1,0 +1,20 @@
+import { OSModel } from "../../../src/core/modelRepo/OSModel";
+import { ModelName, SupportedModel } from "../../../src/core/models/SupportedModels";
+import { getDummyPushSubscriptionOSModel } from "../../support/helpers/core";
+import { TestEnvironment } from "../../support/environment/TestEnvironment";
+
+export async function initializeWithPermission(permission: NotificationPermission) {
+  const mockNotification = {
+    permission,
+    requestPermission: jest.fn(),
+  };
+  // @ts-ignore
+  global.Notification = mockNotification;
+
+  await TestEnvironment.initialize({
+    permission,
+  });
+
+  const pushModel = getDummyPushSubscriptionOSModel();
+  OneSignal.coreDirector.add(ModelName.PushSubscriptions, pushModel as OSModel<SupportedModel>, false);
+}

--- a/__test__/unit/pushSubscription/nativePermissionChange.test.ts
+++ b/__test__/unit/pushSubscription/nativePermissionChange.test.ts
@@ -1,0 +1,61 @@
+import MainHelper from "../../../src/shared/helpers/MainHelper";
+import ModelCache from "../../../src/core/caching/ModelCache";
+import { OSModel } from '../../../src/core/modelRepo/OSModel'
+import PermissionManager from "../../../src/shared/managers/PermissionManager";
+import EventHelper from "../../../src/shared/helpers/EventHelper";
+import { SubscriptionManager } from "../../../src/shared/managers/SubscriptionManager";
+import { DUMMY_PUSH_TOKEN } from "../../support/constants";
+import { initializeWithPermission } from "./helpers";
+
+describe('Notification Types are set correctly on subscription change', () => {
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    test.stub(ModelCache.prototype, 'load', Promise.resolve({}));
+    test.stub(SubscriptionManager, 'isSafari', false)
+    test.stub(MainHelper, 'getCurrentPushToken', DUMMY_PUSH_TOKEN);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('When native permission is rejected, we update notification_types to -2 & enabled to false', async () => {
+    await initializeWithPermission('granted');
+    test.stub(PermissionManager.prototype, 'getNotificationPermission', Promise.resolve('denied'));
+    const osModelSetSpy = jest.spyOn(OSModel.prototype, 'set');
+
+    const permissionChangeEventFiredPromise = new Promise(resolve => {
+      OneSignal.emitter.on(OneSignal.EVENTS.NATIVE_PROMPT_PERMISSIONCHANGED, resolve);
+    });
+
+    // mimick native permission change
+    await MainHelper.checkAndTriggerNotificationPermissionChanged();
+    await EventHelper.checkAndTriggerSubscriptionChanged();
+
+    await permissionChangeEventFiredPromise;
+
+    // check that the set function was called at least once with the correct value
+    expect(osModelSetSpy).toHaveBeenCalledWith('notification_types', -2);
+    expect(osModelSetSpy).toHaveBeenCalledWith('enabled', false);
+  });
+
+  test('When native permission is accepted, we update notification_types to 1 & enabled to true', async () => {
+    await initializeWithPermission('denied');
+    test.stub(PermissionManager.prototype, 'getNotificationPermission', Promise.resolve('granted'));
+    const osModelSetSpy = jest.spyOn(OSModel.prototype, 'set');
+
+    const permissionChangeEventFiredPromise = new Promise(resolve => {
+      OneSignal.emitter.on(OneSignal.EVENTS.NATIVE_PROMPT_PERMISSIONCHANGED, resolve);
+    });
+
+    // mimick native permission change
+    await MainHelper.checkAndTriggerNotificationPermissionChanged();
+    await EventHelper.checkAndTriggerSubscriptionChanged();
+
+    await permissionChangeEventFiredPromise;
+
+    // check that the set function was called at least once with the correct value
+    expect(osModelSetSpy).toHaveBeenCalledWith('notification_types', 1);
+    expect(osModelSetSpy).toHaveBeenCalledWith('enabled', true);
+  });
+});

--- a/src/page/modules/frames/ProxyFrame.ts
+++ b/src/page/modules/frames/ProxyFrame.ts
@@ -249,8 +249,6 @@ export default class ProxyFrame extends RemoteFrame {
   }
 
   async onProcessExpiringSubscriptions(message: MessengerMessageEvent) {
-    const context: Context = OneSignal.context;
-    const result = await InitHelper.processExpiringSubscriptions();
     message.reply(OneSignal.POSTMAM_COMMANDS.REMOTE_OPERATION_COMPLETE);
     return false;
   }

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -25,7 +25,6 @@ export default class EventHelper {
   static async checkAndTriggerSubscriptionChanged() {
     OneSignalUtils.logMethodCall('checkAndTriggerSubscriptionChanged');
     const context: ContextSWInterface = OneSignal.context;
-    const subscriptionState = await context.subscriptionManager.getSubscriptionState();
     // isPushEnabled = subscribed && is not opted out
     const isPushEnabled: boolean = await OneSignal.context.subscriptionManager.isPushNotificationsEnabled();
     // isOptedIn = native permission granted && is not opted out
@@ -42,10 +41,10 @@ export default class EventHelper {
     }
     Log.info(
       `The user's subscription state changed from ` +
-        `${lastKnownPushEnabled === null ? '(not stored)' : lastKnownPushEnabled} ⟶ ${subscriptionState.subscribed}`
+        `${lastKnownPushEnabled === null ? '(not stored)' : lastKnownPushEnabled} ⟶ ${isPushEnabled}`
     );
     // update notification_types via core module
-    const newNotificationTypes = subscriptionState.optedOut ? -2 : 1;
+    const newNotificationTypes = isOptedIn ? 1 : -2;
     await context.subscriptionManager.updatePushSubscriptionNotificationTypes(newNotificationTypes);
 
     const currentPushToken = await MainHelper.getCurrentPushToken();

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -34,8 +34,8 @@ import OneSignalError from "../errors/OneSignalError";
 import { SessionOrigin } from "../models/Session";
 import { executeCallback, logMethodCall } from "../utils/utils";
 import UserDirector from "../../onesignal/UserDirector";
-import { OSModel } from "src/core/modelRepo/OSModel";
-import { isCompleteSubscriptionObject } from "src/core/utils/typePredicates";
+import { OSModel } from "../../core/modelRepo/OSModel";
+import { isCompleteSubscriptionObject } from "../../core/utils/typePredicates";
 
 export interface SubscriptionManagerConfig {
   safariWebId?: string;

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -28,12 +28,14 @@ import Log from "../libraries/Log";
 import { RawPushSubscription } from "../models/RawPushSubscription";
 import OneSignalApiShared from "../api/OneSignalApiShared";
 import FuturePushSubscriptionRecord from "../../page/userModel/FuturePushSubscriptionRecord";
-import { FutureSubscriptionModel } from "../../core/models/SubscriptionModels";
+import { FutureSubscriptionModel, SupportedSubscription } from "../../core/models/SubscriptionModels";
 import { StringKeys } from "../../core/models/StringKeys";
 import OneSignalError from "../errors/OneSignalError";
 import { SessionOrigin } from "../models/Session";
 import { executeCallback, logMethodCall } from "../utils/utils";
 import UserDirector from "../../onesignal/UserDirector";
+import { OSModel } from "src/core/modelRepo/OSModel";
+import { isCompleteSubscriptionObject } from "src/core/utils/typePredicates";
 
 export interface SubscriptionManagerConfig {
   safariWebId?: string;
@@ -789,14 +791,19 @@ export class SubscriptionManager {
   }
 
   private async getSubscriptionStateForSecure(): Promise<PushSubscriptionState> {
-    const { optedOut } = await Database.getSubscription();
+    const { optedOut, subscriptionToken } = await Database.getSubscription();
+
+    const pushSubscriptionOSModel: OSModel<SupportedSubscription> = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
+    const isValidPushSubscription = isCompleteSubscriptionObject(pushSubscriptionOSModel) && !!pushSubscriptionOSModel.onesignalId;
 
     if (SubscriptionManager.isSafari()) {
-      const subscriptionState: SafariRemoteNotificationPermission =
-        window.safari.pushNotification.permission(this.config.safariWebId);
+      const subscriptionState: SafariRemoteNotificationPermission | undefined =
+        window.safari?.pushNotification?.permission(this.config.safariWebId);
       const isSubscribedToSafari = !!(
-        subscriptionState.permission === "granted" &&
-        subscriptionState.deviceToken
+        isValidPushSubscription &&
+        subscriptionToken &&
+        subscriptionState?.permission === "granted" &&
+        subscriptionState?.deviceToken
       );
 
       return {
@@ -833,6 +840,8 @@ export class SubscriptionManager {
      */
 
     const isPushEnabled = !!(
+      isValidPushSubscription &&
+      subscriptionToken &&
       notificationPermission === NotificationPermission.Granted &&
       isWorkerActive
     );

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -789,15 +789,14 @@ export class SubscriptionManager {
   }
 
   private async getSubscriptionStateForSecure(): Promise<PushSubscriptionState> {
-    const { deviceId, optedOut } = await Database.getSubscription();
+    const { optedOut } = await Database.getSubscription();
 
     if (SubscriptionManager.isSafari()) {
       const subscriptionState: SafariRemoteNotificationPermission =
         window.safari.pushNotification.permission(this.config.safariWebId);
       const isSubscribedToSafari = !!(
         subscriptionState.permission === "granted" &&
-        subscriptionState.deviceToken &&
-        deviceId
+        subscriptionState.deviceToken
       );
 
       return {
@@ -834,7 +833,6 @@ export class SubscriptionManager {
      */
 
     const isPushEnabled = !!(
-      deviceId &&
       notificationPermission === NotificationPermission.Granted &&
       isWorkerActive
     );


### PR DESCRIPTION
# 1-line Summary:
Fallback to `lastKnownPushToken` for push subscription, optimize `notification_types` setting, and add test coverage.

# Overview:
This PR improves the handling of push subscriptions by falling back to the `lastKnownPushToken` when getting the current push subscription model. It also optimizes the setting of `notification_types` using the `isOptedIn` property, removing the need to get the subscription state again. Additionally, test coverage has been added to ensure the push subscription models are updated correctly when the native permission changes.

# Details:
- Fallback to `lastKnownPushToken` when getting current push subscription model to handle cases when the function fires after revoking the native permission
- Use `isOptedIn` to set `notification_types`, removing the need to get the subscription state again
- Remove unused vars (nits)
- Remove deviceId (player id) usage under user model (nits)
- Update `TestEnvironmentHelper` with more OneSignal globals needed for testing


# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
- Add test coverage to ensure push subscription models are updated correctly when the native permission changes

### Info
New tests were tested without the changes and failed (good).

Had to also update the TestEnvironment since it was missing static properties like `EVENTS` and `NotificationsNamespace` needed for this test.

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1029)
<!-- Reviewable:end -->
