### PR TITLE
[User Model] [Fix] Update existing subscription on token changes instead of creating new

### DIFF
--- a/__test__/support/helpers/core.ts
+++ b/__test__/support/helpers/core.ts
@@ -5,7 +5,8 @@ import { CoreDelta } from "../../../src/core/models/CoreDeltas";
 import { SupportedSubscription, SubscriptionType } from "../../../src/core/models/SubscriptionModels";
 import { ModelName } from "../../../src/core/models/SupportedModels";
 import { DUMMY_MODEL_ID, DUMMY_PUSH_TOKEN, DUMMY_SUBSCRIPTION_ID } from "../constants";
-
+import CoreModule from "../../../src/core/CoreModule";
+import { CoreModuleDirector } from "../../../src/core/CoreModuleDirector";
 
 export function generateNewSubscription(modelId = '0000000000') {
   return new OSModel<SupportedSubscription>(
@@ -38,6 +39,13 @@ export function getDummyPushSubscriptionOSModel(): OSModel<SupportedSubscription
     id: DUMMY_SUBSCRIPTION_ID,
     token: DUMMY_PUSH_TOKEN,
   }, DUMMY_MODEL_ID);
+}
+
+// Requirement: Test must also call TestEnvironment.initialize();
+export async function getCoreModuleDirector(): Promise<CoreModuleDirector> {
+  const coreModule = new CoreModule();
+  await coreModule.init();
+  return new CoreModuleDirector(coreModule);
 }
 
 export const passIfBroadcastNTimes = (target: number, broadcastCount: number, pass: () => void) => {

--- a/__test__/unit/core/coreModuleDirector.test.ts
+++ b/__test__/unit/core/coreModuleDirector.test.ts
@@ -1,0 +1,46 @@
+import { CoreModuleDirector } from "../../../src/core/CoreModuleDirector";
+import { OSModel } from "../../../src/core/modelRepo/OSModel";
+import { SupportedSubscription } from "../../../src/core/models/SubscriptionModels";
+import { TestEnvironment } from "../../support/environment/TestEnvironment";
+import { getCoreModuleDirector, getDummyPushSubscriptionOSModel } from "../../support/helpers/core";
+
+describe('CoreModuleDirector tests', () => {
+  beforeEach(() => {
+    TestEnvironment.initialize();
+  });
+  describe('getPushSubscriptionModel', () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
+    async function getPushSubscriptionModel(): Promise<OSModel<SupportedSubscription> | undefined> {
+      return (await getCoreModuleDirector()).getPushSubscriptionModel();
+    }
+
+    test('returns undefined when it find no push records', async () => {
+      expect(await getPushSubscriptionModel()).toBe(undefined);
+    });
+
+    test('returns current subscription when available', async () => {
+      const pushModelCurrent = getDummyPushSubscriptionOSModel();
+      test.stub(CoreModuleDirector.prototype, "getPushSubscriptionModelByCurrentToken", Promise.resolve(pushModelCurrent));
+      expect(await getPushSubscriptionModel()).toBe(pushModelCurrent);
+    });
+
+    test('returns last known subscription when current is unavailable', async () => {
+      const pushModelLastKnown = getDummyPushSubscriptionOSModel();
+      test.stub(CoreModuleDirector.prototype, "getPushSubscriptionModelByLastKnownToken", Promise.resolve(pushModelLastKnown));
+      expect(await getPushSubscriptionModel()).toBe(pushModelLastKnown);
+    });
+
+    test('returns current subscription over last known', async () => {
+      const pushModelCurrent = getDummyPushSubscriptionOSModel();
+      test.stub(CoreModuleDirector.prototype, "getPushSubscriptionModelByCurrentToken", Promise.resolve(pushModelCurrent));
+
+      const pushModelLastKnown = getDummyPushSubscriptionOSModel();
+      test.stub(CoreModuleDirector.prototype, "getPushSubscriptionModelByLastKnownToken", Promise.resolve(pushModelLastKnown));
+
+      expect(await getPushSubscriptionModel()).toBe(pushModelCurrent);
+    });
+  });
+});

