### PR TITLE
[Fix] macOS Safari auto resubscribe

### DIFF
--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -401,23 +401,29 @@ export class SubscriptionManager {
 
     const { deviceToken: existingDeviceToken } =
       window.safari.pushNotification.permission(this.config.safariWebId);
-    if (!existingDeviceToken) {
-      /*
-        We're about to show the Safari native permission request. It can fail for a number of
-        reasons, e.g.:
-          - Setup-related reasons when developers just starting to get set up
-            - Address bar URL doesn't match safari certificate allowed origins (case-sensitive)
-            - Safari web ID doesn't match provided web ID
-            - Browsing in a Safari private window
-            - Bad icon DPI
 
-        but shouldn't fail for sites that have already gotten Safari working.
-
-        We'll show the permissionPromptDisplay event if the Safari user isn't already subscribed,
-        otherwise an already subscribed Safari user would not see the permission request again.
-       */
-      OneSignalEvent.trigger(OneSignal.EVENTS.PERMISSION_PROMPT_DISPLAYED);
+    if (existingDeviceToken) {
+      pushSubscriptionDetails.setFromSafariSubscription(
+        existingDeviceToken.toLowerCase(),
+      );
+      return pushSubscriptionDetails;
     }
+
+    /*
+      We're about to show the Safari native permission request. It can fail for a number of
+      reasons, e.g.:
+        - Setup-related reasons when developers just starting to get set up
+          - Address bar URL doesn't match safari certificate allowed origins (case-sensitive)
+          - Safari web ID doesn't match provided web ID
+          - Browsing in a Safari private window
+          - Bad icon DPI
+
+      but shouldn't fail for sites that have already gotten Safari working.
+
+      We'll show the permissionPromptDisplay event if the Safari user isn't already subscribed,
+      otherwise an already subscribed Safari user would not see the permission request again.
+    */
+    OneSignalEvent.trigger(OneSignal.EVENTS.PERMISSION_PROMPT_DISPLAYED);
     const deviceToken = await this.subscribeSafariPromptPermission();
     PermissionUtils.triggerNotificationPermissionChanged();
     if (deviceToken) {


### PR DESCRIPTION
# Description
## 1 Line Summary
Fix macOS Safari auto resubscribe if the site data is cleared and the end-user re-visits the site.

## Details
Fixed by using existing Safari push token if available. Attempting to prompt when permission is already granted still throws with user gesture required error otherwise.

# Validation
## Tests
Tested on macOS 13.6 with Safari 17.0, cleared the site data and refreshed the page and ensured it created a new user with a push subscription automatically. 

### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1117)
<!-- Reviewable:end -->
