### PR TITLE
[Fix] Safari on macOS native prompt with custom link

### DIFF
--- a/src/shared/managers/CustomLinkManager.ts
+++ b/src/shared/managers/CustomLinkManager.ts
@@ -146,9 +146,7 @@ export class CustomLinkManager {
   }
 
   private async handleClick(element: HTMLElement): Promise<void> {
-    const isPushEnabled =
-      await OneSignal.context.subscriptionManager.isPushNotificationsEnabled();
-    if (isPushEnabled) {
+    if (OneSignal.User.PushSubscription.optedIn) {
       await OneSignal.User.PushSubscription.optOut();
       await this.setTextFromPushStatus(element);
     } else {


### PR DESCRIPTION
# Description
## 1 Line Summary
Fix Safari on macOS native prompt not showing from custom links.

## Details
macOS Safari requires a user gesture to show the native prompt, and doesn't allow disk I/O in the Promise. Switched to the opted in check to use optedIn since this uses a cached value which doesn't have this disk I/O issue.

# Validation
## Tests
Tested on Safari 17.0 on macOS 13.6, ensuring the custom link prompts for notifications, subscribes, and can opt-out.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---
