### PR TITLE
[User Model] [Fix] Notification Open & Confirm Delivery REST API calls failing

### DIFF
--- a/src/sw/helpers/ModelCacheDirectAccess.ts
+++ b/src/sw/helpers/ModelCacheDirectAccess.ts
@@ -1,0 +1,20 @@
+import EncodedModel from "../../core/caching/EncodedModel";
+import { ModelName } from "../../core/models/SupportedModels";
+import Database from "../../shared/services/Database";
+
+/**
+ * WARNING: This is a temp workaround for the ServiceWorker context only!
+ * PURPOSE: CoreModuleDirector doesn't work in the SW context.
+ * TODO: This is duplicated logic tech debt to address later
+ */
+export class ModelCacheDirectAccess {
+  static async getPushSubscriptionIdByToken(token: string): Promise<string | undefined> {
+    const pushSubscriptions = await Database.getAll<EncodedModel>(ModelName.PushSubscriptions);
+    for(const pushSubscription of pushSubscriptions) {
+      if (pushSubscription["token"] === token) {
+        return pushSubscription["id"] as string;
+      }
+    }
+    return undefined;
+  }
+}


### PR DESCRIPTION
# Description
## 1 Line Summary
Notification Open & Confirm Delivery REST API calls were failing due to placeholder player_id being used.

## Details
`CoreModuleDirector` was introduced in v16, and is they place to access the `pushSubscriptionId` we needed. However `CoreModuleDirector` does not work in the ServiceWorker context since it uses JS API that are not available. This includes `localStorage` (possibly switch to `indexDB` in the future) as well as access to `window` and possibly others. Give the scope of such changes would large and has unknowns to address `CoreModuleDirector` we added a `ModelCacheDirectAccess` class to directly access what we needed, on the trade off it duplicates some code.

# Validation
## Tests
Tested on Chrome on Windows 11. Ensure both notification open and confirm deliveries show on the dashboard.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1079)
<!-- Reviewable:end -->
