### PR TITLE
[User model] [Fix] User login before subscription create

### DIFF
--- a/__test__/support/constants.ts
+++ b/__test__/support/constants.ts
@@ -25,3 +25,42 @@ export const DUMMY_EXTERNAL_ID = "rodrigo";
 export const DUMMY_EXTERNAL_ID_2 = "iryna";
 export const DUMMY_SUBSCRIPTION_ID = "4444444444-5555555555-6666666666";
 export const DUMMY_MODEL_ID = "0000000000";
+
+/* REQUEST CONSTANTS */
+export const DUMMY_GET_USER_REQUEST_WITH_PUSH_SUB = {
+    "result": {
+        "properties": {
+            "language": "en",
+            "timezone_id": "America/New_York",
+            "first_active": 1689826588,
+            "last_active": 1689826588
+        },
+        "identity": {
+            "external_id": DUMMY_EXTERNAL_ID,
+            "onesignal_id": DUMMY_ONESIGNAL_ID,
+        },
+        "subscriptions": [
+            {
+                "id": DUMMY_SUBSCRIPTION_ID,
+                "app_id": APP_ID,
+                "type": "ChromePush",
+                "token": DUMMY_PUSH_TOKEN,
+                "enabled": false,
+                "notification_types": -2,
+                "session_time": 0,
+                "session_count": 1,
+                "sdk": "160000",
+                "device_model": "MacIntel",
+                "device_os": "114",
+                "rooted": false,
+                "test_type": 0,
+                "app_version": "",
+                "net_type": 0,
+                "carrier": "",
+                "web_auth": "R5dzF/EvmUbv0IsM3Ria7g==",
+                "web_p256": "BNWNgguO0F+id4MjCW2V98cwPiXHs0XyPUOCqlU0OgyqG4W9V3H1R799goSjSSgZ0CMI+7/nZYiVl1bB8ZnDZx0="
+            }
+        ]
+    },
+    "status": 200
+}

--- a/__test__/support/helpers/login.ts
+++ b/__test__/support/helpers/login.ts
@@ -1,15 +1,13 @@
 import SdkEnvironment from "../../../src/shared/managers/SdkEnvironment";
-import { CoreModuleDirector } from "../../../src/core/CoreModuleDirector";
 import PushSubscriptionNamespace from "../../../src/onesignal/PushSubscriptionNamespace";
-import LoginManager from "../../../src/page/managers/LoginManager";
 import MainHelper from "../../../src/shared/helpers/MainHelper";
 import Database from "../../../src/shared/services/Database";
