### PR TITLE
[User Model] [Fix] Notification permission change event stop firing

### DIFF
--- a/src/shared/utils/PermissionUtils.ts
+++ b/src/shared/utils/PermissionUtils.ts
@@ -14,8 +14,17 @@ export class PermissionUtils {
     if (PermissionUtils.executing) {
       return;
     }
-    PermissionUtils.executing = true;
 
+    PermissionUtils.executing = true;
+    try {
+      await PermissionUtils.privateTriggerNotificationPermissionChanged(updateIfIdentical);
+    }
+    finally {
+      PermissionUtils.executing = false;
+    }
+  }
+
+  private static async privateTriggerNotificationPermissionChanged(updateIfIdentical: boolean) {
     const newPermission: NotificationPermission = await OneSignal.context.permissionManager.getPermissionStatus();
     const previousPermission: NotificationPermission = await Database.get('Options', 'notificationPermission');
 
@@ -26,6 +35,5 @@ export class PermissionUtils {
 
     await Database.put('Options', { key: 'notificationPermission', value: newPermission });
     OneSignalEvent.trigger(OneSignal.EVENTS.NATIVE_PROMPT_PERMISSIONCHANGED, newPermission);
-    PermissionUtils.executing = false;
   }
 }


### PR DESCRIPTION
# Description
## 1 Line Summary
Fix bug where notification permission change would stop firing due to a bad state.

## Details
There was an early return on shouldBeUpdated that caused executing to never become false again. To prevent this issue with future code changes made a new privateTriggerNotificationPermissionChanged to encapsulate the executing state. Also added a try..finally to prevent throwing from creating a bad state.

# Validation
## Tests
Tested on Chrome on macOS. Toggle notifications on and off and observed bell icon and custom link change, where it was broken before.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets
Bug was introduced in PR #1050 
This PR mirrors the same fix from main's #1071 PR.

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1072)
<!-- Reviewable:end -->
