### PR TITLE
[Fix] Welcome Notification

### DIFF
--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -85,7 +85,10 @@ export default class EventHelper {
   static async _onSubscriptionChanged(
     change: SubscriptionChangeEvent | undefined,
   ) {
-    // EventHelper.onSubscriptionChanged_showWelcomeNotification(change?.current.enabled);
+    EventHelper.onSubscriptionChanged_showWelcomeNotification(
+      change?.current?.optedIn,
+      change?.current?.id,
+    );
     EventHelper.onSubscriptionChanged_sendCategorySlidedownTags(
       change?.current?.optedIn,
     );
@@ -107,9 +110,15 @@ export default class EventHelper {
     }
   }
 
+  /**
+   * NOTE: This uses the OneSignal REST API POST /notifications with
+   * include_player_ids. This field will be dropped by 2025 so a
+   * replacement will needed by then.
+   */
   private static sendingOrSentWelcomeNotification = false;
   private static async onSubscriptionChanged_showWelcomeNotification(
     isSubscribed: boolean | undefined,
+    pushSubscriptionId: string | undefined | null,
   ) {
     if (OneSignal.__doNotShowWelcomeNotification) {
       Log.debug(
@@ -131,6 +140,10 @@ export default class EventHelper {
       return;
     }
 
+    if (!pushSubscriptionId) {
+      return;
+    }
+
     // Workaround only for this v15 branch; There are race conditions in the SDK
     // that result in the onSubscriptionChanged firing more than once sometimes.
     if (EventHelper.sendingOrSentWelcomeNotification) {
@@ -138,7 +151,6 @@ export default class EventHelper {
     }
     EventHelper.sendingOrSentWelcomeNotification = true;
 
-    const { deviceId } = await Database.getSubscription();
     const { appId } = await Database.getAppConfig();
     let title =
       welcome_notification_opts !== undefined &&
@@ -167,7 +179,7 @@ export default class EventHelper {
     Log.debug('Sending welcome notification.');
     OneSignalApiShared.sendNotification(
       appId,
-      [deviceId],
+      [pushSubscriptionId],
       { en: title },
       { en: message },
       url,

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -115,7 +115,6 @@ export default class EventHelper {
    * include_player_ids. This field will be dropped by 2025 so a
    * replacement will needed by then.
    */
-  private static sendingOrSentWelcomeNotification = false;
   private static async onSubscriptionChanged_showWelcomeNotification(
     isSubscribed: boolean | undefined,
     pushSubscriptionId: string | undefined | null,
@@ -143,13 +142,6 @@ export default class EventHelper {
     if (!pushSubscriptionId) {
       return;
     }
-
-    // Workaround only for this v15 branch; There are race conditions in the SDK
-    // that result in the onSubscriptionChanged firing more than once sometimes.
-    if (EventHelper.sendingOrSentWelcomeNotification) {
-      return;
-    }
-    EventHelper.sendingOrSentWelcomeNotification = true;
 
     const { appId } = await Database.getAppConfig();
     let title =


### PR DESCRIPTION
# Description
## 1 Line Summary
Fix welcome notifications not showing after subscribing.

## Details
This was disabled in code during the User Model beta and a replacement implementation hasn't been done on the backend. We will continue to use include_player_ids until there is a backend replacement which needs to be done by 2025.

# Validation
## Tests
Tested on Windows 11 with Chrome, ensuring the welcome notification showed up.

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1108)
<!-- Reviewable:end -->
