### PR TITLE
[User Model] [Fix] Safari on macOS native prompt not showing from category slidedown 

### DIFF
--- a/src/page/managers/slidedownManager/SlidedownManager.ts
+++ b/src/page/managers/slidedownManager/SlidedownManager.ts
@@ -8,7 +8,6 @@ import PermissionMessageDismissedError from "../../errors/PermissionMessageDismi
 import { NotificationPermission } from "../../../shared/models/NotificationPermission";
 import { OneSignalUtils } from "../../../shared/utils/OneSignalUtils";
 import ChannelCaptureContainer from "../../slidedown/ChannelCaptureContainer";
-import LocalStorage from "../../../shared/utils/LocalStorage";
 import ConfirmationToast from "../../slidedown/ConfirmationToast";
 import { awaitableTimeout } from "../../../shared/utils/AwaitableTimeout";
 import { DismissPrompt } from "../../models/Dismiss";
@@ -126,15 +125,8 @@ export class SlidedownManager {
     const tags = TaggingContainer.getValuesFromTaggingContainer();
     this.context.tagManager.storeTagValuesToUpdate(tags);
 
-    const isPushEnabled: boolean = await OneSignal.context.subscriptionManager.isPushNotificationsEnabled();
-    if (isPushEnabled) {
-      // already subscribed, send tags immediately
-      this.slidedown.setSaveState();
-      await this.context.tagManager.sendTags(true);
-    } else {
-      this.registerForPush();
-      // tags are sent on the subscription change event handler
-    }
+    this.registerForPush();
+    await this.context.tagManager.sendTags(true);
   }
 
   private async handleAllowForEmailType(): Promise<void> {


### PR DESCRIPTION
# Description
## 1 Line Summary
Fix Safari on macOS native prompt not showing from category slidedown.

## Details
There is no need to check if we are subscribed, tags are now saved to cache and we can safely use registerForPush without have to worry about it causing any side effect as well.

This solves the I/O not allowed problem Safari macOS prompting has while showing the native notification permission prompt like commit b724a625d0ee764b12fbe75787614fedb899208d

# Validation
## Tests
Tested on Safari 16.4 on macOS 13.3.1, ensuring I can accept notifications from the category slidedown prompt. Also ensuring that tags get updated if I change the options afterwards.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets
The Category slidedown was missed in PR #1062, which originally fixed some of these Safari on macOS prompting issues.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1070)
<!-- Reviewable:end -->
