### PR TITLE
Fix/double notif on iOS Web Push

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jest": "jest --coverage"
   },
   "config": {
-    "sdkVersion": "151601"
+    "sdkVersion": "151602"
   },
   "repository": {
     "type": "git",

--- a/src/helpers/EventHelper.ts
+++ b/src/helpers/EventHelper.ts
@@ -11,8 +11,11 @@ import LocalStorage from '../utils/LocalStorage';
 import { CustomLinkManager } from '../managers/CustomLinkManager';
 
 export default class EventHelper {
-  static onNotificationPermissionChange() {
-    EventHelper.checkAndTriggerSubscriptionChanged();
+  static _mutexPromise: Promise<void> = Promise.resolve();
+  static _mutexLocked = false;
+
+  static async onNotificationPermissionChange() {
+    await EventHelper.checkAndTriggerSubscriptionChanged();
   }
 
   static async onInternalSubscriptionSet(optedOut: boolean) {
@@ -20,25 +23,40 @@ export default class EventHelper {
   }
 
   static async checkAndTriggerSubscriptionChanged() {
-    OneSignalUtils.logMethodCall('checkAndTriggerSubscriptionChanged');
-    const context: ContextSWInterface = OneSignal.context;
-    const subscriptionState = await context.subscriptionManager.getSubscriptionState();
-    const isPushEnabled = await OneSignal.privateIsPushNotificationsEnabled();
-    const appState = await Database.getAppState();
-    const { lastKnownPushEnabled } = appState;
-    const didStateChange = (
-      lastKnownPushEnabled === null ||
-      isPushEnabled !== lastKnownPushEnabled
-    );
-    if (!didStateChange) return;
-    Log.info(
-      `The user's subscription state changed from ` +
-        `${lastKnownPushEnabled === null ? '(not stored)' : lastKnownPushEnabled} ⟶ ${subscriptionState.subscribed}`
-    );
-    LocalStorage.setIsPushNotificationsEnabled(isPushEnabled);
-    appState.lastKnownPushEnabled = isPushEnabled;
-    await Database.setAppState(appState);
-    EventHelper.triggerSubscriptionChanged(isPushEnabled);
+    if (EventHelper._mutexLocked) {
+      await EventHelper._mutexPromise;
+    }
+
+    EventHelper._mutexLocked = true;
+    // eslint-disable-next-line no-async-promise-executor
+    EventHelper._mutexPromise = new Promise(async (resolve, reject) => {
+      try {
+        OneSignalUtils.logMethodCall('checkAndTriggerSubscriptionChanged');
+        const context: ContextSWInterface = OneSignal.context;
+        const subscriptionState = await context.subscriptionManager.getSubscriptionState();
+        const isPushEnabled = await OneSignal.privateIsPushNotificationsEnabled();
+        const appState = await Database.getAppState();
+        const { lastKnownPushEnabled } = appState;
+        const didStateChange = (
+          lastKnownPushEnabled === null ||
+          isPushEnabled !== lastKnownPushEnabled
+        );
+        if (!didStateChange) return;
+        Log.info(
+          `The user's subscription state changed from ` +
+            `${lastKnownPushEnabled === null ? '(not stored)' : lastKnownPushEnabled} ⟶ ${subscriptionState.subscribed}`
+        );
+        LocalStorage.setIsPushNotificationsEnabled(isPushEnabled);
+        appState.lastKnownPushEnabled = isPushEnabled;
+        await Database.setAppState(appState);
+        EventHelper.triggerSubscriptionChanged(isPushEnabled);
+        EventHelper._mutexLocked = false;
+        resolve();
+      } catch (e) {
+        EventHelper._mutexLocked = false;
+        reject(`checkAndTriggerSubscriptionChanged error: ${e}`);
+      }
+    });
   }
 
   static async _onSubscriptionChanged(newSubscriptionState: boolean | undefined) {

--- a/test/unit/public-sdk-apis/onSession.ts
+++ b/test/unit/public-sdk-apis/onSession.ts
@@ -18,6 +18,7 @@ import {
 import { createSubscription } from "../../support/tester/utils";
 import EventsTestHelper from '../../support/tester/EventsTestHelper';
 import { DelayedPromptType } from '../../../src/models/Prompts';
+import EventHelper from "../../../src/helpers/EventHelper";
 
 
 const sinonSandbox: SinonSandbox = sinon.sandbox.create();
@@ -30,6 +31,8 @@ test.afterEach(function (_t: ExecutionContext) {
   OneSignal._initCalled = false;
   OneSignal.__initAlreadyCalled = false;
   OneSignal._sessionInitAlreadyRunning = false;
+  EventHelper._mutexPromise = Promise.resolve();
+  EventHelper._mutexLocked = false;
 });
 
 /**


### PR DESCRIPTION
# Description
## 1 Line Summary
Prevents double notifications to iOS Web Push by preventing a race condition that results in the app state being the same for both function invocations of `checkAndTriggerSubscriptionChanged`

## Details
In JavaScript, which is a single-threaded, event-driven language, the concept of a Mutex lock doesn't exactly apply in the same way as in multi-threaded languages like Java or C++. JavaScript code is executed in a single thread, which means it can only do one thing at a time, so you don't generally have to worry about multiple threads accessing a shared resource simultaneously.

However, JavaScript can still perform asynchronous operations, such as AJAX calls, timeouts, and promises, which could potentially lead to race conditions. A race condition is a situation where the behavior of your code could vary depending on the precise timing of these asynchronous operations.

### Race condition
There is a race condition in the function `checkAndTriggerSubscriptionChanged`.

This function is called from two key places which lead it to be called twice in both desktop and mobile environments:
- `SubscriptionHelper`: when the browser first subscribes
- `EventHelper.onNotificationPermissionChange`: when the event `NATIVE_PROMPT_PERMISSIONCHANGED` is emitted.

In the second call, because the call is triggered from the event handler, we cannot await on it to ensure sequential execution of the calls. This leads to the race condition that arises when the variable `didStateChange` in the function is true for both calls (it should be true only for the first call).

For some reason, the race condition only creates a problem on iOS -- presumably due to the event firing at a different time than on desktop.

## Solution
We introduce a mutex lock to the `EventHelper` class which we use in the `checkAndTriggerSubscriptionChanged` function to ensure sequential execution.

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
Tested manually on an iOS device. Only one notification is received.

### Info
We will no longer be adding test coverage on pre-user-model code. All automated tests pass.

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info
![IMG_0003](https://github.com/OneSignal/OneSignal-Website-SDK/assets/11739227/e86236ae-7899-4ca1-b2fb-1bcb59fcb815)


### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1047)
<!-- Reviewable:end -->