-import { DUMMY_PUSH_TOKEN } from "../constants";
+import { DUMMY_PUSH_TOKEN, DUMMY_GET_USER_REQUEST_WITH_PUSH_SUB, } from "../constants";
+import { RequestService } from "../../../src/core/requestService/RequestService";
 
 export function setupLoginStubs() {
-  test.stub(CoreModuleDirector.prototype, "resetModelRepoAndCache", Promise.resolve());
   test.stub(PushSubscriptionNamespace.prototype, "_resubscribeToPushModelChanges", Promise.resolve());
-  test.stub(LoginManager, "fetchAndHydrate", Promise.resolve());
+  test.stub(RequestService, "getUser", Promise.resolve(DUMMY_GET_USER_REQUEST_WITH_PUSH_SUB));
   test.stub(SdkEnvironment, "getWindowEnv");
   test.stub(MainHelper, "getCurrentPushToken", Promise.resolve(DUMMY_PUSH_TOKEN));
   test.stub(Database.prototype, "getSubscription", Promise.resolve({

--- a/__test__/unit/user/login.test.ts
+++ b/__test__/unit/user/login.test.ts
@@ -190,3 +190,25 @@ describe('Login tests', () => {
 
   test('If login with JWT token, save it to the database', async () => {});
 });
+
+
+test('Login called before any Subscriptions, should save external_id but not create User', async () => {
+  setupLoginStubs();
+  await TestEnvironment.initialize();
+  test.nock({});
+
+  OneSignal.coreDirector.add(
+    ModelName.Identity,
+    getDummyIdentityOSModel()
+  );
+
+  const createUserSpy = jest.spyOn(RequestService, 'createUser');
+
+  await LoginManager.login(DUMMY_EXTERNAL_ID);
+
+  expect(OneSignal.coreDirector.getIdentityModel().data.external_id)
+    .toBe(DUMMY_EXTERNAL_ID);
+
+  // User should NOT be created, as we have no subscriptions yet.
+  expect(createUserSpy.mock.calls.length).toBe(0);
+});

--- a/__test__/unit/user/login.test.ts
+++ b/__test__/unit/user/login.test.ts
@@ -1,4 +1,3 @@
-import ModelCache from "../../../src/core/caching/ModelCache";
 import { TestEnvironment } from "../../support/environment/TestEnvironment";
 import Database from "../../../src/shared/services/Database";
 import LoginManager from "../../../src/page/managers/LoginManager";
@@ -19,7 +18,6 @@ jest.mock("../../../src/shared/libraries/Log");
 describe('Login tests', () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    test.stub(ModelCache.prototype, 'load', Promise.resolve({}));
     test.stub(PropertiesExecutor.prototype, 'getOperationsFromCache', Promise.resolve([]));
     test.stub(IdentityExecutor.prototype, 'getOperationsFromCache', Promise.resolve([]));
     test.stub(SubscriptionExecutor.prototype, 'getOperationsFromCache', Promise.resolve([]));
@@ -46,13 +44,16 @@ describe('Login tests', () => {
   });
 
   test('Login twice with same user -> only one call to identify user', async () => {
-    await TestEnvironment.initialize({ useMockIdentityModel: true });
+    await TestEnvironment.initialize({ 
+      useMockIdentityModel: true,
+      useMockPushSubscriptionModel: true,
+    });
     setupLoginStubs();
 
     const identifyOrUpsertUserSpy = test.stub(LoginManager, 'identifyOrUpsertUser', Promise.resolve({
       identity: {
         external_id: DUMMY_EXTERNAL_ID,
-        onesignal_id: "1234567890",
+        onesignal_id: DUMMY_ONESIGNAL_ID,
       }
     }));
 

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -258,16 +258,16 @@ export default class LoginManager {
    * otherwise contain any existing user a aliases
    */
   static stripAliasesOtherThanExternalId(userData: Partial<UserData>): void {
-    logMethodCall("LoginManager.prepareIdentityForUpsert", { userData });
+    logMethodCall("LoginManager.stripAliasesOtherThanExternalId", { userData });
 
     const { identity } = userData;
     if (!identity) {
-      throw new OneSignalError("prepareIdentityForUpsert failed: no identity found");
+      throw new OneSignalError("stripAliasesOtherThanExternalId failed: no identity found");
     }
 
     const { external_id } = identity;
     if (!external_id) {
-      throw new OneSignalError("prepareIdentityForUpsert failed: no external_id found");
+      throw new OneSignalError("stripAliasesOtherThanExternalId failed: no external_id found");
     }
 
     const newIdentity = { external_id };

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -86,7 +86,8 @@ export default class LoginManager {
         const onesignalId = result?.identity?.onesignal_id;
 
         if (!onesignalId) {
-          throw new OneSignalError('Login: No OneSignal ID found');
+          Log.info("Caching login call, waiting on network or subscription creation.");
+          return;
         }
         await LoginManager.fetchAndHydrate(onesignalId);
       } catch (e) {

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -61,19 +61,24 @@ export default class LoginManager {
       LoginManager.setExternalId(identityModel, externalId);
 
       let userData: Partial<UserData>;
-      const pushSubscription = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
       if (!isIdentified) {
+        // Guest User -> Logged In User
+        //    If login was not called before we want to keep all data from the "Guest User".
         userData = await UserDirector.getAllUserData();
       } else {
+        // Stripping all other Aliases, The REST API POST /users API only allows one. (as of 2023/07/19)
         userData = {
           identity: {
             external_id: externalId,
           }
         };
 
+        const pushSubscription = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
         if (pushSubscription) {
           userData.subscriptions = [pushSubscription.data];
         }
+        // We don't want to carry over tags and other properties from the current User if we are switching Users.
+        //   - Example switching from User A to User B.
       }
       await OneSignal.coreDirector.resetModelRepoAndCache();
       await UserDirector.initializeUser(true);

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -205,8 +205,16 @@ export default class LoginManager {
 
       const { identity } = userData;
 
-      if (!identity || !onesignalId) {
+
+      if (!identity) {
         throw new OneSignalError("identifyUser failed: no identity found");
+      }
+
+      if (!onesignalId) {
+        // Persist to disk so it is used once we have the opportunity to create a User.
+        const identityModel = OneSignal.coreDirector.getIdentityModel();
+        identityModel?.set(AliasPair.EXTERNAL_ID, identity.external_id, false);
+        return userData;
       }
 
       const appId = await MainHelper.getAppId();


### PR DESCRIPTION
# Description
## 1 Line Summary
If `OneSignal.login` is called before notifications are accepted no longer error and cache value to create the User when possible.

## Details

# Validation
Tested on Chrome on macOS
## Tests
Added new test reproducing issue, confirming the test failed and passed afterwards.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1058)
<!-- Reviewable:end -->
