### PR TITLE
[Fix] Remove soft-prompt in Notifications.requestPermission

### DIFF
--- a/src/onesignal/NotificationsNamespace.ts
+++ b/src/onesignal/NotificationsNamespace.ts
@@ -121,17 +121,17 @@ export default class NotificationsNamespace extends EventListenerBase {
 
   /**
    * Shows a native browser prompt.
+   * Requirement: Must be called from a "user gesture" (click / tap event).
+   *  Otherwise some browsers (Firefox & Safari) won't show anything.
+   * Implementation choice note: We don't have any "error" handling when the
+   *  requirement is not met, as browsers do not provide an API for this, w/o
+   *  requiring be passed to this function that is.
+   *  See https://github.com/OneSignal/OneSignal-Website-SDK/issues/1098
    * @PublicApi
    */
    async requestPermission(): Promise<void> {
     await awaitOneSignalInitAndSupported();
-    const requiresUserInteraction = OneSignal.environmentInfo?.requiresUserInteraction;
-    if (!requiresUserInteraction) {
-      await OneSignal.context.promptsManager.internalShowNativePrompt();
-      return;
-    }
-
-    await OneSignal.Slidedown.promptPush();
+    await OneSignal.context.promptsManager.internalShowNativePrompt();
   }
 
   addEventListener<K extends NotificationEventName>(event: K, listener: (obj: NotificationEventTypeMap[K]) => void): void {


### PR DESCRIPTION
# Description
## One Line Summary
Developers who call `OneSignal.Notifications.requestPermission()` already take the browser's requirement for a user gesture into account want to directly show the native notification permission prompt so we are removing the conditional soft-prompt.

## Details
Some developers want to directly display the native notification permission prompt. However we were trying to detect if a user interaction was required without considering if the developer already met it.

There isn't a browser API to detect if the user interaction was met at either the global level or stacktrace to detect this for them. There also isn't any errors thrown or returned to show one as a fallback either. We don't want to require a parameter so instead simply just always attempt to show the native prompt.

# Validation
## Tests
Tested on Windows 11 22H2 on Firefox 102.14.0esr.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets
Fixes #1098
---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1101)
<!-- Reviewable:end -->
