### PR TITLE
[User Model] [Fix] Wrong notifications type when disabling browser permission

### DIFF
--- a/__test__/unit/helpers/mainHelper.test.ts
+++ b/__test__/unit/helpers/mainHelper.test.ts
@@ -19,6 +19,6 @@ describe('MainHelper Tests', () => {
   test('getCurrentNotificationType for default permission', async () => {
     test.stub(OneSignal.context.permissionManager, 'getNotificationPermission', NotificationPermission.Default);
     const result = await MainHelper.getCurrentNotificationType();
-    expect(result).toBe(SubscriptionStateKind.Default);
+    expect(result).toBe(SubscriptionStateKind.NoNativePermission);
   });
 });

--- a/__test__/unit/pushSubscription/nativePermissionChange.test.ts
+++ b/__test__/unit/pushSubscription/nativePermissionChange.test.ts
@@ -29,7 +29,7 @@ describe('Notification Types are set correctly on subscription change', () => {
     await EventHelper.checkAndTriggerSubscriptionChanged();
 
     // check that the set function was called at least once with the correct value
-    expect(osModelSetSpy).toHaveBeenCalledWith('notification_types', SubscriptionStateKind.Default);
+    expect(osModelSetSpy).toHaveBeenCalledWith('notification_types', SubscriptionStateKind.NoNativePermission);
     expect(osModelSetSpy).toHaveBeenCalledWith('enabled', false);
   });
 

--- a/__test__/unit/pushSubscription/nativePermissionChange.test.ts
+++ b/__test__/unit/pushSubscription/nativePermissionChange.test.ts
@@ -6,6 +6,7 @@ import { DUMMY_PUSH_TOKEN } from "../../support/constants";
 import { initializeWithPermission } from "../../support/helpers/pushSubscription";
 import { PermissionManager } from "../../support/managers/PermissionManager";
 import { NotificationPermission } from "../../../src/shared/models/NotificationPermission";
