### PR TITLE
[User Model] [Fix] Erroring on User property updates before push subscription create

### DIFF
--- a/__test__/unit/core/requestService/userPropertyRequests.test.ts
+++ b/__test__/unit/core/requestService/userPropertyRequests.test.ts
@@ -4,7 +4,7 @@ import UserPropertyRequests from "../../../../src/core/requestService/UserProper
 import { ModelName } from "../../../../src/core/models/SupportedModels";
 import { UserPropertiesModel } from "../../../../src/core/models/UserPropertiesModel";
 import { OSModel } from "../../../../src/core/modelRepo/OSModel";
-import ExecutorResult from "../../../../src/core/executors/ExecutorResult";
+import { ExecutorResultFailNotRetriable } from "../../../../src/core/executors/ExecutorResult";
 import Database from "../../../../src/shared/services/Database";
 
 describe('User Property Request tests', () => {
@@ -29,7 +29,7 @@ describe('User Property Request tests', () => {
 
         const result = await UserPropertyRequests.updateUserProperties(operation);
 
-        expect(result).toStrictEqual(new ExecutorResult(false, false));
+        expect(result).toStrictEqual(new ExecutorResultFailNotRetriable());
     });
 
 });

--- a/__test__/unit/core/requestService/userPropertyRequests.test.ts
+++ b/__test__/unit/core/requestService/userPropertyRequests.test.ts
@@ -1,0 +1,35 @@
+import { Operation } from "../../../../src/core/operationRepo/Operation";
+import { CoreChangeType } from "../../../../src/core/models/CoreChangeType";
+import UserPropertyRequests from "../../../../src/core/requestService/UserPropertyRequests";
+import { ModelName } from "../../../../src/core/models/SupportedModels";
+import { UserPropertiesModel } from "../../../../src/core/models/UserPropertiesModel";
+import { OSModel } from "../../../../src/core/modelRepo/OSModel";
+import ExecutorResult from "../../../../src/core/executors/ExecutorResult";
+import Database from "../../../../src/shared/services/Database";
+
+describe('User Property Request tests', () => {
+
+    beforeAll(() => {
+        // Required for Operation class
+        test.stub(Database.prototype, 'getJWTToken', Promise.resolve([]));
+    });
+
+    test('updateUserProperties returns no retry failure result', async () => {
+        const delta = {
+            changeType: CoreChangeType.Update,
+            model: new OSModel(ModelName.Properties, {}),
+            property: "tags",
+            newValue: { key: "value" },
+        };
+        const operation = new Operation<UserPropertiesModel>(
+            CoreChangeType.Update,
+            ModelName.Properties,
+            [delta],
+        );
+
+        const result = await UserPropertyRequests.updateUserProperties(operation);
+
+        expect(result).toStrictEqual(new ExecutorResult(false, false));
+    });
+
+});

--- a/src/core/executors/ExecutorBase.ts
+++ b/src/core/executors/ExecutorBase.ts
@@ -5,7 +5,7 @@ import { ExecutorConfig } from "../models/ExecutorConfig";
 import { Operation } from "../operationRepo/Operation";
 import { logMethodCall } from "../../shared/utils/utils";
 import { SupportedModel } from "../models/SupportedModels";
-import ExecutorResult from "./ExecutorResult";
+import { ExecutorResult } from "./ExecutorResult";
 import Log from "../../shared/libraries/Log";
 import Database from "../../shared/services/Database";
 import LocalStorage from "../../shared/utils/LocalStorage";

