### PR TITLE
use new URL in `subscribeSafariPromptPermission`

### DIFF
--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -66,6 +66,7 @@ export type SubscriptionStateServiceWorkerNotIntalled =
 export class SubscriptionManager {
   private context: ContextSWInterface;
   private config: SubscriptionManagerConfig;
+  private safariPermissionPromptFailed = false;
 
   constructor(context: ContextSWInterface, config: SubscriptionManagerConfig) {
     this.context = context;
@@ -371,23 +372,36 @@ export class SubscriptionManager {
     return !!deviceId;
   }
 
-  private subscribeSafariPromptPermission(): Promise<string | null> {
-    return new Promise<string>((resolve) => {
-      window.safari.pushNotification.requestPermission(
-        `${SdkEnvironment.getOneSignalApiUrl().toString()}/safari`,
-        this.config.safariWebId,
-        {
-          app_id: this.config.appId,
-        },
-        (response) => {
-          if ((response as any).deviceToken) {
-            resolve((response as any).deviceToken.toLowerCase());
-          } else {
-            resolve(null);
-          }
-        },
+  private async subscribeSafariPromptPermission(): Promise<string | null> {
+    const requestPermission = (url: string) => {
+      return new Promise<string | null>((resolve) => {
+        window.safari.pushNotification.requestPermission(
+          url,
+          this.config.safariWebId,
+          { app_id: this.config.appId },
+          (response) => {
+            if (response && response.deviceToken) {
+              resolve(response.deviceToken.toLowerCase());
+            } else {
+              resolve(null);
+            }
+          },
+        );
+      });
+    };
+
+    if (!this.safariPermissionPromptFailed) {
+      return requestPermission(
+        `${SdkEnvironment.getOneSignalApiUrl().toString()}/safari/apps/${
+          this.config.appId
+        }`,
       );
-    });
+    } else {
+      // If last attempt failed, retry with the legacy URL
+      return requestPermission(
+        `${SdkEnvironment.getOneSignalApiUrl().toString()}/safari`,
+      );
+    }
   }
 
   private async subscribeSafari(): Promise<RawPushSubscription> {
@@ -426,6 +440,7 @@ export class SubscriptionManager {
     if (deviceToken) {
       pushSubscriptionDetails.setFromSafariSubscription(deviceToken);
     } else {
+      this.safariPermissionPromptFailed = true;
       throw new SubscriptionError(SubscriptionErrorReason.InvalidSafariSetup);
     }
     return pushSubscriptionDetails;


### PR DESCRIPTION
# Description
## 1 Line Summary
use new URL with `appId` in `subscribeSafariPromptPermission`

## Details
Due to changes in our API, the `appId` is now required in the URL used by `subscribeSafariPromptPermission`. In instances where the new URL is not usable, we fallback to the legacy URL with an additional request. This ensures compatibility with both the updated and legacy API endpoints.

# Systems Affected
   - [x] WebSDK
   - [x] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1138)
<!-- Reviewable:end -->
