### PR TITLE
[Fix] iOS double welcome notification

### DIFF
--- a/src/helpers/EventHelper.ts
+++ b/src/helpers/EventHelper.ts
@@ -77,6 +77,7 @@ export default class EventHelper {
     }
   }
 
+  private static sendingOrSentWelcomeNotification = false;
   private static async onSubscriptionChanged_showWelcomeNotification(isSubscribed: boolean | undefined) {
     if (OneSignal.__doNotShowWelcomeNotification) {
       Log.debug('Not showing welcome notification because user has previously subscribed.');
@@ -93,6 +94,13 @@ export default class EventHelper {
     if (isSubscribed !== true) {
       return;
     }
+
+    // Workaround only for this v15 branch; There are race conditions in the SDK
+    // that result in the onSubscriptionChanged firing more than once sometimes.
+    if (EventHelper.sendingOrSentWelcomeNotification) {
+      return;
+    }
+    EventHelper.sendingOrSentWelcomeNotification = true;
 
     const { deviceId } = await Database.getSubscription();
     const { appId } = await Database.getAppConfig();

--- a/src/helpers/EventHelper.ts
+++ b/src/helpers/EventHelper.ts
@@ -82,53 +82,57 @@ export default class EventHelper {
       Log.debug('Not showing welcome notification because user has previously subscribed.');
       return;
     }
-    if (isSubscribed === true) {
-      const { deviceId } = await Database.getSubscription();
-      const { appId } = await Database.getAppConfig();
+    const welcome_notification_opts = OneSignal.config.userConfig.welcomeNotification;
+    const welcome_notification_disabled =
+      welcome_notification_opts !== undefined && welcome_notification_opts['disable'] === true;
 
-      const welcome_notification_opts = OneSignal.config.userConfig.welcomeNotification;
-      const welcome_notification_disabled =
-        welcome_notification_opts !== undefined && welcome_notification_opts['disable'] === true;
-      let title =
-        welcome_notification_opts !== undefined &&
-          welcome_notification_opts['title'] !== undefined &&
-          welcome_notification_opts['title'] !== null
-          ? welcome_notification_opts['title']
-          : '';
-      let message =
-        welcome_notification_opts !== undefined &&
-          welcome_notification_opts['message'] !== undefined &&
-          welcome_notification_opts['message'] !== null &&
-          welcome_notification_opts['message'].length > 0
-          ? welcome_notification_opts['message']
-          : 'Thanks for subscribing!';
-      const unopenableWelcomeNotificationUrl = new URL(location.href).origin + '?_osp=do_not_open';
-      const url =
-        welcome_notification_opts && welcome_notification_opts['url'] && welcome_notification_opts['url'].length > 0
-          ? welcome_notification_opts['url']
-          : unopenableWelcomeNotificationUrl;
-      title = BrowserUtils.decodeHtmlEntities(title);
-      message = BrowserUtils.decodeHtmlEntities(message);
-
-      if (!welcome_notification_disabled) {
-        Log.debug('Sending welcome notification.');
-        OneSignalApiShared.sendNotification(
-          appId,
-          [deviceId],
-          { en: title },
-          { en: message },
-          url,
-          null,
-          { __isOneSignalWelcomeNotification: true },
-          undefined
-        );
-        Event.trigger(OneSignal.EVENTS.WELCOME_NOTIFICATION_SENT, {
-          title: title,
-          message: message,
-          url: url
-        });
-      }
+    if (welcome_notification_disabled) {
+      return;
     }
+
+    if (isSubscribed !== true) {
+      return;
+    }
+
+    const { deviceId } = await Database.getSubscription();
+    const { appId } = await Database.getAppConfig();
+    let title =
+      welcome_notification_opts !== undefined &&
+        welcome_notification_opts['title'] !== undefined &&
+        welcome_notification_opts['title'] !== null
+        ? welcome_notification_opts['title']
+        : '';
+    let message =
+      welcome_notification_opts !== undefined &&
+        welcome_notification_opts['message'] !== undefined &&
+        welcome_notification_opts['message'] !== null &&
+        welcome_notification_opts['message'].length > 0
+        ? welcome_notification_opts['message']
+        : 'Thanks for subscribing!';
+    const unopenableWelcomeNotificationUrl = new URL(location.href).origin + '?_osp=do_not_open';
+    const url =
+      welcome_notification_opts && welcome_notification_opts['url'] && welcome_notification_opts['url'].length > 0
+        ? welcome_notification_opts['url']
+        : unopenableWelcomeNotificationUrl;
+    title = BrowserUtils.decodeHtmlEntities(title);
+    message = BrowserUtils.decodeHtmlEntities(message);
+
+    Log.debug('Sending welcome notification.');
+    OneSignalApiShared.sendNotification(
+      appId,
+      [deviceId],
+      { en: title },
+      { en: message },
+      url,
+      null,
+      { __isOneSignalWelcomeNotification: true },
+      undefined
+    );
+    Event.trigger(OneSignal.EVENTS.WELCOME_NOTIFICATION_SENT, {
+      title: title,
+      message: message,
+      url: url
+    });
   }
 
   private static async onSubscriptionChanged_evaluateNotifyButtonDisplayPredicate() {

--- a/test/unit/public-sdk-apis/onSession.ts
+++ b/test/unit/public-sdk-apis/onSession.ts
@@ -18,7 +18,6 @@ import {
 import { createSubscription } from "../../support/tester/utils";
 import EventsTestHelper from '../../support/tester/EventsTestHelper';
 import { DelayedPromptType } from '../../../src/models/Prompts';
-import EventHelper from "../../../src/helpers/EventHelper";
 
 
 const sinonSandbox: SinonSandbox = sinon.sandbox.create();
@@ -31,8 +30,6 @@ test.afterEach(function (_t: ExecutionContext) {
   OneSignal._initCalled = false;
   OneSignal.__initAlreadyCalled = false;
   OneSignal._sessionInitAlreadyRunning = false;
-  EventHelper._mutexPromise = Promise.resolve();
-  EventHelper._mutexLocked = false;
 });
 
 /**


### PR DESCRIPTION
# Description
## 1 Line Summary
Ensures welcome notifications are only sent once, was only reproducible on iOS WebApps, but only somtimes.

## Details
PR #1047 addressed this issue but it introduced some side-effects:
* tags not always being set from the category slide down prompt
* `notificationPermisionChange` not firing when it should sometimes

Instead of patching at the subscription change event we are just patching at the welcome notification send function. (changes in PR #1047 were reverted in this PR)
* Ideally it would be better to fix the root issue of fixing the subscription event firing more than once but we are looking for simpler and safer fix for v15. A longer term fix can be done in v16.

# Validation
## Tests
Tested on iOS 16.5, ensuring only one welcome notification shows.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
       - CI tests no longer run due to Python 2 missing from the image.
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed
      - No existing test coverage.

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed
      - No visual changes, other than sometimes seeing a duplicate welcome notification.

---

## Related Tickets
PR #1047
---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1051)
<!-- Reviewable:end -->
