### PR TITLE
[Fix] Improve error for sites using os.tc subdomain

### DIFF
--- a/src/shared/utils/OneSignalUtils.ts
+++ b/src/shared/utils/OneSignalUtils.ts
@@ -72,11 +72,26 @@ export class OneSignalUtils {
     }
 
     const windowEnv = SdkEnvironment.getWindowEnv();
-    return (
+
+    const isHttp = location.protocol === 'http:';
+    const useSubdomain =
       (windowEnv === WindowEnvironmentKind.Host ||
         windowEnv === WindowEnvironmentKind.CustomIframe) &&
-      (!!subdomain || location.protocol === 'http:')
-    );
+      (!!subdomain || isHttp);
+
+    if (useSubdomain) {
+      if (isHttp) {
+        throw new Error(
+          "OneSignalSDK: HTTP sites are no longer supported starting with version 16 (User Model), your public site must start with https://. Please visit the OneSignal dashboard's Settings > Web Configuration to find this option.",
+        );
+      } else {
+        throw new Error(
+          'OneSignalSDK: The "My site is not fully HTTPS" option is no longer supported starting with version 16 (User Model) of the OneSignal SDK. Please visit the OneSignal dashboard\'s Settings > Web Configuration to find this option.',
+        );
+      }
+    }
+
+    return false;
   }
 
   public static redetectBrowserUserAgent(): IBowser {


### PR DESCRIPTION
# Description
## 1 Line Summary
Replaces confusing "TypeError: Cannot read properties of undefined (reading 'message')" with a specific error that HTTP and the "My site is not fully HTTPS" option is no longer supported.

## Details
Before this change the initialization process would get too far and would result a confusing undefined error.

Dead code will be cleaned up follow up PR.

# Validation
## Tests
Tested with Chrome 119 on Windows 11
* Tested with a site with "My site is not fully HTTPS" enabled to ensure the new message would show in the JS console.
* Tested with a normal HTTPS site to ensure it still works.
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Before
```
TypeError: Cannot read properties of undefined (reading 'message')
    at Dev-OneSignalSDK.page.es6.js?v=160004:19230:46
    at new Promise (<anonymous>)
    at Database.<anonymous> (Dev-OneSignalSDK.page.es6.js?v=160004:19229:30)
    at Generator.next (<anonymous>)
    at Dev-OneSignalSDK.page.es6.js?v=160004:22237:71
    at new Promise (<anonymous>)
    at __awaiter (Dev-OneSignalSDK.page.es6.js?v=160004:22233:12)
    at Database.getAll (Dev-OneSignalSDK.page.es6.js?v=160004:19227:65)
    at Database.<anonymous> (Dev-OneSignalSDK.page.es6.js?v=160004:19863:53)
    at Generator.next (<anonymous>)
```

### After
```
Uncaught (in promise) Error: OneSignalSDK: HTTP sites are no longer supported starting with version 16 (User Model), your public site must start with https://. Please visit the OneSignal dashboard's Settings > Web Configuration to find this option.
    at OneSignalUtils.internalIsUsingSubscriptionWorkaround (Dev-OneSignalSDK.page.es6.js?v=160004:21219:23)
    at ConfigHelper.getMergedConfig (Dev-OneSignalSDK.page.es6.js?v=160004:12008:109)
    at ConfigHelper.<anonymous> (Dev-OneSignalSDK.page.es6.js?v=160004:11956:40)
    at Generator.next (<anonymous>)
    at fulfilled (Dev-OneSignalSDK.page.es6.js?v=160004:22224:58)
```

### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1139)
<!-- Reviewable:end -->
