### PR TITLE
User model/fix bowser

### DIFF
--- a/__test__/support/environment/TestEnvironment.ts
+++ b/__test__/support/environment/TestEnvironment.ts
@@ -2,7 +2,7 @@ import SdkEnvironment from "../../../src/shared/managers/SdkEnvironment";
 import { AppUserConfig, ConfigIntegrationKind, ServerAppConfig } from "../../../src/shared/models/AppConfig";
 import { TestEnvironmentKind } from "../../../src/shared/models/TestEnvironmentKind";
 import BrowserUserAgent from "../models/BrowserUserAgent";
-import { resetDatabase, initOSGlobals, stubDomEnvironment, stubNotification } from "./TestEnvironmentHelpers";
+import { resetDatabase, initOSGlobals, stubDomEnvironment, stubNotification, mockUserAgent } from "./TestEnvironmentHelpers";
 import { HttpHttpsEnvironment } from "../models/HttpHttpsEnvironment";
 import OperationCache from "../../../src/core/caching/OperationCache";
 import "fake-indexeddb/auto";
@@ -33,6 +33,7 @@ export interface TestEnvironmentConfig {
 
 export class TestEnvironment {
   static async initialize(config: TestEnvironmentConfig = {}) {
+    mockUserAgent(config);
     // reset db & localStorage
     resetDatabase();
     OperationCache.flushOperations();

--- a/__test__/support/environment/TestEnvironmentHelpers.ts
+++ b/__test__/support/environment/TestEnvironmentHelpers.ts
@@ -17,13 +17,33 @@ import Context from "../../../src/page/models/Context";
 import NotificationsNamespace from "../../../src/onesignal/NotificationsNamespace";
 import UserNamespace from "../../../src/onesignal/UserNamespace";
 import { ONESIGNAL_EVENTS } from "../../../src/onesignal/OneSignalEvents";
+import bowser from "bowser";
 
 declare const global: any;
+
+jest.mock('../../../src/shared/utils/bowserCastle', () => ({
+  bowserCastle: jest.fn(),
+}));
+
+// Import the mocked module
+const { bowserCastle } = require('../../../src/shared/utils/bowserCastle');
 
 export function resetDatabase() {
   // Erase and reset IndexedDb database name to something random
   Database.resetInstance();
   Database.databaseInstanceName = Random.getRandomString(10);
+}
+
+export function mockUserAgent(config: TestEnvironmentConfig = {}): void {
+  const info = bowser._detect(config.userAgent ?? BrowserUserAgent.Default);
+
+  // Modify the mock implementation
+  bowserCastle.mockImplementation(() => ({
+    mobile: info.mobile,
+    tablet: info.tablet,
+    name: info.name.toLowerCase(),
+    version: info.version,
+  }));
 }
 
 export async function initOSGlobals(config: TestEnvironmentConfig = {}) {

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -43,6 +43,7 @@ import { OneSignalDeferredLoadedCallback } from "../page/models/OneSignalDeferre
 import DebugNamespace from "./DebugNamesapce";
 import { InvalidArgumentError, InvalidArgumentReason } from "../shared/errors/InvalidArgumentError";
 import { ONESIGNAL_EVENTS } from "./OneSignalEvents";
+import { bowserCastle } from "../shared/utils/bowserCastle";
 
 export default class OneSignal {
   static EVENTS = ONESIGNAL_EVENTS;
@@ -379,4 +380,4 @@ LegacyManager.ensureBackwardsCompatibility(OneSignal);
 Log.info(`%cOneSignal Web SDK loaded (version ${OneSignal._VERSION},
   ${SdkEnvironment.getWindowEnv().toString()} environment).`, getConsoleStyle('bold'));
 Log.debug(`Current Page URL: ${typeof location === "undefined" ? "NodeJS" : location.href}`);
-Log.debug(`Browser Environment: ${bowser.name} ${bowser.version}`);
+Log.debug(`Browser Environment: ${bowserCastle().name} ${bowserCastle().version}`);

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -1,4 +1,3 @@
-import bowser from "bowser";
 import { EnvironmentInfoHelper } from "../page/helpers/EnvironmentInfoHelper";
 import AltOriginManager from "../page/managers/AltOriginManager";
 import ConfigManager from "../page/managers/ConfigManager";
@@ -136,7 +135,7 @@ export default class OneSignal {
       throw new Error("OneSignal config not initialized!");
     }
 
-    if (bowser.safari && !OneSignal.config.safariWebId) {
+    if (bowserCastle().name == 'safari' && !OneSignal.config.safariWebId) {
       /**
        * Don't throw an error for missing Safari config; many users set up
        * support on Chrome/Firefox and don't intend to support Safari but don't

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -124,6 +124,7 @@ export default class OneSignal {
    */
   static async init(options: AppUserConfig) {
     logMethodCall('init');
+    Log.debug(`Browser Environment: ${bowserCastle().name} ${bowserCastle().version}`);
 
     LocalStorage.removeLegacySubscriptionOptions();
 
@@ -380,4 +381,3 @@ LegacyManager.ensureBackwardsCompatibility(OneSignal);
 Log.info(`%cOneSignal Web SDK loaded (version ${OneSignal._VERSION},
   ${SdkEnvironment.getWindowEnv().toString()} environment).`, getConsoleStyle('bold'));
 Log.debug(`Current Page URL: ${typeof location === "undefined" ? "NodeJS" : location.href}`);
-Log.debug(`Browser Environment: ${bowserCastle().name} ${bowserCastle().version}`);

--- a/src/page/bell/Bell.ts
+++ b/src/page/bell/Bell.ts
@@ -17,6 +17,7 @@ import MainHelper from '../../shared/helpers/MainHelper';
 import Log from '../../shared/libraries/Log';
 import { AppUserConfigNotifyButton, BellSize, BellPosition, BellText } from '../../shared/models/Prompts';
 import SubscriptionChangeEvent from '../models/SubscriptionChangeEvent';
+import { bowserCastle } from '../../shared/utils/bowserCastle';
 
 const logoSvg = `<svg class="onesignal-bell-svg" xmlns="http://www.w3.org/2000/svg" width="99.7" height="99.7" viewBox="0 0 99.7 99.7"><circle class="background" cx="49.9" cy="49.9" r="49.9"/><path class="foreground" d="M50.1 66.2H27.7s-2-.2-2-2.1c0-1.9 1.7-2 1.7-2s6.7-3.2 6.7-5.5S33 52.7 33 43.3s6-16.6 13.2-16.6c0 0 1-2.4 3.9-2.4 2.8 0 3.8 2.4 3.8 2.4 7.2 0 13.2 7.2 13.2 16.6s-1 11-1 13.3c0 2.3 6.7 5.5 6.7 5.5s1.7.1 1.7 2c0 1.8-2.1 2.1-2.1 2.1H50.1zm-7.2 2.3h14.5s-1 6.3-7.2 6.3-7.3-6.3-7.3-6.3z"/><ellipse class="stroke" cx="49.9" cy="49.9" rx="37.4" ry="36.9"/></svg>`;
 
@@ -447,7 +448,7 @@ export default class Bell {
   }
 
   patchSafariSvgFilterBug() {
-    if (!(bowser.safari && Number(bowser.version) >= 9.1)) {
+    if (!(bowser.safari && Number(bowserCastle().version) >= 9.1)) {
       const bellShadow = `drop-shadow(0 2px 4px rgba(34,36,38,0.35));`;
       const badgeShadow = `drop-shadow(0 2px 4px rgba(34,36,38,0));`;
       const dialogShadow = `drop-shadow(0px 2px 2px rgba(34,36,38,.15));`;

--- a/src/page/bell/Bell.ts
+++ b/src/page/bell/Bell.ts
@@ -448,7 +448,7 @@ export default class Bell {
   }
 
   patchSafariSvgFilterBug() {
-    if (!(bowser.safari && Number(bowserCastle().version) >= 9.1)) {
+    if (!(bowserCastle().name == 'safari' && Number(bowserCastle().version) >= 9.1)) {
       const bellShadow = `drop-shadow(0 2px 4px rgba(34,36,38,0.35));`;
       const badgeShadow = `drop-shadow(0 2px 4px rgba(34,36,38,0));`;
       const dialogShadow = `drop-shadow(0px 2px 2px rgba(34,36,38,.15));`;
@@ -456,7 +456,7 @@ export default class Bell {
       this.badge.element.setAttribute('style', `filter: ${badgeShadow}; -webkit-filter: ${badgeShadow};`);
       this.dialog.element.setAttribute('style', `filter: ${dialogShadow}; -webkit-filter: ${dialogShadow};`);
     }
-    if (bowser.safari) {
+    if (bowserCastle().name == 'safari') {
       this.badge.element.setAttribute('style', `display: none;`);
     }
   }

--- a/src/page/bell/Dialog.ts
+++ b/src/page/bell/Dialog.ts
@@ -5,6 +5,7 @@ import SdkEnvironment from '../../shared/managers/SdkEnvironment';
 import { addDomElement, clearDomElementChildren, getPlatformNotificationIcon } from '../../shared/utils/utils';
 import AnimatedElement from './AnimatedElement';
 import Bell from './Bell';
+import { bowserCastle } from '../../shared/utils/bowserCastle';
 
 export default class Dialog extends AnimatedElement {
 
@@ -79,7 +80,7 @@ export default class Dialog extends AnimatedElement {
         else if (this.bell.state === Bell.STATES.BLOCKED) {
           let imageUrl = null;
           if (bowser.chrome) {
-            if (!bowser.mobile && !bowser.tablet)
+            if (!bowserCastle().mobile && !bowserCastle().tablet)
               imageUrl = '/bell/chrome-unblock.jpg';
           }
           else if (bowser.firefox)
@@ -95,7 +96,7 @@ export default class Dialog extends AnimatedElement {
             instructionsHtml = `<a href="${imageUrl}" target="_blank"><img src="${imageUrl}"></a></div>`;
           }
 
-          if ((bowser.mobile || bowser.tablet) && bowser.chrome) {
+          if ((bowserCastle().mobile || bowserCastle().tablet) && bowser.chrome) {
             instructionsHtml = `<ol><li>Access <strong>Settings</strong> by tapping the three menu dots <strong>⋮</strong></li><li>Click <strong>Site settings</strong> under Advanced.</li><li>Click <strong>Notifications</strong>.</li><li>Find and click this entry for this website.</li><li>Click <strong>Notifications</strong> and set it to <strong>Allow</strong>.</li></ol>`;
           }
           contents = `<h1>${this.bell.options.text['dialog.blocked.title']}</h1><div class="divider"></div><div class="instructions"><p>${this.bell.options.text['dialog.blocked.message']}</p>${instructionsHtml}</div>${footer}`;

--- a/src/page/bell/Dialog.ts
+++ b/src/page/bell/Dialog.ts
@@ -79,15 +79,15 @@ export default class Dialog extends AnimatedElement {
         }
         else if (this.bell.state === Bell.STATES.BLOCKED) {
           let imageUrl = null;
-          if (bowser.chrome) {
+          if (bowserCastle().name === 'chrome') {
             if (!bowserCastle().mobile && !bowserCastle().tablet)
               imageUrl = '/bell/chrome-unblock.jpg';
           }
-          else if (bowser.firefox)
+          else if (bowserCastle().name === 'firefox')
             imageUrl = '/bell/firefox-unblock.jpg';
-          else if (bowser.safari)
+          else if (bowserCastle().name == 'safari')
             imageUrl = '/bell/safari-unblock.jpg';
-          else if (bowser.msedge)
+          else if (bowserCastle().name === 'msedge')
             imageUrl = '/bell/edge-unblock.png';
 
           let instructionsHtml = '';
@@ -96,7 +96,7 @@ export default class Dialog extends AnimatedElement {
             instructionsHtml = `<a href="${imageUrl}" target="_blank"><img src="${imageUrl}"></a></div>`;
           }
 
-          if ((bowserCastle().mobile || bowserCastle().tablet) && bowser.chrome) {
+          if ((bowserCastle().mobile || bowserCastle().tablet) && bowserCastle().name === 'chrome') {
             instructionsHtml = `<ol><li>Access <strong>Settings</strong> by tapping the three menu dots <strong>⋮</strong></li><li>Click <strong>Site settings</strong> under Advanced.</li><li>Click <strong>Notifications</strong>.</li><li>Find and click this entry for this website.</li><li>Click <strong>Notifications</strong> and set it to <strong>Allow</strong>.</li></ol>`;
           }
           contents = `<h1>${this.bell.options.text['dialog.blocked.title']}</h1><div class="divider"></div><div class="instructions"><p>${this.bell.options.text['dialog.blocked.message']}</p>${instructionsHtml}</div>${footer}`;

--- a/src/page/helpers/EnvironmentInfoHelper.ts
+++ b/src/page/helpers/EnvironmentInfoHelper.ts
@@ -26,10 +26,10 @@ export class EnvironmentInfoHelper {
     }
 
     private static getBrowser(): Browser {
-        if (bowser.chrome) { return Browser.Chrome; }
-        if (bowser.msedge) { return Browser.Edge; }
-        if (bowser.opera) { return Browser.Opera; }
-        if (bowser.firefox) { return Browser.Firefox; }
+        if (bowserCastle().name === 'chrome') { return Browser.Chrome; }
+        if (bowserCastle().name === 'msedge') { return Browser.Edge; }
+        if (bowserCastle().name === 'opera') { return Browser.Opera; }
+        if (bowserCastle().name === 'firefox') { return Browser.Firefox; }
         // use existing safari detection to be consistent
         if (this.isMacOSSafari()) { return Browser.Safari; }
 

--- a/src/page/helpers/EnvironmentInfoHelper.ts
+++ b/src/page/helpers/EnvironmentInfoHelper.ts
@@ -4,6 +4,7 @@ import { Browser } from '../../shared/models/Browser';
 import { OneSignalUtils } from '../../shared/utils/OneSignalUtils';
 import { isMacOSSafariInIframe } from '../utils/BrowserSupportsPush';
 import Utils from '../../shared/context/Utils';
+import { bowserCastle } from "../../shared/utils/bowserCastle";
 
 /**
  * EnvironmentInfoHelper is used to save page ("browser") context environment information to
@@ -45,7 +46,7 @@ export class EnvironmentInfoHelper {
     }
 
     private static getBrowserVersion(): number {
-        return Utils.parseVersionString(bowser.version);
+        return Utils.parseVersionString(bowserCastle().version);
     }
 
     private static isHttps(): boolean {

--- a/src/page/managers/PromptsManager.ts
+++ b/src/page/managers/PromptsManager.ts
@@ -1,4 +1,3 @@
-import bowser from "bowser";
 import OneSignalEvent from "../../shared/services/OneSignalEvent";
 import { ResourceLoadState } from "../services/DynamicResourceLoader";
 import { CONFIG_DEFAULTS_SLIDEDOWN_OPTIONS, SERVER_CONFIG_DEFAULTS_PROMPT_DELAYS } from "../../shared/config/constants";
@@ -14,6 +13,7 @@ import { EnvironmentInfoHelper } from "../helpers/EnvironmentInfoHelper";
 import { ContextInterface } from "../models/Context";
 import { DismissPrompt } from "../models/Dismiss";
 import Slidedown from "../slidedown/Slidedown";
+import { bowserCastle } from "../../shared/utils/bowserCastle";
 
 export interface AutoPromptOptions {
   force?: boolean;
@@ -38,7 +38,7 @@ export class PromptsManager {
       const { browserType, browserVersion, requiresUserInteraction } = environmentInfo;
 
       return (
-          (browserType === "chrome" && Number(browserVersion) >= 63 && (bowser.tablet || bowser.mobile)) ||
+          (browserType === "chrome" && Number(browserVersion) >= 63 && (bowserCastle().tablet || bowserCastle().mobile)) ||
           requiresUserInteraction
         );
   }

--- a/src/page/slidedown/ConfirmationToast.ts
+++ b/src/page/slidedown/ConfirmationToast.ts
@@ -1,4 +1,3 @@
-import bowser from 'bowser';
 import OneSignalEvent from '../../shared/services/OneSignalEvent';
 import {
   addCssClass,
@@ -7,6 +6,7 @@ import {
   getDomElementOrStub
 } from '../../shared/utils/utils';
 import { SLIDEDOWN_CSS_CLASSES, SLIDEDOWN_CSS_IDS, TOAST_CLASSES, TOAST_IDS } from "../../shared/slidedown/constants";
+import { bowserCastle } from '../../shared/utils/bowserCastle';
 
 export default class ConfirmationToast {
   private message: string;
@@ -40,7 +40,7 @@ export default class ConfirmationToast {
     this.container.appendChild(dialogContainer);
 
     // Animate it in depending on environment
-    addCssClass(this.container, bowser.mobile ? SLIDEDOWN_CSS_CLASSES.slideUp : SLIDEDOWN_CSS_CLASSES.slideDown);
+    addCssClass(this.container, bowserCastle().mobile ? SLIDEDOWN_CSS_CLASSES.slideUp : SLIDEDOWN_CSS_CLASSES.slideDown);
 
     ConfirmationToast.triggerSlidedownEvent(ConfirmationToast.EVENTS.SHOWN);
   }

--- a/src/page/slidedown/Slidedown.ts
+++ b/src/page/slidedown/Slidedown.ts
@@ -1,5 +1,3 @@
-import bowser from 'bowser';
-
 import OneSignalEvent from '../../shared/services/OneSignalEvent';
 import MainHelper from '../../shared/helpers/MainHelper';
 import {
@@ -22,6 +20,7 @@ import ChannelCaptureContainer from './ChannelCaptureContainer';
 import PromptsHelper from '../../shared/helpers/PromptsHelper';
 import { SlidedownPromptOptions, DelayedPromptType } from '../../shared/models/Prompts';
 import { InvalidChannelInputField } from '../errors/ChannelCaptureError';
+import { bowserCastle } from '../../shared/utils/bowserCastle';
 
 export default class Slidedown {
   public options: SlidedownPromptOptions;
@@ -109,7 +108,7 @@ export default class Slidedown {
       this.container.appendChild(dialogContainer);
 
       // Animate it in depending on environment
-      addCssClass(this.container, bowser.mobile ? SLIDEDOWN_CSS_CLASSES.slideUp : SLIDEDOWN_CSS_CLASSES.slideDown);
+      addCssClass(this.container, bowserCastle().mobile ? SLIDEDOWN_CSS_CLASSES.slideUp : SLIDEDOWN_CSS_CLASSES.slideDown);
 
       // Add click event handlers
       this.allowButton.addEventListener('click', this.onSlidedownAllowed.bind(this));

--- a/src/shared/helpers/Environment.ts
+++ b/src/shared/helpers/Environment.ts
@@ -1,6 +1,6 @@
 import SdkEnvironment from '../managers/SdkEnvironment';
 import { WindowEnvironmentKind } from '../models/WindowEnvironmentKind';
-import bowser from 'bowser';
+import { bowserCastle } from '../utils/bowserCastle';
 
 export default class Environment {
   /**
@@ -11,7 +11,7 @@ export default class Environment {
   }
 
   public static isSafari(): boolean {
-    return Environment.isBrowser() && bowser.safari;
+    return Environment.isBrowser() && bowserCastle().name == 'safari';
   }
 
   public static version() {

--- a/src/shared/helpers/InitHelper.ts
+++ b/src/shared/helpers/InitHelper.ts
@@ -1,4 +1,3 @@
-import bowser from 'bowser';
 import { NotificationPermission } from '../models/NotificationPermission';
 import SdkEnvironment from '../managers/SdkEnvironment';
 import { AppConfig } from '../models/AppConfig';
@@ -26,6 +25,7 @@ import { getConsoleStyle, once, triggerNotificationPermissionChanged } from '../
 import Environment from './Environment';
 import OneSignalEvent from '../services/OneSignalEvent';
 import ProxyFrameHost from '../../page/modules/frames/ProxyFrameHost';
+import { bowserCastle } from '../utils/bowserCastle';
 
 declare var OneSignal: any;
 
@@ -456,7 +456,7 @@ export default class InitHelper {
 
   public static async polyfillSafariFetch() {
     // If Safari - add 'fetch' pollyfill if it isn't already added.
-    if (bowser.safari && typeof window.fetch == 'undefined') {
+    if (bowserCastle().name == 'safari' && typeof window.fetch == 'undefined') {
       Log.debug('Loading fetch polyfill for Safari..');
       try {
         await new DynamicResourceLoader().loadFetchPolyfill();

--- a/src/shared/helpers/InitHelper.ts
+++ b/src/shared/helpers/InitHelper.ts
@@ -19,7 +19,6 @@ import SubscriptionPopupHost from '../../page/modules/frames/SubscriptionPopupHo
 import { DynamicResourceLoader } from '../../page/services/DynamicResourceLoader';
 import Database from '../services/Database';
 import LimitStore from '../services/LimitStore';
-import LocalStorage from '../utils/LocalStorage';
 import OneSignalUtils from '../utils/OneSignalUtils';
 import { getConsoleStyle, once, triggerNotificationPermissionChanged } from '../utils/utils';
 import Environment from './Environment';

--- a/src/shared/managers/PermissionManager.ts
+++ b/src/shared/managers/PermissionManager.ts
@@ -5,6 +5,7 @@ import { NotificationPermission } from '../models/NotificationPermission';
 import SdkEnvironment from './SdkEnvironment';
 import LocalStorage from '../utils/LocalStorage';
 import OneSignalError from '../errors/OneSignalError';
+import { bowserCastle } from '../utils/bowserCastle';
 
 /**
  * A permission manager to consolidate the different quirks of obtaining and evaluating permissions
@@ -88,7 +89,7 @@ export default class PermissionManager {
    * @param safariWebId The Safari web ID necessary to access the permission state on Safari.
    */
   public async getReportedNotificationPermission(safariWebId?: string): Promise<NotificationPermission>{
-    if (bowser.safari)
+    if (bowserCastle().name == 'safari')
       return PermissionManager.getSafariNotificationPermission(safariWebId);
 
     // Is this web push setup using subdomain.os.tc or subdomain.onesignal.com?

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -36,6 +36,7 @@ import { executeCallback, logMethodCall } from "../utils/utils";
 import UserDirector from "../../onesignal/UserDirector";
 import { OSModel } from "../../core/modelRepo/OSModel";
 import { isCompleteSubscriptionObject } from "../../core/utils/typePredicates";
+import { bowserCastle } from "../utils/bowserCastle";
 
 export interface SubscriptionManagerConfig {
   safariWebId?: string;
@@ -476,7 +477,7 @@ export class SubscriptionManager {
 
     const swRegistration = (<ServiceWorkerGlobalScope><any>self).registration;
 
-    if (!swRegistration.active && !bowser.firefox) {
+    if (!swRegistration.active && bowserCastle().name !== 'firefox') {
       throw new InvalidStateError(InvalidStateReason.ServiceWorkerNotActivated);
       /*
         Or should we wait for the service worker to be ready?
@@ -507,7 +508,7 @@ export class SubscriptionManager {
     // Specifically return undefined instead of null if the key isn't available
     let key = undefined;
 
-    if (bowser.firefox) {
+    if (bowserCastle().name === 'firefox') {
       /*
         Firefox uses VAPID for application identification instead of
         authentication, and so all apps share an identification key.

--- a/src/shared/models/DeviceRecord.ts
+++ b/src/shared/models/DeviceRecord.ts
@@ -3,6 +3,7 @@ import { Serializable } from '../../page/models/Serializable';
 
 import NotImplementedError from '../errors/NotImplementedError';
 import Environment from '../helpers/Environment';
+import { bowserCastle } from '../utils/bowserCastle';
 import OneSignalUtils from '../utils/OneSignalUtils';
 import { DeliveryPlatformKind } from './DeliveryPlatformKind';
 import { SubscriptionStateKind } from './SubscriptionStateKind';
@@ -47,7 +48,7 @@ export abstract class DeviceRecord implements Serializable {
     this.language = Environment.getLanguage();
     this.timezone = new Date().getTimezoneOffset() * -60;
     this.timezoneId = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const browserVersion = parseInt(String(bowser.version), 10);
+    const browserVersion = parseInt(String(bowserCastle().version), 10);
     this.browserVersion = isNaN(browserVersion) ? -1 : browserVersion;
     this.deviceModel = navigator.platform;
     this.sdkVersion = Environment.version().toString();

--- a/src/shared/models/DeviceRecord.ts
+++ b/src/shared/models/DeviceRecord.ts
@@ -57,7 +57,7 @@ export abstract class DeviceRecord implements Serializable {
   }
 
   isSafari(): boolean {
-    return bowser.safari && window.safari !== undefined && window.safari.pushNotification !== undefined;
+    return bowserCastle().name == 'safari' && window.safari !== undefined && window.safari.pushNotification !== undefined;
   }
 
   getDeliveryPlatform(): DeliveryPlatformKind {

--- a/src/shared/models/PushDeviceRecord.ts
+++ b/src/shared/models/PushDeviceRecord.ts
@@ -1,9 +1,8 @@
-import bowser from 'bowser';
-
 import NotImplementedError from '../errors/NotImplementedError';
 import { RawPushSubscription } from './RawPushSubscription';
 import { SubscriptionStateKind } from './SubscriptionStateKind';
 import { DeviceRecord, FlattenedDeviceRecord } from './DeviceRecord';
+import { bowserCastle } from '../utils/bowserCastle';
 
 // TO DO: deprecate in favor of FuturePushSubscriptionRecord.ts
 export interface SerializedPushDeviceRecord extends FlattenedDeviceRecord {
@@ -30,7 +29,7 @@ export class PushDeviceRecord extends DeviceRecord {
     const serializedBundle: SerializedPushDeviceRecord = super.serialize();
 
     if (this.subscription) {
-      serializedBundle.identifier = bowser.safari ?
+      serializedBundle.identifier = bowserCastle().name == 'safari' ?
         this.subscription.safariDeviceToken :
         this.subscription.w3cEndpoint ? this.subscription.w3cEndpoint.toString() : null;
       serializedBundle.web_auth = this.subscription.w3cAuth;

--- a/src/shared/utils/OneSignalUtils.ts
+++ b/src/shared/utils/OneSignalUtils.ts
@@ -43,7 +43,7 @@ export class OneSignalUtils {
         `(${windowEnv.toString()}) isUsingSubscriptionWorkaround() cannot be called until OneSignal.config exists.`
       );
     }
-    if (bowser.safari) {
+    if (bowserCastle().name == 'safari') {
       return false;
     }
 
@@ -58,7 +58,7 @@ export class OneSignalUtils {
     subdomain: string | undefined,
     allowLocalhostAsSecureOrigin: boolean | undefined
   ): boolean {
-    if (bowser.safari) {
+    if (bowserCastle().name == 'safari') {
       return false;
     }
 

--- a/src/shared/utils/OneSignalUtils.ts
+++ b/src/shared/utils/OneSignalUtils.ts
@@ -4,6 +4,7 @@ import Environment from "../helpers/Environment";
 import { WindowEnvironmentKind } from "../models/WindowEnvironmentKind";
 import { Utils } from "../context/Utils";
 import Log from "../libraries/Log";
+import { bowserCastle } from "./bowserCastle";
 
 export class OneSignalUtils {
   public static getBaseUrl() {
@@ -75,7 +76,7 @@ export class OneSignalUtils {
 
   public static redetectBrowserUserAgent(): IBowser {
     // During testing, the browser object may be initialized before the userAgent is injected
-    if (bowser.name === "" && bowser.version === "") {
+    if (bowserCastle().name === "" && bowserCastle().version === "") {
       return bowser._detect(navigator.userAgent);
     }
     return bowser;

--- a/src/shared/utils/bowserCastle.ts
+++ b/src/shared/utils/bowserCastle.ts
@@ -1,0 +1,10 @@
+import * as bowser from 'bowser';
+
+export function bowserCastle() {
+  return {
+    mobile: bowser.mobile,
+    tablet: bowser.tablet,
+    name: bowser.name.toLowerCase(),
+    version: bowser.version,
+  };
+}

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -8,6 +8,7 @@ import { Utils } from "../context/Utils";
 import bowser from 'bowser';
 import TimeoutError from '../errors/TimeoutError';
 import Log from '../libraries/Log';
+import { bowserCastle } from './bowserCastle';
 
 export function isArray(variable: any) {
   return Object.prototype.toString.call(variable) === '[object Array]';
@@ -392,9 +393,9 @@ export function getPlatformNotificationIcon(notificationIcons: NotificationIcons
   if (!notificationIcons)
     return 'default-icon';
 
-  if (bowser.safari && notificationIcons.safari)
+  if (bowserCastle().name == 'safari' && notificationIcons.safari)
     return notificationIcons.safari;
-  else if (bowser.firefox && notificationIcons.firefox)
+  else if (bowserCastle().name === 'firefox' && notificationIcons.firefox)
     return notificationIcons.firefox;
 
   return notificationIcons.chrome ||


### PR DESCRIPTION
# Description
## 1 Line Summary
For testability, isolate usage of `bowser` to a single function in order to easily setup jest mocks

## Details
New `bowserCastle` function returns browser related info from one spot. This allows us to easily change the browser environment in tests by setting the userAgent.

This change is needed because the bowser values are normally calculated on module import which happens before jest mocks are set up.

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
Manually tested on my machine.

Tests pass.

### Info
### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1041)
<!-- Reviewable:end -->