+import { SubscriptionStateKind } from "../../../src/shared/models/SubscriptionStateKind";
 
 describe('Notification Types are set correctly on subscription change', () => {
   beforeEach(async () => {
@@ -18,7 +19,7 @@ describe('Notification Types are set correctly on subscription change', () => {
     jest.resetAllMocks();
   });
 
-  test('When native permission is rejected, we update notification_types to -2 & enabled to false', async () => {
+  test('When native permission is rejected, we update notification_types to 0 & enabled to false', async () => {
     await initializeWithPermission('granted');
     const osModelSetSpy = jest.spyOn(OSModel.prototype, 'set');
 
@@ -28,7 +29,7 @@ describe('Notification Types are set correctly on subscription change', () => {
     await EventHelper.checkAndTriggerSubscriptionChanged();
 
     // check that the set function was called at least once with the correct value
-    expect(osModelSetSpy).toHaveBeenCalledWith('notification_types', -2);
+    expect(osModelSetSpy).toHaveBeenCalledWith('notification_types', SubscriptionStateKind.Default);
     expect(osModelSetSpy).toHaveBeenCalledWith('enabled', false);
   });
 
@@ -42,7 +43,7 @@ describe('Notification Types are set correctly on subscription change', () => {
     await EventHelper.checkAndTriggerSubscriptionChanged();
 
     // check that the set function was called at least once with the correct value
-    expect(osModelSetSpy).toHaveBeenCalledWith('notification_types', 1);
+    expect(osModelSetSpy).toHaveBeenCalledWith('notification_types', SubscriptionStateKind.Subscribed);
     expect(osModelSetSpy).toHaveBeenCalledWith('enabled', true);
   });
 });

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -43,9 +43,9 @@ export default class EventHelper {
       `The user's subscription state changed from ` +
         `${lastKnownPushEnabled === null ? '(not stored)' : lastKnownPushEnabled} ⟶ ${isPushEnabled}`
     );
+
     // update notification_types via core module
-    const newNotificationTypes = isOptedIn ? 1 : -2;
-    await context.subscriptionManager.updatePushSubscriptionNotificationTypes(newNotificationTypes);
+    await context.subscriptionManager.updateNotificationTypes();
 
     const currentPushToken = await MainHelper.getCurrentPushToken();
     const pushModel: OSModel<SubscriptionModel> = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();

--- a/src/shared/helpers/MainHelper.ts
+++ b/src/shared/helpers/MainHelper.ts
@@ -43,19 +43,6 @@ export default class MainHelper {
   }
 
   /**
-   * If the user has manually opted out of notifications (OneSignal.User.PushSubscription.optOut),
-   * returns -2; otherwise returns 1.
-   * @param isOptedIn The result of OneSignal.getSubscription().
-   */
-  static getNotificationTypeFromOptIn(isOptedIn: boolean | null) {
-    if (isOptedIn == true || isOptedIn == null) {
-      return SubscriptionStateKind.Subscribed;
-    } else {
-      return SubscriptionStateKind.MutedByApi;
-    }
-  }
-
-  /**
    * Stores a flag in sessionStorage that we've already shown the HTTP slidedown to this user and that we should not
    * show it again until they open a new window or tab to the site.
    */

--- a/src/shared/helpers/MainHelper.ts
+++ b/src/shared/helpers/MainHelper.ts
@@ -21,25 +21,25 @@ export default class MainHelper {
       await OneSignal.context.permissionManager.getNotificationPermission(OneSignal.context.appConfig.safariWebId);
 
     if (currentPermission === NotificationPermission.Default) {
-      return SubscriptionStateKind.Default;
+      return SubscriptionStateKind.NoNativePermission;
     }
 
     if (currentPermission === NotificationPermission.Denied) {
       // Due to this issue https://github.com/OneSignal/OneSignal-Website-SDK/issues/289 we cannot reliably detect
       // "default" permission in HTTP context. Browser reports denied for both "default" and "denied" statuses.
-      // Returning SubscriptionStateKind.Default for this case.
+      // Returning SubscriptionStateKind.NoNativePermission for this case.
       return (OneSignalUtils.isUsingSubscriptionWorkaround()) ?
-        SubscriptionStateKind.Default :
+        SubscriptionStateKind.NoNativePermission :
         SubscriptionStateKind.NotSubscribed;
     }
 
     const existingUser = await OneSignal.context.subscriptionManager.isAlreadyRegisteredWithOneSignal();
     if (currentPermission === NotificationPermission.Granted && existingUser) {
       const isPushEnabled = await OneSignal.context.subscriptionManager.isPushNotificationsEnabled();
-      return  isPushEnabled ? SubscriptionStateKind.Subscribed : SubscriptionStateKind.MutedByApi;
+      return  isPushEnabled ? SubscriptionStateKind.Subscribed : SubscriptionStateKind.UserOptedOut;
     }
 
-    return SubscriptionStateKind.Default;
+    return SubscriptionStateKind.NoNativePermission;
   }
 
   /**

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -194,7 +194,7 @@ export class SubscriptionManager {
   async getNotificationTypes(): Promise<SubscriptionStateKind> {
     const { optedOut } = await Database.getSubscription();
     if (optedOut) {
-      return SubscriptionStateKind.MutedByApi;
+      return SubscriptionStateKind.UserOptedOut;
     }
 
     const permission = await OneSignal.context.permissionManager.getPermissionStatus();
@@ -202,7 +202,7 @@ export class SubscriptionManager {
       return SubscriptionStateKind.Subscribed;
     }
 
-    return SubscriptionStateKind.Default;
+    return SubscriptionStateKind.NoNativePermission;
   }
 
   async updatePushSubscriptionNotificationTypes(notificationTypes: SubscriptionStateKind): Promise<void> {

--- a/src/shared/models/SubscriptionStateKind.ts
+++ b/src/shared/models/SubscriptionStateKind.ts
@@ -1,7 +1,13 @@
 export enum SubscriptionStateKind {
-  Default = 0,
+  // Notification permission is not granted at the browser level.
+  // Used if the native notification permission is 'default' or 'declined'
+  NoNativePermission = 0,
+  // Everything is available for the subscription to be enabled;
+  // not opted out, has token, and notification permission is granted.
   Subscribed = 1,
-  MutedByApi = -2,
+  // OneSignal.User.PushSubscription.optOut() called or end-user opted out from SDK bell widget
+  // UserOptedOut takes priority over NoNativePermission
+  UserOptedOut = -2,
   NotSubscribed = -10,
   TemporaryWebRecord = -20,
   PermissionRevoked = -21,

--- a/test/unit/helpers/MainHelper.ts
+++ b/test/unit/helpers/MainHelper.ts
@@ -26,7 +26,7 @@ test("getCurrentNotificationType for default permission", async t => {
   sinonSandbox.stub(OneSignal.context.permissionManager, "getNotificationPermission")
     .resolves(NotificationPermission.Default);
 
-  t.is(await MainHelper.getCurrentNotificationType(), SubscriptionStateKind.Default);
+  t.is(await MainHelper.getCurrentNotificationType(), SubscriptionStateKind.NoNativePermission);
 });
 
 test("getCurrentNotificationType for denied permission in HTTP context", async t => {
@@ -34,7 +34,7 @@ test("getCurrentNotificationType for denied permission in HTTP context", async t
     .resolves(NotificationPermission.Denied);
   sinonSandbox.stub(OneSignalUtils, "isUsingSubscriptionWorkaround").returns(true);
 
-  t.is(await MainHelper.getCurrentNotificationType(), SubscriptionStateKind.Default);
+  t.is(await MainHelper.getCurrentNotificationType(), SubscriptionStateKind.NoNativePermission);
 });
 
 test("getCurrentNotificationType for denied permission in HTTPS context", async t => {
@@ -60,7 +60,7 @@ test("getCurrentNotificationType for granted permission: opted out", async t => 
   sinonSandbox.stub(OneSignal, "privateIsPushNotificationsEnabled").resolves(false);
   sinonSandbox.stub(OneSignal.context.subscriptionManager, "isAlreadyRegisteredWithOneSignal").resolves(true);
 
-  t.is(await MainHelper.getCurrentNotificationType(), SubscriptionStateKind.MutedByApi);
+  t.is(await MainHelper.getCurrentNotificationType(), SubscriptionStateKind.UserOptedOut);
 });
 
 test("getCurrentNotificationType for granted permission: new user", async t => {
@@ -68,5 +68,5 @@ test("getCurrentNotificationType for granted permission: new user", async t => {
     .resolves(NotificationPermission.Granted);
   sinonSandbox.stub(OneSignal.context.subscriptionManager, "isAlreadyRegisteredWithOneSignal").resolves(false);
 
-  t.is(await MainHelper.getCurrentNotificationType(), SubscriptionStateKind.Default);
+  t.is(await MainHelper.getCurrentNotificationType(), SubscriptionStateKind.NoNativePermission);
 });

--- a/test/unit/managers/UpdateManager.ts
+++ b/test/unit/managers/UpdateManager.ts
@@ -137,7 +137,7 @@ test("sendOnSessionUpdate triggers on_session for existing unsubscribed user if 
   sandbox.stub(Database, "getSubscription").resolves({ deviceId: Random.getRandomUuid() });
   sandbox.stub(OneSignal.context.pageViewManager, "isFirstPageView").returns(true);
   sandbox.stub(OneSignal.context.subscriptionManager, "isAlreadyRegisteredWithOneSignal").resolves(true);
-  sandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.MutedByApi);
+  sandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.UserOptedOut);
   OneSignal.config.enableOnSession = true;
 
   const onSessionSpy = sandbox.stub(OneSignal.context.sessionManager, "upsertSession").resolves();
@@ -154,7 +154,7 @@ test(
   sandbox.stub(Database, "getSubscription").resolves({ deviceId: Random.getRandomUuid() });
   sandbox.stub(OneSignal.context.pageViewManager, "isFirstPageView").returns(true);
   sandbox.stub(OneSignal.context.subscriptionManager, "isAlreadyRegisteredWithOneSignal").resolves(true);
-  sandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.MutedByApi);
+  sandbox.stub(MainHelper, "getCurrentNotificationType").resolves(SubscriptionStateKind.UserOptedOut);
   OneSignal.config.enableOnSession = false;
 
   const onSessionSpy = sandbox.stub(OneSignal.context.sessionManager, "upsertSession").resolves();


### PR DESCRIPTION
# Description
## 1 Line Summary
Fix reported notifications type when disabling browser permission, from -2 (api disabled) to 0 (no notification permissions).

## Details

# Validation
Tested on Chrome on macOS, disabling permission after accepting and observing the network call.
## Tests
Updated unit tests looking for the specific notification type.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1076)
<!-- Reviewable:end -->
