### PR TITLE
[Fix] hide bell if user is subscribed, dashboard setting

### DIFF
--- a/src/shared/helpers/ConfigHelper.ts
+++ b/src/shared/helpers/ConfigHelper.ts
@@ -532,14 +532,7 @@ export class ConfigHelper {
             enable: serverConfig.config.staticPrompts.bell.enabled,
             displayPredicate: serverConfig.config.staticPrompts.bell
               .hideWhenSubscribed
-              ? () => {
-                  return OneSignal.isPushNotificationsEnabled().then(
-                    (isPushEnabled: boolean) => {
-                      /* The user is subscribed, so we want to return "false" to hide the notify button */
-                      return !isPushEnabled;
-                    },
-                  );
-                }
+              ? () => !OneSignal.User.PushSubscription.optedIn
               : null,
             size: serverConfig.config.staticPrompts.bell.size,
             position: serverConfig.config.staticPrompts.bell.location,

--- a/src/shared/models/Prompts.ts
+++ b/src/shared/models/Prompts.ts
@@ -123,7 +123,7 @@ export interface BellText {
 export interface AppUserConfigNotifyButton {
   options?: AppUserConfigNotifyButton;
   enable: boolean;
-  displayPredicate?: () => void | null | undefined;
+  displayPredicate?: null | (() => void | null | undefined | boolean);
   size?: BellSize;
   position?: BellPosition;
   offset?: { bottom: string; left: string; right: string };


### PR DESCRIPTION
# Description
## 1 Line Summary
Fix "Hide bell if user is subscribed" that can be set in dashboard when configuring the bell.

## Details

# Validation
## Tests
Tested on Chrome 119 on Windows 11.
* Enabled the "Hide bell if user is subscribed" on the OneSignal.com dashboard and ensure the bell toggled based on both the native browser permission as well as the opt out setting.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
Dashboard option for reference:
![image](https://github.com/OneSignal/OneSignal-Website-SDK/assets/645861/3aa9e118-a879-4a27-8236-0d31a778bf45)

### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1130)
<!-- Reviewable:end -->
