### PR TITLE
[User Model] [Fix] OneSignal.User.PushSubscription.id always undefined, until you refresh the page

### DIFF
--- a/__test__/support/helpers/login.ts
+++ b/__test__/support/helpers/login.ts
@@ -1,12 +1,10 @@
 import SdkEnvironment from "../../../src/shared/managers/SdkEnvironment";
-import PushSubscriptionNamespace from "../../../src/onesignal/PushSubscriptionNamespace";
 import MainHelper from "../../../src/shared/helpers/MainHelper";
 import Database from "../../../src/shared/services/Database";
 import { DUMMY_PUSH_TOKEN, DUMMY_GET_USER_REQUEST_WITH_PUSH_SUB, } from "../constants";
 import { RequestService } from "../../../src/core/requestService/RequestService";
 
 export function setupLoginStubs() {
-  test.stub(PushSubscriptionNamespace.prototype, "_resubscribeToPushModelChanges", Promise.resolve());
   test.stub(RequestService, "getUser", Promise.resolve(DUMMY_GET_USER_REQUEST_WITH_PUSH_SUB));
   test.stub(SdkEnvironment, "getWindowEnv");
   test.stub(MainHelper, "getCurrentPushToken", Promise.resolve(DUMMY_PUSH_TOKEN));

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -83,9 +83,6 @@ export default class LoginManager {
       await OneSignal.coreDirector.resetModelRepoAndCache();
       await UserDirector.initializeUser(true);
 
-      // use optional chaining to prevent errors if the namespace is not initialized (e.g. in unit tests)
-      await OneSignal.User?.PushSubscription?._resubscribeToPushModelChanges();
-
       try {
         const result = await LoginManager.identifyOrUpsertUser(userData, isIdentified, currentPushSubscriptionId);
         const onesignalId = result?.identity?.onesignal_id;
@@ -130,7 +127,6 @@ export default class LoginManager {
     // add the push subscription model back to the repo since we need at least 1 sub to create a new user
     OneSignal.coreDirector.add(ModelName.PushSubscriptions, pushSubModel as OSModel<SupportedModel>, false);
     await UserDirector.initializeUser(false);
-    await OneSignal.User.PushSubscription._resubscribeToPushModelChanges();
   }
 
   static setExternalId(identityOSModel: OSModel<SupportedIdentity>, externalId: string): void {


### PR DESCRIPTION


# Description
## 1 Line Summary
Fix `OneSignal.User.PushSubscription.id` always `undefined`, until you refresh the page.

## Details
`OneSignal.coreDirector.getCurrentPushSubscriptionModel()` was used to attempt to listen when the `PushSubscription.id` becomes available from it's internal `_subscribeToPushModelChanges` however this doesn't work if there isn't a subscription yet.

This is a short term fix to make things more consistent by using the `SUBSCRIPTION_CHANGED` event already being using for token updates.

Long term would be would be to make PushSubscriptionNamespace listen to an event on another class in charge of adding a Subscription to a User, so the global `SUBSCRIPTION_CHANGED` can be removed.
  - `LoginManager` isn't it either, which is why this path wasn't picked

# Validation
## Tests
Tested manually on Chrome on macOS and the id now becomes available after accepting notifications.
No automated tests added, planing on making larger changes in the near term.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1069)
<!-- Reviewable:end -->
