### PR TITLE
[Fix] [Tests] Carryover with MainHelper

### DIFF
--- a/__test__/unit/helpers/mainHelper.test.ts
+++ b/__test__/unit/helpers/mainHelper.test.ts
@@ -5,9 +5,9 @@ import { TestEnvironment } from "../../support/environment/TestEnvironment";
 import { NotificationPermission } from "../../../src/shared/models/NotificationPermission";
 
 describe('MainHelper Tests', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.useFakeTimers();
-    TestEnvironment.initialize({
+    await TestEnvironment.initialize({
       httpOrHttps: HttpHttpsEnvironment.Https,
     });
   });
@@ -15,8 +15,6 @@ describe('MainHelper Tests', () => {
   afterEach(() => {
     jest.resetAllMocks();
   });
-
-  // test('This is a test description', () => {});
 
   test('getCurrentNotificationType for default permission', async () => {
     test.stub(OneSignal.context.permissionManager, 'getNotificationPermission', NotificationPermission.Default);


### PR DESCRIPTION
# Description
## 1 Line Summary
Fixes `console.error` that print after the MainHelper test would run due to some Promises not finishing in time.

## Details
This fixes the following stacktrace that shows up in the test log:
```
MainHelper Tests
    ✓ getCurrentNotificationType for default permission (84 ms)

  console.error
    TypeError: Cannot read property '_location' of null
        at Window.get location [as location] (/sdk/node_modules/jest-environment-jsdom/node_modules/jsdom/lib/jsdom/browser/Window.js:376:79)
        at Function.getWindowEnv (/sdk/src/shared/managers/SdkEnvironment.ts:203:13)
        at Database.getWindowEnv [as shouldUsePostmam] (/sdk/src/shared/services/Database.ts:99:27)
        at Database.shouldUsePostmam [as getAll] (/sdk/src/shared/services/Database.ts:131:14)
        at Function.getAll (/sdk/src/shared/services/Database.ts:638:45)
        at ModelCache.getAll [as getCachedEncodedModels] (/sdk/src/core/caching/ModelCache.ts:106:27)
        at ModelCache.getCachedEncodedModels [as getAndDecodeModelsWithModelName] (/sdk/src/core/caching/ModelCache.ts:115:31)
        at ModelCache.getAndDecodeModelsWithModelName [as load] (/sdk/src/core/caching/ModelCache.ts:76:41)
        at runNextTicks (internal/process/task_queues.js:60:5)
        at processImmediate (internal/timers.js:437:9)

      30 |       }
      31 |     ).catch(e => {
    > 32 |       Log.error(e);
         |           ^
      33 |     });
      34 |   }
      35 |

      at error (src/core/CoreModule.ts:32:11)
```
While no test were observed failing this issue may have also caused flaky tests.

# Validation
## Tests
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1056)
<!-- Reviewable:end -->