--- a/src/core/executors/ExecutorResult.ts
+++ b/src/core/executors/ExecutorResult.ts
@@ -1,28 +1,28 @@
-export default interface ExecutorResult<Model> {
+export interface ExecutorResult<Model> {
   readonly success: boolean,
   readonly retriable: boolean,
   readonly result?: Model
 }
 
 export class ExecutorResultSuccess<Model> implements ExecutorResult<Model> {
-  success = true;
-  retriable = false;
+  readonly success = true;
+  readonly retriable = false;
   constructor(readonly result?: Model) {
 
   }
 }
 
 export class ExecutorResultFailRetriable<Model> implements ExecutorResult<Model> {
-  success = false;
-  retriable = true;
+  readonly success = false;
+  readonly retriable = true;
   constructor(readonly result?: Model) {
 
   }
 }
 
 export class ExecutorResultFailNotRetriable<Model> implements ExecutorResult<Model> {
-  success = false;
-  retriable = false;
+  readonly success = false;
+  readonly retriable = false;
   constructor(readonly result?: Model) {
 
   }

--- a/src/core/executors/ExecutorResult.ts
+++ b/src/core/executors/ExecutorResult.ts
@@ -1,7 +1,29 @@
-export default class ExecutorResult<Model> {
-  constructor(
-    readonly success: boolean,
-    readonly retriable: boolean,
-    readonly result?: Model
-    ){}
+export default interface ExecutorResult<Model> {
+  readonly success: boolean,
+  readonly retriable: boolean,
+  readonly result?: Model
+}
+
+export class ExecutorResultSuccess<Model> implements ExecutorResult<Model> {
+  success = true;
+  retriable = false;
+  constructor(readonly result?: Model) {
+
+  }
+}
+
+export class ExecutorResultFailRetriable<Model> implements ExecutorResult<Model> {
+  success = false;
+  retriable = true;
+  constructor(readonly result?: Model) {
+
+  }
+}
+
+export class ExecutorResultFailNotRetriable<Model> implements ExecutorResult<Model> {
+  success = false;
+  retriable = false;
+  constructor(readonly result?: Model) {
+
+  }
 }

--- a/src/core/models/ExecutorConfig.ts
+++ b/src/core/models/ExecutorConfig.ts
@@ -1,4 +1,4 @@
-import ExecutorResult from "../executors/ExecutorResult";
+import { ExecutorResult } from "../executors/ExecutorResult";
 import { Operation } from "../operationRepo/Operation";
 import { ModelName, SupportedModel } from "./SupportedModels";
 

--- a/src/core/requestService/IdentityRequests.ts
+++ b/src/core/requestService/IdentityRequests.ts
@@ -1,7 +1,8 @@
 import OneSignalApiBaseResponse from "../../shared/api/OneSignalApiBaseResponse";
 import { logMethodCall } from "../../shared/utils/utils";
 import OneSignalError from "../../shared/errors/OneSignalError";
-import ExecutorResult, {
+import {
+  ExecutorResult,
   ExecutorResultFailNotRetriable,
   ExecutorResultFailRetriable,
   ExecutorResultSuccess

--- a/src/core/requestService/IdentityRequests.ts
+++ b/src/core/requestService/IdentityRequests.ts
@@ -1,7 +1,11 @@
 import OneSignalApiBaseResponse from "../../shared/api/OneSignalApiBaseResponse";
 import { logMethodCall } from "../../shared/utils/utils";
 import OneSignalError from "../../shared/errors/OneSignalError";
-import ExecutorResult from "../executors/ExecutorResult";
+import ExecutorResult, {
+  ExecutorResultFailNotRetriable,
+  ExecutorResultFailRetriable,
+  ExecutorResultSuccess
+} from "../executors/ExecutorResult";
 import { IdentityModel } from "../models/IdentityModel";
 import { Operation } from "../operationRepo/Operation";
 import { isIdentityObject } from "../utils/typePredicates";
@@ -56,14 +60,14 @@ export default class IdentityRequests {
         throw new OneSignalError(`processIdentityResponse: result ${identity} is not an identity object`);
       }
 
-      return new ExecutorResult(true, true, identity);
+      return new ExecutorResultSuccess(identity);
     }
 
     // shouldn't impact login since doesn't go through core module (special 409 case)
     if (status >= 400 && status < 500) {
-      return new ExecutorResult(false, false);
+      return new ExecutorResultFailNotRetriable();
     }
 
-    return new ExecutorResult(false, true);
+    return new ExecutorResultFailRetriable();
   }
 }

--- a/src/core/requestService/SubscriptionRequests.ts
+++ b/src/core/requestService/SubscriptionRequests.ts
@@ -1,7 +1,8 @@
 import MainHelper from "../../shared/helpers/MainHelper";
 import OneSignalError from "../../shared/errors/OneSignalError";
 import { logMethodCall } from "../../shared/utils/utils";
-import ExecutorResult, {
+import {
+  ExecutorResult,
   ExecutorResultFailNotRetriable,
   ExecutorResultFailRetriable,
   ExecutorResultSuccess

--- a/src/core/requestService/SubscriptionRequests.ts
+++ b/src/core/requestService/SubscriptionRequests.ts
@@ -1,7 +1,11 @@
 import MainHelper from "../../shared/helpers/MainHelper";
 import OneSignalError from "../../shared/errors/OneSignalError";
 import { logMethodCall } from "../../shared/utils/utils";
-import ExecutorResult from "../executors/ExecutorResult";
+import ExecutorResult, {
+  ExecutorResultFailNotRetriable,
+  ExecutorResultFailRetriable,
+  ExecutorResultSuccess
+} from "../executors/ExecutorResult";
 import { SupportedSubscription } from "../models/SubscriptionModels";
 import { Operation } from "../operationRepo/Operation";
 import { processSubscriptionOperation } from "./helpers";
@@ -71,13 +75,13 @@ export default class SubscriptionRequests {
           throw new OneSignalError(`processSubscriptionResponse: bad subscription object: ${subscription}`);
         }
 
-        return new ExecutorResult<SupportedSubscription>(true, true, subscription);
+        return new ExecutorResultSuccess<SupportedSubscription>(subscription);
       }
 
       if (status >= 400 && status < 500) {
-        return new ExecutorResult(false, false);
+        return new ExecutorResultFailNotRetriable();
       }
 
-      return new ExecutorResult(false, true);
+      return new ExecutorResultFailRetriable();
   }
 }

--- a/src/core/requestService/UserPropertyRequests.ts
+++ b/src/core/requestService/UserPropertyRequests.ts
@@ -7,6 +7,7 @@ import AliasPair from "./AliasPair";
 import { RequestService } from "./RequestService";
 import MainHelper from "../../shared/helpers/MainHelper";
 import OneSignalApiBaseResponse from "../../shared/api/OneSignalApiBaseResponse";
+import Log from "../../shared/libraries/Log";
 
 /**
  * This class contains logic for all the UserProperty model related requests that can be made to the OneSignal API
@@ -19,14 +20,13 @@ export default class UserPropertyRequests {
     const propertiesModel = operation.model;
     const properties = propertiesModel?.data;
 
-    // fixes typescript errors
     if (!properties || !propertiesModel) {
       throw new OneSignalError(`updateUserProperty: bad identity model: ${propertiesModel}`);
     }
 
-    // fixes typescript errors
     if (!propertiesModel.onesignalId) {
-      throw new OneSignalError(`updateUserProperty: missing onesignalId: ${propertiesModel}`);
+      Log.info("Caching User Property update until subscription is created.");
+      return new ExecutorResult(false, false);
     }
 
     const aliasPair = new AliasPair(AliasPair.ONESIGNAL_ID, propertiesModel.onesignalId);

--- a/src/core/requestService/UserPropertyRequests.ts
+++ b/src/core/requestService/UserPropertyRequests.ts
@@ -1,6 +1,7 @@
 import { logMethodCall } from "../../shared/utils/utils";
 import OneSignalError from "../../shared/errors/OneSignalError";
-import ExecutorResult, {
+import {
+  ExecutorResult,
   ExecutorResultFailNotRetriable,
   ExecutorResultFailRetriable,
   ExecutorResultSuccess

--- a/src/core/requestService/UserPropertyRequests.ts
+++ b/src/core/requestService/UserPropertyRequests.ts
@@ -1,6 +1,10 @@
 import { logMethodCall } from "../../shared/utils/utils";
 import OneSignalError from "../../shared/errors/OneSignalError";
-import ExecutorResult from "../executors/ExecutorResult";
+import ExecutorResult, {
+  ExecutorResultFailNotRetriable,
+  ExecutorResultFailRetriable,
+  ExecutorResultSuccess
+} from "../executors/ExecutorResult";
 import { UserPropertiesModel } from "../models/UserPropertiesModel";
 import { Operation } from "../operationRepo/Operation";
 import AliasPair from "./AliasPair";
@@ -26,7 +30,7 @@ export default class UserPropertyRequests {
 
     if (!propertiesModel.onesignalId) {
       Log.info("Caching User Property update until subscription is created.");
-      return new ExecutorResult(false, false);
+      return new ExecutorResultFailNotRetriable();
     }
 
     const aliasPair = new AliasPair(AliasPair.ONESIGNAL_ID, propertiesModel.onesignalId);
@@ -47,13 +51,13 @@ export default class UserPropertyRequests {
       const { status, result } = response;
 
       if (status >= 200 && status < 300) {
-        return new ExecutorResult(true, true, result?.properties);
+        return new ExecutorResultSuccess(result?.properties);
       }
 
       if (status >= 400 && status < 500) {
-        return new ExecutorResult(false, false);
+        return new ExecutorResultFailNotRetriable();
       }
 
-      return new ExecutorResult(false, true);
+      return new ExecutorResultFailRetriable();
   }
 }


### PR DESCRIPTION
# Description
## 1 Line Summary
Fixes an error where any User property update before a push subscribed is crated causes the SDK to throw.

## Details

# Validation
## Tests
* Added new automated test
* Manually tested by calling `OneSignal.User.addTag("key", "value");` then accepting notifications, ensuring the User create call included the tags.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1061)
<!-- Reviewable:end -->
