### PR TITLE
[CI/CD Fix] Builds missing python 2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   test_build_deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    container:
+      image: python:2.7.18-buster
 
     strategy:
       matrix:
@@ -17,9 +19,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '2.7'
       - name: "[Setup] Install dependencies"
         run: yarn
       - name: "[Test] Run all tests"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install Yarn
+        run: npm install -g yarn
       - name: "[Setup] Install dependencies"
         run: yarn
       - name: "[Test] Run all tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
+    container:
+      image: python:2.7.18-buster
 
     strategy:
       matrix:
@@ -18,10 +20,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Use Python 2.7
-        uses: actions/setup-python@v4
-        with:
-          python-version: '2.7'
       - name: "[Setup] Install dependencies"
         run: yarn
       - name: "[Test] Run linters"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install Yarn
+        run: npm install -g yarn
       - name: "[Setup] Install dependencies"
         run: yarn
       - name: "[Test] Run linters"


### PR DESCRIPTION

# Description
## 1 Line Summary
Python 2 support was dropped by Github's CI/CD images. Switch to python:2.7.18-buster image to address the issue on this branch

## Details
Our builds started failing with this error:
```
Warning: The support for python 2.7 will be removed on June 19. Related issue: https://github.com/actions/setup-python/issues/672
Version 2.7 was not found in the local cache
```

To work around the issue we are using a different image `python:2.7.18-buster` that includes Python 2. In v16 we can ensure we are using python 3.

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
      - CI/CD only change
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1053)
<!-- Reviewable:end -->
