### PR TITLE
[User Model] [Dev Env] Ngrok url reading fix

### DIFF
--- a/build/scripts/ngrok.sh
+++ b/build/scripts/ngrok.sh
@@ -19,7 +19,7 @@ startNgrokHTTPSForwarding() {
     sleep 5
 
     # Get the ngrok url
-    read -r rawurl < <(grep -o "https://[^ ]*\.ngrok\.io" ngrok.log)
+    read -r rawurl < <(curl localhost:4040/api/tunnels | jq -r '.tunnels | .[0] | .public_url')
     url=$(echo $rawurl | sed 's/https:\/\///')
     echo "ngrok url: $url"
     rm -f ngrok_last_url


### PR DESCRIPTION
# Description
## 1 Line Summary
Ngrok changed their URL format, instead of parsing from the log read the URL from the localhost service JSON API.

## Details
# Validation
## Tests
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1063)
<!-- Reviewable:end -->