--- a/src/onesignal/PushSubscriptionNamespace.ts
+++ b/src/onesignal/PushSubscriptionNamespace.ts
@@ -29,7 +29,7 @@ export default class PushSubscriptionNamespace extends EventListenerBase {
     this._permission = permission;
     this._token = subscription.subscriptionToken;
 
-    OneSignal.coreDirector.getCurrentPushSubscriptionModel()
+    OneSignal.coreDirector.getPushSubscriptionModel()
       .then((pushModel: OSModel<SupportedSubscription> | undefined) => {
         if (pushModel && isCompleteSubscriptionObject(pushModel.data)) {
           this._id = pushModel.data.id;

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -48,7 +48,7 @@ export default class LoginManager {
         return;
       }
 
-      const pushSubModel = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
+      const pushSubModel = await OneSignal.coreDirector.getPushSubscriptionModel();
       let currentPushSubscriptionId;
 
       if (pushSubModel && isCompleteSubscriptionObject(pushSubModel.data)) {
@@ -73,7 +73,7 @@ export default class LoginManager {
           }
         };
 
-        const pushSubscription = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
+        const pushSubscription = await OneSignal.coreDirector.getPushSubscriptionModel();
         if (pushSubscription) {
           userData.subscriptions = [pushSubscription.data];
         }
@@ -122,7 +122,7 @@ export default class LoginManager {
     // before, logging out, process anything waiting in the delta queue so it's not lost
     OneSignal.coreDirector.forceDeltaQueueProcessingOnAllExecutors();
     UserDirector.resetUserMetaProperties();
-    const pushSubModel = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
+    const pushSubModel = await OneSignal.coreDirector.getPushSubscriptionModel();
     await OneSignal.coreDirector.resetModelRepoAndCache();
     // add the push subscription model back to the repo since we need at least 1 sub to create a new user
     OneSignal.coreDirector.add(ModelName.PushSubscriptions, pushSubModel as OSModel<SupportedModel>, false);

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -51,7 +51,6 @@ export default class EventHelper {
     // update notification_types via core module
     await context.subscriptionManager.updateNotificationTypes()
 
-    await Database.setIsPushEnabled(isPushEnabled);
     appState.lastKnownPushEnabled = isPushEnabled;
     appState.lastKnownPushToken = currentPushToken;
     appState.lastKnownPushId = pushSubscriptionId;

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -32,24 +32,24 @@ export default class EventHelper {
 
     const appState = await Database.getAppState();
     const { lastKnownPushEnabled, lastKnownPushId, lastKnownPushToken, lastKnownOptedIn } = appState;
+
+    const currentPushToken = await MainHelper.getCurrentPushToken();
+
+    const pushModel = await OneSignal.coreDirector.getPushSubscriptionModel();
+    const pushSubscriptionId = pushModel?.data?.id;
+
     const didStateChange = (
       lastKnownPushEnabled === null ||
-      isPushEnabled !== lastKnownPushEnabled
+      isPushEnabled !== lastKnownPushEnabled ||
+      currentPushToken !== lastKnownPushToken ||
+      pushSubscriptionId !== lastKnownPushId
     );
     if (!didStateChange) {
       return;
     }
-    Log.info(
-      `The user's subscription state changed from ` +
-        `${lastKnownPushEnabled === null ? '(not stored)' : lastKnownPushEnabled} ⟶ ${isPushEnabled}`
-    );
 
     // update notification_types via core module
-    await context.subscriptionManager.updateNotificationTypes();
-
-    const currentPushToken = await MainHelper.getCurrentPushToken();
-    const pushModel: OSModel<SubscriptionModel> = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
-    const pushSubscriptionId = pushModel.data?.id;
+    await context.subscriptionManager.updateNotificationTypes()
 
     await Database.setIsPushEnabled(isPushEnabled);
     appState.lastKnownPushEnabled = isPushEnabled;
@@ -71,7 +71,7 @@ export default class EventHelper {
         optedIn: isOptedIn,
       }
     };
-
+    Log.info("Push Subscription state changed: ", change);
     EventHelper.triggerSubscriptionChanged(change);
   }
 

--- a/src/shared/helpers/SubscriptionHelper.ts
+++ b/src/shared/helpers/SubscriptionHelper.ts
@@ -120,8 +120,8 @@ export default class SubscriptionHelper {
   static getRawPushSubscriptionForLegacySafari(safariWebId: string): RawPushSubscription {
     const subscription = new RawPushSubscription();
 
-    const { deviceToken: existingDeviceToken } = window.safari.pushNotification.permission(safariWebId);
-    subscription.existingSafariDeviceToken = existingDeviceToken;
+    const { deviceToken } = window.safari.pushNotification.permission(safariWebId);
+    subscription.setFromSafariSubscription(deviceToken);
 
     return subscription;
   }

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -163,7 +163,8 @@ export class SubscriptionManager {
   }
 
   private async _updatePushSubscriptionModelWithRawSubscription(rawPushSubscription: RawPushSubscription) {
-    const pushModel = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
+    // This undefined when it shouldn't be
+    const pushModel = await OneSignal.coreDirector.getPushSubscriptionModel();
 
     if (!pushModel) {
       OneSignal.coreDirector.generatePushSubscriptionModel(rawPushSubscription);
@@ -206,7 +207,7 @@ export class SubscriptionManager {
   }
 
   async updatePushSubscriptionNotificationTypes(notificationTypes: SubscriptionStateKind): Promise<void> {
-    const pushModel = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
+    const pushModel = await OneSignal.coreDirector.getPushSubscriptionModel();
     if (!pushModel) {
       throw new OneSignalError(
         `Cannot update notification_types for push subscription model because it does not exist.`
@@ -800,7 +801,7 @@ export class SubscriptionManager {
   private async getSubscriptionStateForSecure(): Promise<PushSubscriptionState> {
     const { optedOut, subscriptionToken } = await Database.getSubscription();
 
-    const pushSubscriptionOSModel: OSModel<SupportedSubscription> | undefined = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
+    const pushSubscriptionOSModel: OSModel<SupportedSubscription> | undefined = await OneSignal.coreDirector.getPushSubscriptionModel();
     const isValidPushSubscription = isCompleteSubscriptionObject(pushSubscriptionOSModel?.data) && !!pushSubscriptionOSModel?.onesignalId;
 
     if (Environment.useSafariLegacyPush()) {

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -163,7 +163,6 @@ export class SubscriptionManager {
   }
 
   private async _updatePushSubscriptionModelWithRawSubscription(rawPushSubscription: RawPushSubscription) {
-    // This undefined when it shouldn't be
     const pushModel = await OneSignal.coreDirector.getPushSubscriptionModel();
 
     if (!pushModel) {

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -366,8 +366,6 @@ export class SubscriptionManager {
     }
 
     const { deviceToken: existingDeviceToken } = window.safari.pushNotification.permission(this.config.safariWebId);
-    pushSubscriptionDetails.existingSafariDeviceToken = existingDeviceToken;
-
     if (!existingDeviceToken) {
       /*
         We're about to show the Safari native permission request. It can fail for a number of
@@ -605,10 +603,6 @@ export class SubscriptionManager {
 
     // Create our own custom object from the browser's native PushSubscription object
     const pushSubscriptionDetails = RawPushSubscription.setFromW3cSubscription(newPushSubscription);
-    if (existingPushSubscription) {
-      pushSubscriptionDetails.existingW3cPushSubscription =
-        RawPushSubscription.setFromW3cSubscription(existingPushSubscription);
-    }
     return pushSubscriptionDetails;
   }
 

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -209,9 +209,8 @@ export class SubscriptionManager {
   async updatePushSubscriptionNotificationTypes(notificationTypes: SubscriptionStateKind): Promise<void> {
     const pushModel = await OneSignal.coreDirector.getPushSubscriptionModel();
     if (!pushModel) {
-      throw new OneSignalError(
-        `Cannot update notification_types for push subscription model because it does not exist.`
-        );
+      Log.info("No Push Subscription yet to update notification_types.");
+      return;
     }
 
     pushModel.set("notification_types", notificationTypes);

--- a/src/shared/managers/UpdateManager.ts
+++ b/src/shared/managers/UpdateManager.ts
@@ -61,7 +61,7 @@ export class UpdateManager {
       return;
     }
 
-    const subscriptionModel = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
+    const subscriptionModel = await OneSignal.coreDirector.getPushSubscriptionModel();
 
     if (subscriptionModel?.data.notification_types !== SubscriptionStateKind.Subscribed &&
       OneSignal.config?.enableOnSession !== true) {
@@ -151,7 +151,7 @@ export class UpdateManager {
 
   public async sendOutcomeDirect(appId: string, notificationIds: string[], outcomeName: string, value?: number) {
     logMethodCall("sendOutcomeDirect");
-    const pushSubscriptionModel = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
+    const pushSubscriptionModel = await OneSignal.coreDirector.getPushSubscriptionModel();
 
     if (pushSubscriptionModel && isCompleteSubscriptionObject(pushSubscriptionModel?.data)) {
       const outcomeRequestData: OutcomeRequestData = {
@@ -175,7 +175,7 @@ export class UpdateManager {
 
   public async sendOutcomeInfluenced(appId: string, notificationIds: string[], outcomeName: string, value?: number) {
     logMethodCall("sendOutcomeInfluenced");
-    const pushSubscriptionModel = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
+    const pushSubscriptionModel = await OneSignal.coreDirector.getPushSubscriptionModel();
 
     if (pushSubscriptionModel && isCompleteSubscriptionObject(pushSubscriptionModel?.data)) {
       const outcomeRequestData: OutcomeRequestData = {
@@ -199,7 +199,7 @@ export class UpdateManager {
 
   public async sendOutcomeUnattributed(appId: string, outcomeName: string, value?: number) {
     logMethodCall("sendOutcomeUnattributed");
-    const pushSubscriptionModel = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
+    const pushSubscriptionModel = await OneSignal.coreDirector.getPushSubscriptionModel();
 
     if (pushSubscriptionModel && isCompleteSubscriptionObject(pushSubscriptionModel?.data)) {
       const outcomeRequestData: OutcomeRequestData = {

--- a/src/shared/managers/sessionManager/SessionManager.ts
+++ b/src/shared/managers/sessionManager/SessionManager.ts
@@ -92,7 +92,7 @@ export class SessionManager implements ISessionManager {
 
   async _getOneSignalAndSubscriptionIds(): Promise<{ onesignalId: string; subscriptionId: string }> {
     const identityModel = OneSignal.coreDirector.getIdentityModel();
-    const pushSubscriptionModel = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
+    const pushSubscriptionModel = await OneSignal.coreDirector.getPushSubscriptionModel();
 
     if (!identityModel || !identityModel.onesignalId) {
       throw new OneSignalError("Abort _getOneSignalAndSubscriptionIds: no identity");
@@ -340,7 +340,7 @@ export class SessionManager implements ISessionManager {
       return;
     }
 
-    const pushSubscription = await OneSignal.coreDirector.getCurrentPushSubscriptionModel();
+    const pushSubscription = await OneSignal.coreDirector.getPushSubscriptionModel();
     if (pushSubscription?.data.notification_types !== SubscriptionStateKind.Subscribed &&
       OneSignal.config?.enableOnSession !== true) {
       return;

--- a/src/shared/models/RawPushSubscription.ts
+++ b/src/shared/models/RawPushSubscription.ts
@@ -9,48 +9,8 @@ export class RawPushSubscription implements Serializable {
   w3cAuth: string | undefined;
   /**
      * A Safari-only push subscription device token. Not used for Chrome/Firefox.
-     */
+  */
   safariDeviceToken: string | undefined;
-  /**
-   * A full RawPushSubscription object of the existing W3C subscription, if any.
-   *
-   * This is used to determine whether the subscription changed, so we know
-   * whether to contact OneSignal to update the subscription.
-   */
-  existingW3cPushSubscription: RawPushSubscription | undefined;
-  /**
-   * The existing Safari subscription device token, if it exists.
-   *
-   * This is used to determine whether the subscription changed, so we know
-   * whether to contact OneSignal to update the subscription.
-   */
-  existingSafariDeviceToken: string | undefined | null;
-
-  /**
-   * Returns true if an existing recorded W3C or Safari subscription is
-   * identical to the current subscription.
-   */
-  public isNewSubscription(): boolean {
-    if (this.existingW3cPushSubscription) {
-      if (!!this.existingW3cPushSubscription.w3cEndpoint !== !!this.w3cEndpoint) {
-        return true;
-      }
-      if (!!this.existingW3cPushSubscription.w3cEndpoint && !!this.w3cEndpoint &&
-        this.existingW3cPushSubscription.w3cEndpoint.toString() !== this.w3cEndpoint.toString()) {
-          return true;
-      }
-      if (this.existingW3cPushSubscription.w3cP256dh !== this.w3cP256dh) {
-        return true;
-      }
-      if (this.existingW3cPushSubscription.w3cAuth !== this.w3cAuth) {
-        return true;
-      }
-      return false;
-    } else if (this.existingSafariDeviceToken) {
-      return this.existingSafariDeviceToken !== this.safariDeviceToken;
-    }
-    return true;
-  }
 
   /**
    * Given a native W3C browser push subscription, takes the endpoint, p256dh,
@@ -102,7 +62,10 @@ export class RawPushSubscription implements Serializable {
    *
    * @param safariDeviceToken A native browser Safari push subscription.
    */
-  public setFromSafariSubscription(safariDeviceToken: string) {
+  public setFromSafariSubscription(safariDeviceToken?: string | null) {
+    if (!safariDeviceToken) {
+      return;
+    }
     this.safariDeviceToken = safariDeviceToken;
   }
 
@@ -113,8 +76,6 @@ export class RawPushSubscription implements Serializable {
       w3cP256dh: this.w3cP256dh,
       w3cAuth: this.w3cAuth,
       safariDeviceToken: this.safariDeviceToken,
-      existingPushSubscription: this.existingW3cPushSubscription ? this.existingW3cPushSubscription.serialize() : null,
-      existingSafariDeviceToken: this.existingSafariDeviceToken
     };
 
     return serializedBundle;
@@ -134,14 +95,7 @@ export class RawPushSubscription implements Serializable {
     }
     subscription.w3cP256dh = bundle.w3cP256dh;
     subscription.w3cAuth = bundle.w3cAuth;
-    subscription.existingW3cPushSubscription = undefined;
-    if (bundle.existingW3cPushSubscription) {
-      subscription.existingW3cPushSubscription = RawPushSubscription.deserialize(bundle.existingW3cPushSubscription);
-    } else if (bundle.existingPushSubscription) {
-      subscription.existingW3cPushSubscription = RawPushSubscription.deserialize(bundle.existingPushSubscription);
-    }
     subscription.safariDeviceToken = bundle.safariDeviceToken;
-    subscription.existingSafariDeviceToken = bundle.existingSafariDeviceToken;
     return subscription;
   }
 }


### PR DESCRIPTION
# Description
## 1 Line Summary
Fix bug where new push subscriptions were being created instead of updating the existing one.

## Details
There are two key changes that were needed to fix this bug:
1. `getCurrentPushSubscriptionModel()`  - wasn't correctly using `lastKnownPushToken`, fixed in commit e9134eec3fb7c9f12f7520b6718e95740738bf53
2. `checkAndTriggerSubscriptionChanged()` - wasn't checking for token changes, so the backend was never updated, fixed in commit https://github.com/OneSignal/OneSignal-Website-SDK/commit/8e4235abd1abe5358dea4636f89c617e2e73074a
3. Other changes are small refactors and commit a4f312908741777638663096323b5219e4bde8ea is clearing up some related dead code.

# Validation
Tested on macOS with Chrome, with a clean browser. Then toggled notification permission off and on, refreshed page and repeated a few times in different combination. Observed notification_types and token network calls were made as expected without errors.
## Tests
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1077)
<!-- Reviewable:end -->
