### PR TITLE
[Fix] notification click event not firing if it opens a new tab

### DIFF
--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -124,8 +124,8 @@
     });
 
     OneSignalDeferred.push(function(onesignal) {
-      onesignal.Notifications.addEventListener('willDisplay', function (event) {
-        showEventAlert('willDisplay', { event });
+      onesignal.Notifications.addEventListener('foregroundWillDisplay', function (event) {
+        showEventAlert('foregroundWillDisplay', event);
       });
     });
 

--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -149,6 +149,7 @@
     }
 
     function showEventAlert(eventName, payload) {
+      console.log(`OneSignal event ${eventName} fired!`, payload);
       if (!showEventAlertToggleSetting) {
         return;
       }

--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -102,9 +102,6 @@
         onesignal.User.PushSubscription.addEventListener('subscriptionChange', function (event) {
           showEventAlert('subscriptionChange', { event });
         });
-        onesignal.Notifications.addEventListener('click', event => {
-          showEventAlert('click', { event });
-        });
     });
 
     /* E V E N T   L I S T E N E R S */

--- a/src/onesignal/NotificationsNamespace.ts
+++ b/src/onesignal/NotificationsNamespace.ts
@@ -13,6 +13,7 @@ import { EventListenerBase } from '../page/userModel/EventListenerBase';
 import { NotificationEventName } from '../page/models/NotificationEventName';
 import { NotificationPermission } from '../shared/models/NotificationPermission';
 import NotificationEventTypeMap from '../page/models/NotificationEventTypeMap';
+import EventHelper from '../shared/helpers/EventHelper';
 
 export default class NotificationsNamespace extends EventListenerBase {
   private _permission: boolean;
@@ -146,6 +147,10 @@ export default class NotificationsNamespace extends EventListenerBase {
     listener: (obj: NotificationEventTypeMap[K]) => void,
   ): void {
     OneSignal.emitter.on(event, listener);
+
+    if (event === 'click') {
+      EventHelper.fireStoredNotificationClicks();
+    }
   }
 
   removeEventListener<K extends NotificationEventName>(

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -14,6 +14,7 @@ import {
   NotificationClickEvent,
   NotificationClickEventInternal,
 } from '../models/NotificationEvent';
+import { awaitOneSignalInitAndSupported } from '../utils/utils';
 
 export default class EventHelper {
   static onNotificationPermissionChange() {
@@ -243,7 +244,13 @@ export default class EventHelper {
    * This method is fired for both HTTPS and HTTP sites, so for HTTP sites, the host URL needs to be used, not the
    * subdomain.onesignal.com URL.
    */
-  static async fireStoredNotificationClicks(url: string = document.URL) {
+  static async fireStoredNotificationClicks() {
+    await awaitOneSignalInitAndSupported();
+    const url =
+      OneSignal.config.pageUrl ||
+      OneSignal.config.userConfig.pageUrl ||
+      document.URL;
+
     async function fireEventWithNotification(
       selectedEvent: NotificationClickEventInternal,
     ) {


### PR DESCRIPTION
# Description
## 1 Line Summary
Fix notification click event not firing if it opens a new tab.

## Details
The internal `fireStoredNotificationClicks()` function was not called to fire any pending click events when `OneSignal.Notifications.addEventListener('click', function() {})` is called.

# Validation
## Tests
Tested on Chrome 119 on Window 11, testing both "focus" and "navigate" options for notification open behavior.
* Click behavior set on dashboard "Origin: Take actions on a previous tab open to same domain"
* Click behavior set on dashboard "Exact: (default) Opens a new window"

### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X} Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
Tested click Behavior Exact:
![image](https://github.com/OneSignal/OneSignal-Website-SDK/assets/645861/cf5d831c-92e0-44b7-8546-45f5f94d4a98)

Tested click behavior Focus:
![image](https://github.com/OneSignal/OneSignal-Website-SDK/assets/645861/894d54c4-2748-41dc-855d-e112391ee94e)

### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---
