### PR TITLE
[user model] Remove `getPermissionStatus` & add `permission` property

### DIFF
--- a/__test__/support/helpers/pushSubscription.ts
+++ b/__test__/support/helpers/pushSubscription.ts
@@ -1,7 +1,7 @@
 import { OSModel } from "../../../src/core/modelRepo/OSModel";
 import { ModelName, SupportedModel } from "../../../src/core/models/SupportedModels";
-import { getDummyPushSubscriptionOSModel } from "../../support/helpers/core";
-import { TestEnvironment } from "../../support/environment/TestEnvironment";
+import { getDummyPushSubscriptionOSModel } from "./core";
+import { TestEnvironment } from "../environment/TestEnvironment";
 
 export async function initializeWithPermission(permission: NotificationPermission) {
   const mockNotification = {

--- a/__test__/unit/notifications/permission.test.ts
+++ b/__test__/unit/notifications/permission.test.ts
@@ -1,0 +1,62 @@
+import ModelCache from "../../../src/core/caching/ModelCache";
+import PermissionManager from "../../../src/shared/managers/PermissionManager";
+import { SubscriptionManager } from "../../../src/shared/managers/SubscriptionManager";
+import { PermissionUtils } from "../../../src/shared/utils/PermissionUtils";
+import { NotificationPermission } from "../../../src/shared/models/NotificationPermission";
+import { TestEnvironment } from "../../support/environment/TestEnvironment";
+
+describe('Notifications namespace permission properties', () => {
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    test.stub(ModelCache.prototype, 'load', Promise.resolve({}));
+    test.stub(SubscriptionManager, 'isSafari', false)
+    TestEnvironment.initialize();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+
+  test('When permission changes to granted, we update the permission properties on the Notifications namespace', async () => {
+    test.stub(PermissionManager.prototype, 'getPermissionStatus', Promise.resolve(NotificationPermission.Granted));
+    const permissionChangeEventFiredPromise = new Promise(resolve => {
+      OneSignal.emitter.on(OneSignal.EVENTS.NATIVE_PROMPT_PERMISSIONCHANGED, resolve);
+    });
+
+    // mimick native permission change
+    PermissionUtils.triggerNotificationPermissionChanged();
+
+    await permissionChangeEventFiredPromise
+    expect(OneSignal.Notifications.permission).toBe(true);
+    expect(OneSignal.Notifications.permissionNative).toBe(NotificationPermission.Granted);
+  });
+
+  test('When permission changes to default, we update the permission properties on the Notifications namespace', async () => {
+    test.stub(PermissionManager.prototype, 'getPermissionStatus', Promise.resolve(NotificationPermission.Default));
+    const permissionChangeEventFiredPromise = new Promise(resolve => {
+      OneSignal.emitter.on(OneSignal.EVENTS.NATIVE_PROMPT_PERMISSIONCHANGED, resolve);
+    });
+
+    // mimick native permission change
+    PermissionUtils.triggerNotificationPermissionChanged();
+
+    await permissionChangeEventFiredPromise
+    expect(OneSignal.Notifications.permission).toBe(false);
+    expect(OneSignal.Notifications.permissionNative).toBe(NotificationPermission.Default);
+  });
+
+  test('When permission changes to denied, we update the permission properties on the Notifications namespace', async () => {
+    test.stub(PermissionManager.prototype, 'getPermissionStatus', Promise.resolve(NotificationPermission.Denied));
+    const permissionChangeEventFiredPromise = new Promise(resolve => {
+      OneSignal.emitter.on(OneSignal.EVENTS.NATIVE_PROMPT_PERMISSIONCHANGED, resolve);
+    });
+
+    // mimick native permission change
+    PermissionUtils.triggerNotificationPermissionChanged();
+
+    await permissionChangeEventFiredPromise
+    expect(OneSignal.Notifications.permission).toBe(false);
+    expect(OneSignal.Notifications.permissionNative).toBe(NotificationPermission.Denied);
+  });
+});

--- a/__test__/unit/pushSubscription/nativePermissionChange.test.ts
+++ b/__test__/unit/pushSubscription/nativePermissionChange.test.ts
@@ -5,7 +5,7 @@ import PermissionManager from "../../../src/shared/managers/PermissionManager";
 import EventHelper from "../../../src/shared/helpers/EventHelper";
 import { SubscriptionManager } from "../../../src/shared/managers/SubscriptionManager";
 import { DUMMY_PUSH_TOKEN } from "../../support/constants";
-import { initializeWithPermission } from "./helpers";
+import { initializeWithPermission } from "../../support/helpers/pushSubscription";
 
 describe('Notification Types are set correctly on subscription change', () => {
   beforeEach(async () => {

--- a/api.json
+++ b/api.json
@@ -95,18 +95,6 @@
         "returnType": "boolean"
       },
       {
-        "name": "getPermissionStatus",
-        "isAsync": true,
-        "args": [
-          {
-            "name": "onComplete",
-            "type": "Action<NotificationPermission>",
-            "optional": false
-          }
-        ],
-        "returnType": "Promise<NotificationPermission>"
-      },
-      {
         "name": "requestPermission",
         "isAsync": true,
         "args":[],
@@ -152,7 +140,11 @@
     "properties": [
       {
         "name": "permissionNative",
-        "type": "'granted' | 'denied' | 'default'"
+        "type": "NotificationPermission"
+      },
+      {
+        "name": "permission",
+        "type": "boolean | undefined"
       }
     ]
   },

--- a/api.json
+++ b/api.json
@@ -144,7 +144,7 @@
       },
       {
         "name": "permission",
-        "type": "boolean | undefined"
+        "type": "boolean"
       }
     ]
   },

--- a/src/onesignal/NotificationsNamespace.ts
+++ b/src/onesignal/NotificationsNamespace.ts
@@ -5,9 +5,8 @@ import { awaitOneSignalInitAndSupported, logMethodCall } from "../shared/utils/u
 import OneSignal from "./OneSignal";
 import { EventListenerBase } from "../page/userModel/EventListenerBase";
 import NotificationEventName from "../page/models/NotificationEventName";
-import { NotificationClickResult, NotificationForegroundWillDisplayEvent } from "../page/models/NotificationEvent";
 import { NotificationPermission } from "../shared/models/NotificationPermission";
-import NotificationEventTypeMap from "src/page/models/NotificationEventTypeMap";
+import NotificationEventTypeMap from "../page/models/NotificationEventTypeMap";
 
 export default class NotificationsNamespace extends EventListenerBase {
   private _permission: boolean;

--- a/src/onesignal/NotificationsNamespace.ts
+++ b/src/onesignal/NotificationsNamespace.ts
@@ -2,23 +2,32 @@ import { ValidatorUtils } from "../page/utils/ValidatorUtils";
 import { InvalidArgumentError, InvalidArgumentReason } from "../shared/errors/InvalidArgumentError";
 import Database from "../shared/services/Database";
 import { awaitOneSignalInitAndSupported, logMethodCall } from "../shared/utils/utils";
-import OneSignalError from "../../src/shared/errors/OneSignalError";
 import OneSignal from "./OneSignal";
 import { EventListenerBase } from "../page/userModel/EventListenerBase";
 import NotificationEventName from "../page/models/NotificationEventName";
 import { NotificationClickResult, NotificationForegroundWillDisplayEvent } from "../page/models/NotificationEvent";
+import { NotificationPermission } from "../shared/models/NotificationPermission";
 
 export default class NotificationsNamespace extends EventListenerBase {
+  private _permission?: boolean;
+
   constructor(private _permissionNative?: NotificationPermission) {
     super();
 
-    OneSignal.emitter.on(OneSignal.EVENTS.NATIVE_PROMPT_PERMISSIONCHANGED, (permission: NotificationPermission) => {
-      this._permissionNative = permission;
+    this._permission = _permissionNative === NotificationPermission.Granted;
+
+    OneSignal.emitter.on(OneSignal.EVENTS.NATIVE_PROMPT_PERMISSIONCHANGED, (permissionNative: NotificationPermission) => {
+      this._permissionNative = permissionNative;
+      this._permission = permissionNative === NotificationPermission.Granted;
     });
   }
 
   get permissionNative(): NotificationPermission | undefined {
     return this._permissionNative;
+  }
+
+  get permission(): boolean | undefined {
+    return this._permission;
   }
 
   /**
@@ -109,29 +118,6 @@ export default class NotificationsNamespace extends EventListenerBase {
     }
   }
   */
-
-  /**
-   * Returns a promise that resolves to the browser's current notification permission as
-   *    'default', 'granted', or 'denied'.
-   * @param callback A callback function that will be called when the browser's current notification permission
-   *           has been obtained, with one of 'default', 'granted', or 'denied'.
-   * @PublicApi
-   */
-  async getPermissionStatus(onComplete?: Action<NotificationPermission>): Promise<NotificationPermission> {
-    if (!OneSignal.context) {
-      throw new OneSignalError(`OneSignal.context is undefined. Make sure to call OneSignal.init() before calling getPermissionStatus().`);
-    }
-
-    const permission = await OneSignal.context.permissionManager.getNotificationPermission(
-        OneSignal.config!.safariWebId
-      );
-
-    if (onComplete) {
-      onComplete(permission);
-    }
-
-    return permission;
-  }
 
   /**
    * Shows a native browser prompt.

--- a/src/onesignal/NotificationsNamespace.ts
+++ b/src/onesignal/NotificationsNamespace.ts
@@ -9,7 +9,7 @@ import { NotificationClickResult, NotificationForegroundWillDisplayEvent } from 
 import { NotificationPermission } from "../shared/models/NotificationPermission";
 
 export default class NotificationsNamespace extends EventListenerBase {
-  private _permission?: boolean;
+  private _permission: boolean;
 
   constructor(private _permissionNative?: NotificationPermission) {
     super();

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -52,7 +52,7 @@ export default class OneSignal {
     await core.initPromise;
     OneSignal.coreDirector = new CoreModuleDirector(core);
     const subscription = await Database.getSubscription();
-    const permission = await OneSignal.Notifications.getPermissionStatus();
+    const permission = await OneSignal.context.permissionManager.getPermissionStatus();
     OneSignal.User = new UserNamespace(true, subscription, permission);
     this.Notifications = new NotificationsNamespace(permission);
   }

--- a/src/onesignal/PushSubscriptionNamespace.ts
+++ b/src/onesignal/PushSubscriptionNamespace.ts
@@ -70,7 +70,7 @@ export default class PushSubscriptionNamespace extends EventListenerBase {
     await awaitOneSignalInitAndSupported();
     this._optedIn = true;
 
-    const permissionStatus = await OneSignal.Notifications.getPermissionStatus();
+    const permissionStatus = await OneSignal.context.permissionManager.getPermissionStatus();
 
     if (permissionStatus !== 'granted') {
       // TO DO: use user-config options prompting method

--- a/src/page/bell/Bell.ts
+++ b/src/page/bell/Bell.ts
@@ -294,7 +294,7 @@ export default class Bell {
         }
       }
 
-      OneSignal.Notifications.getPermissionStatus((permission: NotificationPermission) => {
+      OneSignal.context.permissionManager.getPermissionStatus((permission: NotificationPermission) => {
         let bellState: BellState;
         if (isSubscribed.current.optedIn) {
           bellState = Bell.STATES.SUBSCRIBED;
@@ -572,7 +572,7 @@ export default class Bell {
   updateState() {
     Promise.all([
       OneSignal.context.subscriptionManager.isPushNotificationsEnabled(),
-      OneSignal.Notifications.getPermissionStatus()
+      OneSignal.context.permissionManager.getPermissionStatus()
     ])
     .then(([isEnabled, permission]) => {
       this.setState(isEnabled ? Bell.STATES.SUBSCRIBED : Bell.STATES.UNSUBSCRIBED);

--- a/src/page/managers/slidedownManager/SlidedownManager.ts
+++ b/src/page/managers/slidedownManager/SlidedownManager.ts
@@ -43,7 +43,7 @@ export class SlidedownManager {
   /* P R I V A T E */
 
   private async checkIfSlidedownShouldBeShown(options: AutoPromptOptions): Promise<boolean> {
-    const permissionDenied = await OneSignal.Notifications.getPermissionStatus() === NotificationPermission.Denied;
+    const permissionDenied = await OneSignal.context.permissionManager.getPermissionStatus() === NotificationPermission.Denied;
     let wasDismissed: boolean;
 
     const subscriptionInfo: PushSubscriptionState = await OneSignal.context.subscriptionManager.getSubscriptionState();

--- a/src/page/modules/frames/SubscriptionModalHost.ts
+++ b/src/page/modules/frames/SubscriptionModalHost.ts
@@ -36,7 +36,7 @@ export default class SubscriptionModalHost implements Disposable {
    */
   async load(): Promise<void> {
     const isPushEnabled = await OneSignal.context.subscriptionManager.isPushNotificationsEnabled();
-    const notificationPermission = await OneSignal.Notifications.getPermissionStatus();
+    const notificationPermission = await OneSignal.context.permissionManager.getPermissionStatus();
     this.url = SdkEnvironment.getOneSignalApiUrl();
     this.url.pathname = 'webPushModal';
     this.url.search = `${MainHelper.getPromptOptionsQueryString()}&id=${this.appId}&httpsPrompt=true&pushEnabled=${isPushEnabled}&permissionBlocked=${(notificationPermission as any) === 'denied'}&promptType=modal`;

--- a/src/shared/helpers/InitHelper.ts
+++ b/src/shared/helpers/InitHelper.ts
@@ -210,7 +210,7 @@ export default class InitHelper {
 
   public static async storeInitialValues() {
     const isPushEnabled = await OneSignal.context.subscriptionManager.isPushNotificationsEnabled();
-    const notificationPermission = await OneSignal.Notifications.getPermissionStatus();
+    const notificationPermission = await OneSignal.context.permissionManager.getPermissionStatus();
     const isOptedOut = await OneSignal.context.subscriptionManager.isOptedOut();
     LimitStore.put('subscription.optedOut', isOptedOut);
     await Database.put('Options', { key: 'isPushEnabled', value: isPushEnabled });

--- a/src/shared/helpers/MainHelper.ts
+++ b/src/shared/helpers/MainHelper.ts
@@ -72,7 +72,7 @@ export default class MainHelper {
 
   static async checkAndTriggerNotificationPermissionChanged() {
     const previousPermission = await Database.get('Options', 'notificationPermission');
-    const currentPermission = await OneSignal.Notifications.getPermissionStatus();
+    const currentPermission = await OneSignal.context.permissionManager.getPermissionStatus();
     if (previousPermission !== currentPermission) {
       await PermissionUtils.triggerNotificationPermissionChanged();
       await Database.put('Options', {

--- a/src/shared/managers/PermissionManager.ts
+++ b/src/shared/managers/PermissionManager.ts
@@ -22,17 +22,17 @@ export default class PermissionManager {
    * @param callback A callback function that will be called when the browser's current notification permission
    *           has been obtained, with one of 'default', 'granted', or 'denied'.
    */
-     async getPermissionStatus(): Promise<NotificationPermission> {
-      if (!OneSignal.context) {
-        throw new OneSignalError(`OneSignal.context is undefined. Make sure to call OneSignal.init() before calling getPermissionStatus().`);
-      }
-
-      const permission = await OneSignal.context.permissionManager.getNotificationPermission(
-          OneSignal.config!.safariWebId
-        );
-
-      return permission;
+  async getPermissionStatus(): Promise<NotificationPermission> {
+    if (!OneSignal.context) {
+      throw new OneSignalError(`OneSignal.context is undefined. Make sure to call OneSignal.init() before calling getPermissionStatus().`);
     }
+
+    const permission = await OneSignal.context.permissionManager.getNotificationPermission(
+        OneSignal.config!.safariWebId
+      );
+
+    return permission;
+  }
 
   /**
    * Returns an interpreted version of the browser's notification permission.

--- a/src/shared/managers/PermissionManager.ts
+++ b/src/shared/managers/PermissionManager.ts
@@ -15,6 +15,29 @@ export default class PermissionManager {
     return 'storedNotificationPermission';
   }
 
+    /**
+   * Returns a promise that resolves to the browser's current notification permission as
+   *    'default', 'granted', or 'denied'.
+   * @param callback A callback function that will be called when the browser's current notification permission
+   *           has been obtained, with one of 'default', 'granted', or 'denied'.
+   * @PublicApi
+   */
+     async getPermissionStatus(onComplete?: Action<NotificationPermission>): Promise<NotificationPermission> {
+      if (!OneSignal.context) {
+        throw new OneSignalError(`OneSignal.context is undefined. Make sure to call OneSignal.init() before calling getPermissionStatus().`);
+      }
+  
+      const permission = await OneSignal.context.permissionManager.getNotificationPermission(
+          OneSignal.config!.safariWebId
+        );
+  
+      if (onComplete) {
+        onComplete(permission);
+      }
+  
+      return permission;
+    }
+
   /**
    * Returns an interpreted version of the browser's notification permission.
    *

--- a/src/shared/managers/PermissionManager.ts
+++ b/src/shared/managers/PermissionManager.ts
@@ -4,6 +4,7 @@ import { InvalidArgumentError, InvalidArgumentReason } from '../errors/InvalidAr
 import { NotificationPermission } from '../models/NotificationPermission';
 import SdkEnvironment from './SdkEnvironment';
 import LocalStorage from '../utils/LocalStorage';
+import OneSignalError from '../errors/OneSignalError';
 
 /**
  * A permission manager to consolidate the different quirks of obtaining and evaluating permissions
@@ -20,21 +21,16 @@ export default class PermissionManager {
    *    'default', 'granted', or 'denied'.
    * @param callback A callback function that will be called when the browser's current notification permission
    *           has been obtained, with one of 'default', 'granted', or 'denied'.
-   * @PublicApi
    */
-     async getPermissionStatus(onComplete?: Action<NotificationPermission>): Promise<NotificationPermission> {
+     async getPermissionStatus(): Promise<NotificationPermission> {
       if (!OneSignal.context) {
         throw new OneSignalError(`OneSignal.context is undefined. Make sure to call OneSignal.init() before calling getPermissionStatus().`);
       }
-  
+
       const permission = await OneSignal.context.permissionManager.getNotificationPermission(
           OneSignal.config!.safariWebId
         );
-  
-      if (onComplete) {
-        onComplete(permission);
-      }
-  
+
       return permission;
     }
 

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -85,7 +85,7 @@ export class SubscriptionManager {
    */
   async isOptedIn(): Promise<boolean> {
     const subscriptionState = await this.getSubscriptionState();
-    const permission = await OneSignal.Notifications.getPermissionStatus();
+    const permission = await OneSignal.context.permissionManager.getPermissionStatus();
     return permission === 'granted' && !subscriptionState.optedOut;
   }
 
@@ -140,7 +140,7 @@ export class SubscriptionManager {
           Subscribing is only possible on the top-level frame, so there's no permission ambiguity
           here.
         */
-        if ((await OneSignal.Notifications.getPermissionStatus()) === NotificationPermission.Denied)
+        if ((await OneSignal.context.permissionManager.getPermissionStatus()) === NotificationPermission.Denied)
           throw new PushPermissionNotGrantedError(PushPermissionNotGrantedErrorReason.Blocked);
 
         if (SubscriptionManager.isSafari()) {

--- a/src/shared/utils/PermissionUtils.ts
+++ b/src/shared/utils/PermissionUtils.ts
@@ -3,7 +3,7 @@ import OneSignalEvent from '../services/OneSignalEvent';
 
 export class PermissionUtils {
   public static async triggerNotificationPermissionChanged(updateIfIdentical = false) {
-    const newPermission: NotificationPermission = await OneSignal.Notifications.getPermissionStatus();
+    const newPermission: NotificationPermission = await OneSignal.context.permissionManager.getPermissionStatus();
     const previousPermission: NotificationPermission = await Database.get('Options', 'notificationPermission');
 
     const shouldBeUpdated = newPermission !== previousPermission || updateIfIdentical;


### PR DESCRIPTION
## Summary
This PR updates the SDK by removing the `getPermissionStatus()` function, adding a `permission` property, moving functions to the `PermissionManager`, renaming and moving files to improve organization, and adding test coverage for proper functionality.

## Overview
This PR makes several updates to the SDK to improve organization and functionality. The `getPermissionStatus()` function has been removed, and a `permission` property has been added for clearer and more concise permission status checks. The `getPermissionStatus()` function has been moved to the `PermissionManager` to avoid cluttering the SDK with redundant functions. The `helpers.ts` file has been renamed and moved to a `helpers` directory for better organization, and test coverage has been added to ensure proper functionality of the SDK.

## Details
- Remove `getPermissionStatus()` function and add `permission` property to SDK. The `getPermissionStatus()` function was redundant and not in line with other SDKs, and adding the `permission` property provides a clearer way to check the permission status.
- Move `getPermissionStatus()` to `PermissionManager`. This is done to better organize the code and avoid cluttering the SDK with redundant functions.
- Update `getPermissionStatus()` function and fix usages throughout SDK. This is done to ensure that the SDK is compatible with other SDKs and to avoid breaking existing usage.
- Rename `helpers.ts` and move to `helpers` directory. This is done to better organize the code and avoid cluttering the root directory with helper files.
- Add test coverage. This is done to ensure proper functionality of the SDK and to catch any potential bugs or issues that may arise when the native permission fires.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1035)
<!-- Reviewable:end -->
