### PR TITLE
[Improvement] Call out error to show 409 http is expected

### DIFF
--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -284,7 +284,11 @@ export default class LoginManager {
    */
   static async transferSubscription(appId: string, pushSubscriptionId: string, identity: SupportedIdentity):
     Promise<Partial<UserData>> {
-      Log.info(`identifyUser failed: externalId already exists. Attempting to transfer push subscription...`);
+      Log.error(
+        "^^^ Handling 409 HTTP response reported by the browser above."
+        + " This is an expected result when the User already exists."
+        + " Push subscription is being transferred the existing User."
+      );
 
       const retainPreviousOwner = false;
       const transferResponse = await RequestService.transferSubscription(


### PR DESCRIPTION
# Description
## One Line Summary
We get a HTTP response 409 "One or more Aliases claimed by another User" when `OneSignal.login` is called which is expected in some case. However browser's print non-successful HTTP responses that isn't supressable so we are adding an error message to explain this.

## Details
# Validation
## Tests
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
Unsupressable error follow by our new explanation.
<img width="1069" alt="image" src="https://github.com/OneSignal/OneSignal-Website-SDK/assets/645861/c5f06909-b377-4ba7-8b46-59cc06d01ff6">

### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets
Issue #1100

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1102)
<!-- Reviewable:end -->
