### PR TITLE
User model/rename sw file

### DIFF
--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -26,8 +26,6 @@
     OneSignalDeferred.push(async function(onesignal) {
       await onesignal.init({
           appId,
-          serviceWorkerParam: { scope: "/" + SERVICE_WORKER_PATH },
-          serviceWorkerPath: SERVICE_WORKER_PATH + "OneSignalSDK.sw.js",
           notifyButton: {
               enable: true
           },

--- a/src/shared/helpers/ConfigHelper.ts
+++ b/src/shared/helpers/ConfigHelper.ts
@@ -480,7 +480,7 @@ export class ConfigHelper {
           Except injecting some default values for prompts.
         */
         const defaultServiceWorkerParam = { scope: '/' };
-        const defaultServiceWorkerPath = 'OneSignalSDK.sw.js';
+        const defaultServiceWorkerPath = 'OneSignalSDKWorker.js';
 
         const config = {
           ...userConfig,

--- a/src/shared/helpers/ContextHelper.ts
+++ b/src/shared/helpers/ContextHelper.ts
@@ -1,6 +1,5 @@
 import { ServiceWorkerManager } from '../managers/ServiceWorkerManager';
 import { SubscriptionManager, SubscriptionManagerConfig } from '../managers/SubscriptionManager';
-import SdkEnvironment from '../managers/SdkEnvironment';
 import { ContextSWInterface } from "../models/ContextSW";
 import { AppConfig } from '../models/AppConfig';
 import Path from '../models/Path';
@@ -9,9 +8,8 @@ export class ContextHelper {
   public static getServiceWorkerManager(context: ContextSWInterface): ServiceWorkerManager {
     const config: AppConfig = context.appConfig;
 
-    const envPrefix = SdkEnvironment.getBuildEnvPrefix();
     const serviceWorkerManagerConfig = {
-      workerPath: new Path(`/${envPrefix}OneSignalSDK.sw.js`),
+      workerPath: new Path(`OneSignalSDKWorker.js`),
       registrationOptions: { scope: '/' }
     };
 

--- a/src/shared/helpers/ServiceWorkerHelper.ts
+++ b/src/shared/helpers/ServiceWorkerHelper.ts
@@ -248,11 +248,11 @@ export default class ServiceWorkerHelper {
 
 export enum ServiceWorkerActiveState {
   /**
-   * OneSignalSDK.sw.js, or the equivalent custom file name, is active.
+   * OneSignalSDKWorker.js, or the equivalent custom file name, is active.
    */
   OneSignalWorker = 'OneSignal Worker',
   /**
-   * A service worker is active, but it is not OneSignalSDK.sw.js
+   * A service worker is active, but it is not OneSignalSDKWorker.js
    * (or the equivalent custom file names as provided by user config).
    */
   ThirdParty = '3rd Party',
@@ -270,7 +270,7 @@ export enum ServiceWorkerActiveState {
 
 export interface ServiceWorkerManagerConfig {
   /**
-   * The path and filename of the "main" worker (e.g. '/OneSignalSDK.sw.js');
+   * The path and filename of the "main" worker (e.g. '/OneSignalSDKWorker.js');
    */
   workerPath: Path;
   /**

--- a/src/shared/libraries/WorkerMessenger.ts
+++ b/src/shared/libraries/WorkerMessenger.ts
@@ -147,7 +147,7 @@ export class WorkerMessenger {
   public async directPostMessageToSW(command: WorkerMessengerCommand, payload?: WorkerMessengerPayload): Promise<void> {
     Log.debug(`[Worker Messenger] [Page -> SW] Direct command '${command.toString()}' to service worker.`);
 
-    const workerRegistration = await this.context.serviceWorkerManager.getRegistration();
+    const workerRegistration = await this.context?.serviceWorkerManager.getRegistration();
     if (!workerRegistration) {
       Log.error("`[Worker Messenger] [Page -> SW] Could not get ServiceWorkerRegistration to postMessage!");
       return;

--- a/src/shared/managers/SdkEnvironment.ts
+++ b/src/shared/managers/SdkEnvironment.ts
@@ -243,7 +243,7 @@ export default class SdkEnvironment {
    * service worker.
    *
    * For example, in staging the registered service worker filename is
-   * Staging-OneSignalSDK.sw.js.
+   * Staging-OneSignalSDKWorker.js.
    */
   public static getBuildEnvPrefix(buildEnv: EnvironmentKind = SdkEnvironment.getBuildEnv()) : string {
     switch (buildEnv) {

--- a/src/shared/managers/ServiceWorkerManager.ts
+++ b/src/shared/managers/ServiceWorkerManager.ts
@@ -353,7 +353,7 @@ export class ServiceWorkerManager {
    * We have a couple different models of installing service workers:
    *
    * a) Originally, we provided users with two worker files:
-   * OneSignalSDK.sw.js and OneSignalSDKUpdaterWorker.js. Two workers were
+   * OneSignalSDKWorker.js and OneSignalSDKUpdaterWorker.js. Two workers were
    * provided so each could be swapped with the other when the worker needed to
    * update. The contents of both workers were identical; only the filenames
    * were different, which is enough to update the worker.
@@ -363,22 +363,22 @@ export class ServiceWorkerManager {
    * version as a query parameter. This is enough for the browser to detect a
    * change and re-install the worker.
    *
-   * b) With AMP web push, users specify the worker file OneSignalSDK.sw.js
+   * b) With AMP web push, users specify the worker file OneSignalSDKWorker.js
    * with an app ID parameter ?appId=12345. AMP web push
    * is vendor agnostic and doesn't know about OneSignal, so all relevant
    * information has to be passed to the service worker, which is the only
    * vendor-specific file.
    *
    * If AMP web push sees another worker like OneSignalSDKUpdaterWorker.js (deprecated), or
-   * even the same OneSignalSDK.sw.js without the app ID query parameter, the
+   * even the same OneSignalSDKWorker.js without the app ID query parameter, the
    * user is considered unsubscribed.
    *
    * c) Due to b's restriction, we must always install
-   * OneSignalSDK.sw.js?appId=xxx. We also have to appropriately handle the
+   * OneSignalSDKWorker.js?appId=xxx. We also have to appropriately handle the
    * legacy case:
    *
    *    c-1) Where developers running progressive web apps force-register
-   *    OneSignalSDK.sw.js
+   *    OneSignalSDKWorker.js
    *
    * Actually, users can customize the file names of the Service Worker but
    * it's up to them to be consistent with their naming. For AMP web push, users


### PR DESCRIPTION
# Switch Back to Original SDK Worker Filename

## Summary
This update includes multiple changes to the OneSignal SDK worker filename and registration scope. The changes aim to make it easier for customers to differentiate between service worker files, migrate to new versions, and avoid conflicts.

## Overview
The OneSignal SDK worker filename has been changed back to its original name. This change has been made to simplify the differentiation between OneSignal service worker files and those of other services. Additionally, it provides an easier migration path by simply updating the contents of the file to point to the OneSignal CDN script.

In addition, the `envPrefix` has been removed from the front of the worker path. This change was made as it doesn't make sense in this context.

Lastly, a fallback mechanism has been implemented to support users who may have used the previous OneSignalSDK.sw.js filename. This ensures that integrations are not broken by the change.

## Details
- Switched back to using the original SDK worker filename to differentiate between service worker files
- Removed `envPrefix` from the front of the worker path
- Implemented a fallback mechanism to support previous OneSignalSDK.sw.js filename users
- Removed SW config from init options

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1031)
<!-- Reviewable:end -->
