### PR TITLE
[user model] Bugfix: jwtToken argument to login function is optional, shouldn't throw

### DIFF
--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -105,8 +105,8 @@ export default class OneSignal {
       throw new InvalidArgumentError('externalId', InvalidArgumentReason.WrongType);
     }
 
-    if (typeof jwtToken !== 'string') {
-      throw new InvalidArgumentError('token', InvalidArgumentReason.WrongType);
+    if (jwtToken !== undefined && typeof jwtToken !== 'string') {
+      throw new InvalidArgumentError('jwtToken', InvalidArgumentReason.WrongType);
     }
 
     LoginManager.login(externalId, jwtToken);


### PR DESCRIPTION
Fix bug causing throw if `jwtToken` is omitted

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1036)
<!-- Reviewable:end -->
