### PR TITLE
Adjustments for Dev-Dev Environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "build:prod": "ENV=production yarn transpile:sources && ENV=production yarn bundle-sw && ENV=production yarn bundle-sdk && ENV=production yarn bundle-page-sdk-es6 && bundlesize && ENV=production build/scripts/publish.sh",
     "test": "NODE_OPTIONS=\"--trace-warnings --unhandled-rejections=warn\" yarn run jest --detectOpenHandles --forceExit --runInBand",
     "publish": "yarn clean && yarn build:prod && yarn",
-    "build:dev-dev": "./build/scripts/build.sh -f development -t development",
+    "build:dev-dev": "./build/scripts/build.sh -f development -t development -a localhost",
     "build:dev-prod": "./build/scripts/build.sh -f development -t production",
     "build:dev-stag": "./build/scripts/build.sh -f development -t staging",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx; yarn prettylint 'src/**/*' 'test/**/*' '__test__/**/*' --no-editorconfig",

--- a/src/shared/managers/SdkEnvironment.ts
+++ b/src/shared/managers/SdkEnvironment.ts
@@ -8,7 +8,7 @@ import Environment from '../helpers/Environment';
 
 const RESOURCE_HTTP_PORT = 4000;
 const RESOURCE_HTTPS_PORT = 4001;
-const API_URL_PORT = 3001;
+const API_URL_PORT = 3000;
 const TURBINE_API_URL_PORT = 18080;
 const TURBINE_ENDPOINTS = ['outcomes', 'on_focus'];
 
@@ -128,9 +128,9 @@ export default class SdkEnvironment {
     switch (buildEnv) {
       case EnvironmentKind.Development:
         if (SdkEnvironment.isTurbineEndpoint(action)) {
-          return new URL(`https://${apiOrigin}:${TURBINE_API_URL_PORT}/api/v1`);
+          return new URL(`http://${apiOrigin}:${TURBINE_API_URL_PORT}/api/v1`);
         }
-        return new URL(`https://${apiOrigin}:${API_URL_PORT}/api/v1`);
+        return new URL(`http://${apiOrigin}:${API_URL_PORT}/api/v1`);
       case EnvironmentKind.Staging:
         return new URL(`https://${apiOrigin}/api/v1`);
       case EnvironmentKind.Production:

--- a/test/unit/modules/sdkEnvironment.ts
+++ b/test/unit/modules/sdkEnvironment.ts
@@ -27,7 +27,7 @@ test('getWindowEnv should get host window environment', async (t) => {
 test('API URL should be valid for development environment', async (t) => {
   t.is(
     SdkEnvironment.getOneSignalApiUrl(EnvironmentKind.Development).toString(),
-    'https://localhost:3001/api/v1',
+    'https://localhost:3000/api/v1',
   );
 });
 


### PR DESCRIPTION
# Adjustments for Dev-Dev Environments

## Summary
- Change API port number to 3000 in dev-dev environments
- Update build script to default to localhost for API origin in dev-dev environments

## Description
This PR includes two primary updates to improve the development experience in dev-dev environments.

**API Port Configuration**
The API port number has been modified to 3000. This aligns with the current usage in our API development environment, ensuring consistency across our development setup.

**Build Script Modification**
We've made a key change in the build script. Now, it will automatically set the API origin to localhost when in dev-dev environments. This addresses the issue where the system would default to onesignal.com if no API origin was specified. With this update, developers can work more seamlessly, without the need to manually configure the API origin for local development.


# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
Changes were tested in conjunction with the a running local dev server.

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed
      - Changes unrelated to source code

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1157)
<!-- Reviewable:end -->
