### PR TITLE
[User model] [Fix] macOS Safari prompting and subscribing

### DIFF
--- a/src/shared/helpers/InitHelper.ts
+++ b/src/shared/helpers/InitHelper.ts
@@ -118,6 +118,8 @@ export default class InitHelper {
     await OneSignalEvent.trigger(OneSignal.EVENTS.SDK_INITIALIZED);
   }
 
+  // In-Addition to registering for push, this shows a native browser
+  // notification permission prompt, if needed.
   public static async registerForPushNotifications(options: RegisterOptions = {}): Promise<void> {
     if (options && options.modalPrompt) {
       /* Show the HTTPS fullscreen modal permission message. */
@@ -146,15 +148,7 @@ export default class InitHelper {
       return;
     }
 
-    /*
-     * We don't want to resubscribe if the user is opted out, and we can't check on HTTP, because the promise will
-     * prevent the popup from opening.
-     */
-    const subscription = await Database.getSubscription();
-    const isOptedOut = subscription.optedOut;
-    if (!isOptedOut) {
-      await SubscriptionHelper.registerForPush();
-    }
+    await SubscriptionHelper.registerForPush();
   }
 
   /**

--- a/src/shared/helpers/InitHelper.ts
+++ b/src/shared/helpers/InitHelper.ts
@@ -364,14 +364,15 @@ export default class InitHelper {
     try {
       if (navigator.permissions) {
         const permissionStatus = await navigator.permissions.query({ name: 'notifications' });
+        // NOTE: Safari 16.4 has a bug where onchange callback never fires
         permissionStatus.onchange = function() {
           triggerNotificationPermissionChanged();
         };
       }
     } catch (e) {
-      // navigator.permissions.query({ name: 'notifications' }) currently not supported on Safari 16 (beta)
-      // as of June 2022
-      Log.warn(`Could not install native prompt permission change hook w/ error: ${e}`);
+      // Some browsers (Safari 16.3 and older) have the API navigator.permissions.query, but don't support the
+      // { name: 'notifications' } param and throws.
+      Log.warn(`Could not install native notification permission change hook w/ error: ${e}`);
     }
   }
 

--- a/src/shared/helpers/MainHelper.ts
+++ b/src/shared/helpers/MainHelper.ts
@@ -12,7 +12,7 @@ import Database from '../services/Database';
 import OneSignalUtils from '../utils/OneSignalUtils';
 import { PermissionUtils } from '../utils/PermissionUtils';
 import OneSignalEvent from '../services/OneSignalEvent';
-import { supportsVapidPush } from '../../page/utils/BrowserSupportsPush';
+import Environment from './Environment';
 
 export default class MainHelper {
 
@@ -219,8 +219,7 @@ export default class MainHelper {
 
   // TO DO: unit test
   static async getCurrentPushToken(): Promise<string | undefined> {
-    // legacy safari (<16)
-    if (window.safari && !supportsVapidPush()) {
+    if (Environment.useSafariLegacyPush()) {
       const safariToken = window.safari?.pushNotification?.permission(OneSignal.config.safariWebId).deviceToken;
       return safariToken?.toLowerCase() || undefined;
     }

--- a/src/shared/helpers/SubscriptionHelper.ts
+++ b/src/shared/helpers/SubscriptionHelper.ts
@@ -11,8 +11,8 @@ import Log from '../libraries/Log';
 import { ContextSWInterface } from '../models/ContextSW';
 import SdkEnvironment from '../managers/SdkEnvironment';
 import { EnvironmentInfo } from '../../page/models/EnvironmentInfo';
-import { Browser } from '../models/Browser';
 import { PermissionUtils } from '../utils/PermissionUtils';
+import Environment from './Environment';
 
 export default class SubscriptionHelper {
   public static async registerForPush(): Promise<Subscription | null> {
@@ -117,7 +117,7 @@ export default class SubscriptionHelper {
     return subscription;
   }
 
-  static getRawPushSubscriptionForSafari(safariWebId: string): RawPushSubscription {
+  static getRawPushSubscriptionForLegacySafari(safariWebId: string): RawPushSubscription {
     const subscription = new RawPushSubscription();
 
     const { deviceToken: existingDeviceToken } = window.safari.pushNotification.permission(safariWebId);
@@ -145,8 +145,8 @@ export default class SubscriptionHelper {
   static async getRawPushSubscription(
     environmentInfo: EnvironmentInfo, safariWebId: string
   ):Promise<RawPushSubscription | null> {
-    if (environmentInfo.browserType === Browser.Safari) {
-      return SubscriptionHelper.getRawPushSubscriptionForSafari(safariWebId);
+    if (Environment.useSafariLegacyPush()) {
+      return SubscriptionHelper.getRawPushSubscriptionForLegacySafari(safariWebId);
     }
 
     if (environmentInfo.isUsingSubscriptionWorkaround) {

--- a/src/sw/serviceWorker/ServiceWorker.ts
+++ b/src/sw/serviceWorker/ServiceWorker.ts
@@ -1,5 +1,3 @@
-import bowser from "bowser";
-
 import Environment from "../../shared/helpers/Environment";
 import ContextSW from "../../shared/models/ContextSW";
 import Database from "../../shared/services/Database";
@@ -33,6 +31,7 @@ import { RawPushSubscription } from "../../../src/shared/models/RawPushSubscript
 import { DeliveryPlatformKind } from "../../shared/models/DeliveryPlatformKind";
 import { NotificationClickEvent } from "../../page/models/NotificationEvent";
 import { RawNotificationPayload } from "../../shared/models/RawNotificationPayload";
+import { bowserCastle } from "../../shared/utils/bowserCastle";
 
 declare const self: ServiceWorkerGlobalScope & OSServiceWorkerFields;
 
@@ -73,13 +72,6 @@ export class ServiceWorker {
    */
   static get database() {
     return Database;
-  }
-
-  /**
-   * Describes the current browser name and version.
-   */
-  static get browser() {
-    return bowser;
   }
 
   /**
@@ -392,7 +384,7 @@ export class ServiceWorker {
    * to be safe we are disabling it for all Safari browsers.
   */
   static browserSupportsConfirmedDelivery(): boolean {
-    return !bowser.safari
+    return bowserCastle().name !== 'safari'
   }
 
   /**


### PR DESCRIPTION
# Description
## 1 Line Summary
Fix macOS Safari error "Push notification prompting can only be done from a user gesture." when prompting for notification permission and registering for push.

## Details
* Safari's legacy prompting API (`window.safari.pushNotification.requestPermission()`) doesn't allow awaiting for any I/O which was causing the prompting error. Commits:
    - b724a625d0ee764b12fbe75787614fedb899208d
    - 04c97aed1731552a7e7a12dc73f97c73179bc1f8
* After prompting was fixed Safari wasn't registering for push due to a few changes that didn't come over correctly from PR #1002. Commits:
   - 03d59892ee6c098052eef2252ddd0a6dc489af5b

# Validation
## Tests
* Tested with Safari 16.4 on macOS 13.3.1, ensured prompting worked and a subscription record was created on OneSignal's server.
* Tested end-to-end with iOS 16.5, ensuring notifications display as well.
   - Unsure if this was working before this PR, since it works different from macOS Safari
* Tested refreshing the page to ensure no behavior changes with session counts. (referring to changes in commit b724a625d0ee764b12fbe75787614fedb899208d)
* Automated tests were not added since it isn't feasible to cover all I/O Promises that could happen in the chain. Additionally Legacy Safari will be deprecated in the future.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1062)
<!-- Reviewable:end -->
