### PR TITLE
[User Model] [CD] [CI] Update Ubuntu version and remove no longer needed Python2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,8 +17,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install Yarn
-        run: npm install -g yarn
       - name: "[Setup] Install dependencies"
         run: yarn
       - name: "[Build] Staging"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,9 +5,7 @@ on:
 
 jobs:
   test_build_deploy:
-    runs-on: ubuntu-20.04
-    container:
-      image: python:2.7.18-buster
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -21,9 +19,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install Yarn
         run: npm install -g yarn
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '2.7'
       - name: "[Setup] Install dependencies"
         run: yarn
       - name: "[Build] Staging"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install Yarn
-        run: npm install -g yarn
       - name: "[Setup] Install dependencies"
         run: yarn
       - name: "[Test] Run linters"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
-    container:
-      image: python:2.7.18-buster
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     },
     {
       "path": "./build/bundles/OneSignalSDK.sw.js",
-      "maxSize": "40 kB",
+      "maxSize": "41 kB",
       "compression": "gzip"
     },
     {


### PR DESCRIPTION
# Description
## 1 Line Summary
Remove old Python2 from CI/CD that is no longer used and updated to ubuntu-22.04.

## Details
We want to ensure we aren't running Python2 as it is no longer being updated. Also needed to bump ServiceWorker size check by 1KB as it started failing since an early rebase.

# Validation
## Tests
Ensured both CI and CD task ran successfully on Github.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1060)
<!-- Reviewable:end -->
