### PR TITLE
[Fix] iOS denied notificationPermissionChange

### DIFF
--- a/src/managers/SubscriptionManager.ts
+++ b/src/managers/SubscriptionManager.ts
@@ -334,15 +334,12 @@ export class SubscriptionManager {
       const permission = await SubscriptionManager.requestPresubscribeNotificationPermission();
 
       /*
-        Notification permission changes are already broadcast by the page's
-        notificationpermissionchange handler. This means that allowing or
-        denying the permission prompt will cause double events. However, the
-        native event handler does not broadcast an event for dismissing the
+        The native event handler does not broadcast an event for dismissing the
         prompt, because going from "default" permissions to "default"
         permissions isn't a change. We specifically broadcast "default" to "default" changes.
        */
-      if (permission === NotificationPermission.Default)
-        await PermissionUtils.triggerNotificationPermissionChanged(true);
+      const forcePermissionChangeEvent = permission === NotificationPermission.Default
+      await PermissionUtils.triggerNotificationPermissionChanged(forcePermissionChangeEvent);
 
       // If the user did not grant push permissions, throw and exit
       switch (permission) {

--- a/src/utils/PermissionUtils.ts
+++ b/src/utils/PermissionUtils.ts
@@ -2,7 +2,20 @@ import Database from "../services/Database";
 import Event from '../Event';
 
 export class PermissionUtils {
+
+  // This flag prevents firing the NATIVE_PROMPT_PERMISSIONCHANGED event twice
+  // We use multiple APIs:
+  //    1. Notification.requestPermission callback
+  //    2. navigator.permissions.query({ name: 'notifications' }`).onchange
+  // Some browsers support both, while others only support Notification.requestPermission
+  private static executing = false;
+
   public static async triggerNotificationPermissionChanged(updateIfIdentical = false) {
+    if (PermissionUtils.executing) {
+      return;
+    }
+    PermissionUtils.executing = true;
+
     const newPermission = await OneSignal.privateGetNotificationPermission();
     const previousPermission = await Database.get('Options', 'notificationPermission');
 
@@ -13,5 +26,6 @@ export class PermissionUtils {
 
     await Database.put('Options', { key: 'notificationPermission', value: newPermission });
     Event.trigger(OneSignal.EVENTS.NATIVE_PROMPT_PERMISSIONCHANGED, { to: newPermission });
+    PermissionUtils.executing = false;
   }
 }


### PR DESCRIPTION
# Description
## 1 Line Summary
Fixes the `OneSignal.on('notificationPermissionChange', function() {})` event not firing on iOS WebApps.

## Details
We were relying on the browser API `navigator.permissions.query({ name: 'notifications' }).onchange` to call our `triggerNotificationPermissionChanged` which fires the OneSignal `notificationPermissionChange` event, however on iOS WebApps this does not fire due to a bug with the browser.
To account for this we are calling our `PermissionUtils.triggerNotificationPermissionChanged` event every time the native notification prompt is answered or dismissed.

This however does create duplicate events so this commit adds logic to our `PermissionUtils.triggerNotificationPermissionChanged` to prevent this.

# Validation
## Tests
Tested event now fire exactly once on iOS 16.5.
* Tested both for accepting and declining.

Also confirmed Chrome on macOS still works
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
      - Tests no longer run on CI due to image no longer having Python 2.
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed
      - No visual changes

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1050)
<!-- Reviewable:end -->
