### PR TITLE
[Fix] Add email and sms User issues

### DIFF
--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -126,7 +126,7 @@ export default class OneSignal {
       );
     }
 
-    LoginManager.login(externalId, jwtToken);
+    await LoginManager.login(externalId, jwtToken);
   }
 
   static async logout(): Promise<void> {

--- a/src/onesignal/User.ts
+++ b/src/onesignal/User.ts
@@ -115,7 +115,7 @@ export default class User {
     });
   }
 
-  public addEmail(email: string): void {
+  public async addEmail(email: string): Promise<void> {
     logMethodCall('addEmail', { email });
 
     if (typeof email !== 'string') {
@@ -157,7 +157,7 @@ export default class User {
         newSubscription,
         false,
       );
-      UserDirector.createUserOnServer();
+      await UserDirector.createAndHydrateUser();
     }
 
     UserDirector.updateModelWithCurrentUserOneSignalId(newSubscription).catch(
@@ -167,7 +167,7 @@ export default class User {
     );
   }
 
-  public addSms(sms: string): void {
+  public async addSms(sms: string): Promise<void> {
     logMethodCall('addSms', { sms });
 
     if (typeof sms !== 'string') {
@@ -206,7 +206,7 @@ export default class User {
         newSubscription,
         false,
       );
-      UserDirector.createUserOnServer();
+      await UserDirector.createAndHydrateUser();
     }
 
     UserDirector.updateModelWithCurrentUserOneSignalId(newSubscription).catch(

--- a/src/onesignal/UserDirector.ts
+++ b/src/onesignal/UserDirector.ts
@@ -104,6 +104,13 @@ export default class UserDirector {
     }
   }
 
+  static async createAndHydrateUser(): Promise<void> {
+    const userData = await UserDirector.createUserOnServer();
+    if (userData) {
+      OneSignal.coreDirector.hydrateUser(userData);
+    }
+  }
+
   static async getAllUserData(): Promise<UserData> {
     logMethodCall('LoginManager.getAllUserData');
 

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -192,10 +192,7 @@ export class SubscriptionManager {
 
     if (!pushModel) {
       OneSignal.coreDirector.generatePushSubscriptionModel(rawPushSubscription);
-      const userData = await UserDirector.createUserOnServer();
-      if (userData) {
-        OneSignal.coreDirector.hydrateUser(userData);
-      }
+      await UserDirector.createAndHydrateUser();
       return;
     } else {
       // resubscribing. update existing push subscription model


### PR DESCRIPTION
# Description
## 1 Line Summary
Fix issues with anonymous User onesignal_id and login with both addEmail and addSms.

## Details
* addEmail and addSms now save onesignal_id for anonymous Users if notifications have not been enabled yet
   - commit 36b8b7b393f804f8b57ebda4f5b0d1f8a08a7d13
* When awaiting OneSignal.login the Promise now resolve correctly after all work has been completed.
   - commit a99d2f7adccdc26094b593fc3e0e35a293889c98

# Validation
## Tests
Tested on Chrome 119 on Windows 11
* Tested calling `await OneSignal.login("myId"); OneSignal.User.addEmail("a@a.com");` ensuring it sending `external_id` with the user create request.
* Tested calling `addEmail` before accepting notifications and ensured the `identity` table in indexDb correctly had `onesignal_id` filled in.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1129)
<!-- Reviewable:end -->
