### PR TITLE
User model/fix subscription state predicates

### DIFF
--- a/src/core/utils/typePredicates.ts
+++ b/src/core/utils/typePredicates.ts
@@ -14,29 +14,29 @@ export function isModelDelta<Model>(delta: CoreDelta<Model>): delta is ModelDelt
 }
 
 export function isPureObject(obj: any): obj is Object {
-  return obj !== null && typeof obj === "object" && obj.constructor === Object;
+  return obj !== null && typeof obj === "object" && obj?.constructor === Object;
 }
 
 export function isOSModel<Model>(obj: any): obj is OSModel<Model> {
-  return obj !== null && typeof obj === "object" && obj.constructor === OSModel;
+  return obj !== null && typeof obj === "object" && obj?.constructor === OSModel;
 }
 
 export function isOSModelUpdatedArgs<Model>(obj: any): obj is OSModelUpdatedArgs<Model> {
-  return obj !== null && typeof obj === "object" && obj.constructor === OSModelUpdatedArgs;
+  return obj !== null && typeof obj === "object" && obj?.constructor === OSModelUpdatedArgs;
 }
 
 export function isModelStoreHydratedObject<Model>(obj: any): obj is ModelStoreHydrated<Model> {
-  return obj !== null && typeof obj === "object" && obj.constructor === ModelStoreHydrated;
+  return obj !== null && typeof obj === "object" && obj?.constructor === ModelStoreHydrated;
 }
 
 export function isIdentityObject(obj: any): obj is IdentityModel {
-  return obj.onesignal_id !== undefined;
+  return obj?.onesignal_id !== undefined;
 }
 
 export function isFutureSubscriptionObject(obj: any): obj is FutureSubscriptionModel {
-  return obj.type !== undefined;
+  return obj?.type !== undefined;
 }
 
 export function isCompleteSubscriptionObject(obj: any): obj is SubscriptionModel {
-  return obj.type !== undefined && obj.id !== undefined;
+  return obj?.type !== undefined && obj?.id !== undefined;
 }

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -793,8 +793,8 @@ export class SubscriptionManager {
   private async getSubscriptionStateForSecure(): Promise<PushSubscriptionState> {
     const { optedOut, subscriptionToken } = await Database.getSubscription();
 
-    const pushSubscriptionOSModel: OSModel<SupportedSubscription> = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
-    const isValidPushSubscription = isCompleteSubscriptionObject(pushSubscriptionOSModel) && !!pushSubscriptionOSModel.onesignalId;
+    const pushSubscriptionOSModel: OSModel<SupportedSubscription> | undefined = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
+    const isValidPushSubscription = isCompleteSubscriptionObject(pushSubscriptionOSModel?.data) && !!pushSubscriptionOSModel?.onesignalId;
 
     if (SubscriptionManager.isSafari()) {
       const subscriptionState: SafariRemoteNotificationPermission | undefined =


### PR DESCRIPTION
# Fix Type Predicates

## Summary
This update fixes issues with type predicates in the OneSignal code. It replaces <any> type with optional chaining to prevent the function from throwing if the passed object is undefined/null. Additionally, it corrects the bug with the `pushSubscriptionOSModel` var type and updates it to be able to accept undefined values.

## Overview
The update fixes type predicates in the OneSignal code to prevent the function from throwing if the passed object is undefined/null. This is achieved by using optional chaining since the type predicate accepts <any> type. If the passed in obj is null or undefined, the predicate returns the corresponding boolean value.

Moreover, the `pushSubscriptionOSModel` var type has been corrected to be able to accept undefined values. This update fixes the issue with the type predicate checking the model data instead of the OSModel instance. Additionally, the `pushSubscriptionOSModel` var type is set here since we're not importing the `OneSignal` class.

## Details
- Replaced <any> type with optional chaining to prevent the function from throwing if the passed object is undefined/null
- Updated the `pushSubscriptionOSModel` var type to be able to accept undefined values
- Corrected the issue with the type predicate checking the model data instead of the OSModel instance
- `pushSubscriptionOSModel` var type set here since we're not importing the `OneSignal` class

These updates were made by @rgomezp.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1032)
<!-- Reviewable:end -->
