### PR TITLE
[Fix] Service Worker race condition, when a 2nd sw is in play, causing User not to register

### DIFF
--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -8,12 +8,19 @@
 <!-- NOTE: This does not work with the relative pathed manifest.json above. -->
 <!--<base href="https://www.example.com/"> -->
 <script src="sdks/web/v16/Dev-OneSignalSDK.page.js" defer></script>
+
+<script>
+  // Example of a root service worker a site may have.
+  // This is common for a PWA.
+  navigator.serviceWorker.register('sw.js');
+</script>
+
 <script>
     // NOTE: Uncomment and open site in Safari on macOS 13+ to simulate
     // a similar JS API as an iOS 16.4 WebApp.
     // window.safari = undefined;
 
-    const SERVICE_WORKER_PATH = "push/onesignal/";
+    const SERVICE_WORKER_PATH = 'push/onesignal/';
     let showEventAlertToggleSetting = false;
 
     function getUrlQueryParam(name) {
@@ -26,6 +33,8 @@
     OneSignalDeferred.push(async function(onesignal) {
       await onesignal.init({
           appId,
+          serviceWorkerParam: { scope: '/' + SERVICE_WORKER_PATH },
+          serviceWorkerPath: SERVICE_WORKER_PATH + 'OneSignalSDKWorker.js',
           notifyButton: {
               enable: true
           },

--- a/express_webpack/server.js
+++ b/express_webpack/server.js
@@ -34,6 +34,10 @@ app.get('/:file', (req, res) => {
     res.sendFile(sanitize(req.params.file), { root: __dirname });
 });
 
+app.get('/push/onesignal/:file', (req, res) => {
+    res.sendFile(path.join(DIST_DIR, '/push/onesignal/') + sanitize(req.params.file));
+});
+
 https.createServer(options, app).listen(4001, () => console.log("express_webpack: listening on port 4001 (https)"));
 
 // http

--- a/express_webpack/sw.js
+++ b/express_webpack/sw.js
@@ -1,0 +1,19 @@
+// Example of a root scope service worker a site might have.
+// This tests to ensure OneSignal can use the correctly scoped one when
+// 2 service workers are in play.
+
+// This exists to point out the fact this service worker is being
+// used instead of the intended OneSignalSDKWorker.js.
+self.addEventListener('push', async (e) => {
+  console.error("push - Should not fire on sw.js");
+
+  const options = {
+      body: 'Non-SDK from sw.js',
+  };
+
+  // Display notification
+  const displayPromise = self.registration.showNotification('Non-SDK from sw.js', options);
+
+  // Must wait for all promises to finish before return from this event.
+  e.waitUntil(displayPromise);
+});

--- a/src/shared/helpers/SubscriptionHelper.ts
+++ b/src/shared/helpers/SubscriptionHelper.ts
@@ -41,7 +41,7 @@ export default class SubscriptionHelper {
           await PermissionUtils.triggerNotificationPermissionChanged();
           await EventHelper.checkAndTriggerSubscriptionChanged();
         } catch (e) {
-          Log.info(e);
+          Log.error(e);
         }
         break;
       case WindowEnvironmentKind.OneSignalSubscriptionPopup: {

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -487,8 +487,10 @@ export class SubscriptionManager {
     }
 
     /* Now that permissions have been granted, install the service worker */
+    let workerRegistration: ServiceWorkerRegistration | undefined | null;
     try {
-      await this.context.serviceWorkerManager.installWorker();
+      workerRegistration =
+        await this.context.serviceWorkerManager.installWorker();
     } catch (err) {
       if (err instanceof ServiceWorkerRegistrationError) {
         if (err.status === 403) {
@@ -506,9 +508,6 @@ export class SubscriptionManager {
       throw err;
     }
 
-    Log.debug('[Subscription Manager] Getting OneSignal service Worker...');
-    const workerRegistration =
-      await this.context.serviceWorkerManager.getRegistration();
     if (!workerRegistration) {
       throw new Error('OneSignal service worker not found!');
     }

--- a/src/sw/helpers/ServiceWorkerUtilHelper.ts
+++ b/src/sw/helpers/ServiceWorkerUtilHelper.ts
@@ -33,4 +33,29 @@ export default class ServiceWorkerUtilHelper {
     }
     return availableWorker;
   }
+
+  // Allows waiting for the service worker registration to become active.
+  // Some APIs, like registration.pushManager.subscribe, required it be active
+  // otherwise it throws.
+  static waitUntilActive(
+    registration: ServiceWorkerRegistration,
+  ): Promise<void> {
+    return new Promise((resolve) => {
+      // IMPORTANT: checking non-active instances first,
+      // otherwise the 'statechange' event could be missed.
+      const inactiveWorker = registration.installing || registration.waiting;
+      if (inactiveWorker) {
+        inactiveWorker.addEventListener('statechange', () => {
+          Log.debug(
+            'OneSignal Service Worker state changed:',
+            inactiveWorker.state,
+          );
+          if (registration.active) {
+            resolve();
+          }
+        });
+      }
+      if (registration.active) resolve();
+    });
+  }
 }


### PR DESCRIPTION
# Description
## 1 Line Summary
Fix Service Worker race condition, when a 2nd sw is in play, causing User not to register.

## Details
If you attempt to get the service worker registration immediately after registering it the browser can give you a different registration than expected. This is due to the fact the new registration may not be ready yet and there might be sw in scope at a higher level.

The problem noted above cause the OneSignal SDK to register for a push token on the wrong service worker. This in turn causes the SDK to attempt to create a user with a push subscription but without a push token, which results in a `400` error on `POST /users`.

To fix, instead of calling `navigator.serviceWorker.getRegistration` we are now simply using the `ServiceWorkerRegistration` give to us by `navigator.serviceWorker.register` to avoid this race condition completely

# Validation
## Tests
Test on Chrome 119 on Windows 11
* Ensured after accepting push notifications I received a welcome notification. Clear the browser data and push permission, opened a new tab, and tested again 3 more times.
* Refreshed page after accepting notifications to ensure existing service worker is found without an error.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1136)
<!-- Reviewable:end -->
