### PR TITLE
[Feat] Show iOS supported message

### DIFF
--- a/src/page/utils/BrowserSupportsPush.ts
+++ b/src/page/utils/BrowserSupportsPush.ts
@@ -1,3 +1,5 @@
+// Light weight JS to detect browsers push notification capabilities
+//
 // This is used by the OneSignalSDK.page.js shim
 // DO NOT add other imports since it is an ES5 target and dead code imports can't be clean up.
 
@@ -7,8 +9,9 @@ export function isPushNotificationsSupported() {
   return supportsVapidPush() || supportsSafariPush();
 }
 
+// Fallback detection for Safari on macOS in an iframe context
+//   - window.safari is undefined in this context
 export function isMacOSSafariInIframe(): boolean {
-  // Fallback detection for Safari on macOS in an iframe context
   return (
     window.top !== window && // isContextIframe
     isSafariBrowser() &&
@@ -16,6 +19,7 @@ export function isMacOSSafariInIframe(): boolean {
   ); // isMacOS
 }
 
+// Does the browser support legacy Safari push? (only available on macOS)
 export function supportsSafariPush(): boolean {
   return (
     (window.safari && typeof window.safari.pushNotification !== 'undefined') ||
@@ -56,4 +60,3 @@ function isSafariBrowser(): boolean {
 // Firefox
 //   Normal - typeof PushSubscriptionOptions == "function"
 //     HTTP & HTTPS - typeof PushSubscriptionOptions == "function"
-//   ESR - typeof PushSubscriptionOptions == "undefined"

--- a/src/page/utils/BrowserSupportsPush.ts
+++ b/src/page/utils/BrowserSupportsPush.ts
@@ -11,7 +11,7 @@ export function isMacOSSafariInIframe(): boolean {
   // Fallback detection for Safari on macOS in an iframe context
   return (
     window.top !== window && // isContextIframe
-    navigator.vendor === 'Apple Computer, Inc.' && // isSafari
+    isSafariBrowser() &&
     navigator.platform === 'MacIntel'
   ); // isMacOS
 }
@@ -30,6 +30,19 @@ export function supportsVapidPush(): boolean {
     // eslint-disable-next-line no-prototype-builtins
     PushSubscriptionOptions.prototype.hasOwnProperty('applicationServerKey')
   );
+}
+
+// Is Safari on iOS or iPadOS
+export function isIosSafari(): boolean {
+  // Safari's "Request Desktop Website" (default for iPad) masks the
+  // userAgent as macOS. So we are using maxTouchPoints to assume it is
+  // iOS, since there are no touch screen Macs.
+  return isSafariBrowser() && navigator.maxTouchPoints > 0;
+}
+
+// Is any Safari browser, includes macOS and iOS.
+function isSafariBrowser(): boolean {
+  return navigator.vendor === 'Apple Computer, Inc.';
 }
 
 /* Notes on browser results which lead the logic of the functions above */

--- a/src/page/utils/OneSignalShimLoader.ts
+++ b/src/page/utils/OneSignalShimLoader.ts
@@ -1,4 +1,7 @@
-import { isPushNotificationsSupported } from './BrowserSupportsPush';
+import {
+  isIosSafari,
+  isPushNotificationsSupported,
+} from './BrowserSupportsPush';
 // NOTE: Careful if adding imports, ES5 targets can't clean up functions never called.
 
 // See sdk.ts for what entry points this handles
@@ -55,7 +58,16 @@ export class OneSignalShimLoader {
     if (isPushNotificationsSupported()) {
       OneSignalShimLoader.loadFullPageSDK();
     } else {
-      console.log('OneSignal: SDK is not compatible with this browser.');
+      this.printEnvironmentNotSupported();
     }
+  }
+
+  private static printEnvironmentNotSupported() {
+    let logMessage = 'OneSignal: SDK is not compatible with this browser.';
+    if (isIosSafari()) {
+      logMessage +=
+        ' To support iOS please install as a Web App. See the OneSignal guide https://documentation.onesignal.com/docs/safari-web-push-for-ios';
+    }
+    console.log(logMessage);
   }
 }


### PR DESCRIPTION
# Description
## 1 Line Summary
Improve DX for not supported browser since it can be confusing for iOS.

## Details
# Validation
## Tests
Tested to ensure new "...To support iOS please install as a Web App. See the OneSignal guide https://documentation.onesignal.com/docs/safari-web-push-for-ios" shows on an iPhone running iOS 16.7.2 in the JS console when using Safari.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

Fixes #1126

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1135)
<!-- Reviewable:end -->
