### PR TITLE
[Feat] Add getTags to public API

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -168,6 +168,7 @@ All user functions are synchronous.
 | `addTags`       | Adds multiple tags for the current user.       | `tags: { [key: string]: string }`    |
 | `removeTag`     | Removes a tag for the current user.            | `key: string`                        |
 | `removeTags`    | Removes multiple tags for the current user.    | `keys: string[]`                     |
+| `getTags`       | Gets the current user's tags.                  |                                      |
 
 ### Notifications Namespace
 

--- a/__test__/support/helpers/core.ts
+++ b/__test__/support/helpers/core.ts
@@ -14,6 +14,7 @@ import {
 } from '../constants';
 import CoreModule from '../../../src/core/CoreModule';
 import { CoreModuleDirector } from '../../../src/core/CoreModuleDirector';
+import { UserPropertiesModel } from '../../../src/core/models/UserPropertiesModel';
 
 export function generateNewSubscription(modelId = '0000000000') {
   return new OSModel<SupportedSubscription>(
@@ -40,6 +41,12 @@ export function getDummyIdentityOSModel(
   modelId = DUMMY_MODEL_ID,
 ): OSModel<SupportedIdentity> {
   return new OSModel<SupportedIdentity>(ModelName.Identity, {}, modelId);
+}
+
+export function getDummyPropertyOSModel(
+  modelId = DUMMY_MODEL_ID,
+): OSModel<UserPropertiesModel> {
+  return new OSModel<UserPropertiesModel>(ModelName.Properties, {}, modelId);
 }
 
 export function getDummyPushSubscriptionOSModel(): OSModel<SupportedSubscription> {

--- a/__test__/unit/user/user.test.ts
+++ b/__test__/unit/user/user.test.ts
@@ -1,0 +1,57 @@
+import { TestEnvironment } from '../../support/environment/TestEnvironment';
+import User from '../../../src/onesignal/User';
+import { ModelName } from '../../../src/core/models/SupportedModels';
+import { getDummyPropertyOSModel } from '../../support/helpers/core';
+
+// suppress all internal logging
+jest.mock('../../../src/shared/libraries/Log');
+
+describe('User tests', () => {
+  test('getTags called without a properties model should return undefined tags', async () => {
+    await TestEnvironment.initialize();
+
+    const user = User.createOrGetInstance();
+    const tags = user.getTags();
+
+    expect(tags).toBe(undefined);
+  });
+
+  test('getTags called with undefined tags in properties model should return undefined tags', async () => {
+    await TestEnvironment.initialize();
+
+    OneSignal.coreDirector.add(ModelName.Properties, getDummyPropertyOSModel());
+
+    const user = User.createOrGetInstance();
+    const tags = user.getTags();
+
+    expect(tags).toBe(undefined);
+  });
+
+  test('getTags called with empty tags in properties model should return empty tags', async () => {
+    await TestEnvironment.initialize();
+
+    const propertyModel = getDummyPropertyOSModel();
+    propertyModel.set('tags', {});
+    OneSignal.coreDirector.add(ModelName.Properties, propertyModel);
+
+    const user = User.createOrGetInstance();
+    const tags = user.getTags();
+
+    expect(tags).toStrictEqual({});
+  });
+
+  test('getTags called with tags in properties model should return tags', async () => {
+    await TestEnvironment.initialize();
+
+    const tagsSample = { key1: 'value1' };
+
+    const propertyModel = getDummyPropertyOSModel();
+    propertyModel.set('tags', tagsSample);
+    OneSignal.coreDirector.add(ModelName.Properties, propertyModel);
+
+    const user = User.createOrGetInstance();
+    const tags = user.getTags();
+
+    expect(tags).toBe(tagsSample);
+  });
+});

--- a/api.json
+++ b/api.json
@@ -450,6 +450,12 @@
           }
         ],
         "returnType": "void"
+      },
+      {
+        "name": "getTags",
+        "isAsync": false,
+        "args": [],
+        "returnType": "{ [key: string]: string }"
       }
     ],
     "namespaces": ["PushSubscription"]

--- a/src/onesignal/User.ts
+++ b/src/onesignal/User.ts
@@ -335,4 +335,10 @@ export default class User {
       propertiesModel?.set('tags', tagsCopy);
     }
   }
+
+  public getTags(): { [key: string]: string } {
+    logMethodCall('getTags');
+
+    return OneSignal.coreDirector.getPropertiesModel()?.data?.tags;
+  }
 }

--- a/src/onesignal/UserNamespace.ts
+++ b/src/onesignal/UserNamespace.ts
@@ -72,6 +72,6 @@ export default class UserNamespace {
   }
 
   public getTags(): { [key: string]: string } {
-    return this._currentUser?.getTags() ? this._currentUser.getTags() : {};
+    return this._currentUser?.getTags() || {};
   }
 }

--- a/src/onesignal/UserNamespace.ts
+++ b/src/onesignal/UserNamespace.ts
@@ -70,4 +70,8 @@ export default class UserNamespace {
   public removeTags(keys: string[]): void {
     this._currentUser?.removeTags(keys);
   }
+
+  public getTags(): { [key: string]: string } {
+    return this._currentUser?.getTags() ? this._currentUser.getTags() : {};
+  }
 }


### PR DESCRIPTION
# Description
## 1 Line Summary
Adds the `getTags` method to the public API

## Details
Calling the public API `getTags` method returns an empty dictionary `{}` when the user property model tags field is undefined

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1140)
<!-- Reviewable:end -->
