### PR TITLE
Upgrade database version number

### DIFF
--- a/src/shared/services/IndexedDb.ts
+++ b/src/shared/services/IndexedDb.ts
@@ -4,7 +4,7 @@ import Utils from '../context/Utils';
 import Emitter from '../libraries/Emitter';
 import Log from '../libraries/Log';
 
-const DATABASE_VERSION = 3;
+const DATABASE_VERSION = 4;
 
 export default class IndexedDb {
 
@@ -122,6 +122,9 @@ export default class IndexedDb {
       db.createObjectStore(ModelName.PushSubscriptions, { keyPath: "modelId" });
       db.createObjectStore(ModelName.SmsSubscriptions, { keyPath: "modelId" });
       db.createObjectStore(ModelName.EmailSubscriptions, { keyPath: "modelId" });
+    }
+    if (event.oldVersion < 5) {
+      // Make sure to update the database version at the top of the file
     }
     // Wrap in conditional for tests
     if (typeof OneSignal !== "undefined") {


### PR DESCRIPTION
Motivation: is breaking the migration path since we can't access the model cache models (identity, pushSubscription, etc...)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1030)
<!-- Reviewable:end -->
