### PR TITLE
[Feat] Add User change event listener and getters for OneSignal Id and external Id

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -154,21 +154,25 @@ OneSignal.User.addAlias("my_alias", "1234");
 
 All user functions are synchronous.
 
-| Function Name   | Description                                    | Argument List                        |
+| Property/Function | Description                                    | Argument List                        |
 | --------------- | ---------------------------------------------- | ------------------------------------ |
-| `addAlias`      | Adds a new alias for the current user.         | `label: string, id: string`          |
-| `addAliases`    | Adds multiple aliases for the current user.    | `aliases: { [key: string]: string }` |
-| `removeAlias`   | Removes an alias for the current user.         | `label: string`                      |
-| `removeAliases` | Removes multiple aliases for the current user. | `labels: string[]`                   |
-| `addEmail`      | Adds an email address for the current user.    | `email: string`                      |
-| `removeEmail`   | Removes an email address for the current user. | `email: string`                      |
-| `addSms`        | Adds an SMS number for the current user.       | `smsNumber: string`                  |
-| `removeSms`     | Removes an SMS number for the current user.    | `smsNumber: string`                  |
-| `addTag`        | Adds a tag for the current user.               | `key: string, value: string`         |
-| `addTags`       | Adds multiple tags for the current user.       | `tags: { [key: string]: string }`    |
-| `removeTag`     | Removes a tag for the current user.            | `key: string`                        |
-| `removeTags`    | Removes multiple tags for the current user.    | `keys: string[]`                     |
-| `getTags`       | Gets the current user's tags.                  |                                      |
+| `addAlias()`      | Adds a new alias for the current user.         | `label: string, id: string`          |
+| `addAliases()`    | Adds multiple aliases for the current user.    | `aliases: { [key: string]: string }` |
+| `removeAlias()`   | Removes an alias for the current user.         | `label: string`                      |
+| `removeAliases()` | Removes multiple aliases for the current user. | `labels: string[]`                   |
+| `addEmail()`      | Adds an email address for the current user.    | `email: string`                      |
+| `removeEmail()`   | Removes an email address for the current user. | `email: string`                      |
+| `addSms()`        | Adds an SMS number for the current user.       | `smsNumber: string`                  |
+| `removeSms()`     | Removes an SMS number for the current user.    | `smsNumber: string`                  |
+| `addTag()`        | Adds a tag for the current user.               | `key: string, value: string`         |
+| `addTags()`       | Adds multiple tags for the current user.       | `tags: { [key: string]: string }`    |
+| `removeTag()`     | Removes a tag for the current user.            | `key: string`                        |
+| `removeTags()`    | Removes multiple tags for the current user.    | `keys: string[]`                     |
+| `getTags()`       | Returns the local tags on the current user.    |                                      |
+| `onesignalId`     | Returns the local OneSignal Id for the current user. |                                |
+| `externalId`      | Returns the local external Id for the current user. |                                 |
+| `addEventListener()` | Adds an event listener for the `change` event. | - `event` ("change")<br>- `listener` ((change: UserChangeEvent) => void) |
+| `removeEventListener()` | Removes an event listener for the `change` event. | - `event` ("change")<br>- `listener` ((change: UserChangeEvent) => void) |
 
 ### Notifications Namespace
 

--- a/__test__/support/helpers/login.ts
+++ b/__test__/support/helpers/login.ts
@@ -6,6 +6,7 @@ import {
   DUMMY_GET_USER_REQUEST_WITH_PUSH_SUB,
 } from '../constants';
 import { RequestService } from '../../../src/core/requestService/RequestService';
+import { WindowEnvironmentKind } from '../../../src/shared/models/WindowEnvironmentKind';
 
 export function setupLoginStubs() {
   test.stub(
@@ -13,7 +14,7 @@ export function setupLoginStubs() {
     'getUser',
     Promise.resolve(DUMMY_GET_USER_REQUEST_WITH_PUSH_SUB),
   );
-  test.stub(SdkEnvironment, 'getWindowEnv');
+  test.stub(SdkEnvironment, 'getWindowEnv', WindowEnvironmentKind.Host);
   test.stub(
     MainHelper,
     'getCurrentPushToken',

--- a/api.json
+++ b/api.json
@@ -456,6 +456,50 @@
         "isAsync": false,
         "args": [],
         "returnType": "{ [key: string]: string }"
+      },
+      {
+        "name": "addEventListener",
+        "isAsync": false,
+        "args": [
+          {
+            "name": "event",
+            "type": "'change'",
+            "optional": false
+          },
+          {
+            "name": "listener",
+            "type": "(change: UserChangeEvent) => void",
+            "optional": false
+          }
+        ],
+        "returnType": "void"
+      },
+      {
+        "name": "removeEventListener",
+        "isAsync": false,
+        "args": [
+          {
+            "name": "event",
+            "type": "'change'",
+            "optional": false
+          },
+          {
+            "name": "listener",
+            "type": "(change: UserChangeEvent) => void",
+            "optional": false
+          }
+        ],
+        "returnType": "void"
+      }
+    ],
+    "properties": [
+      {
+        "name": "onesignalId",
+        "type": "string | undefined"
+      },
+      {
+        "name": "externalId",
+        "type": "string | undefined"
       }
     ],
     "namespaces": ["PushSubscription"]

--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -119,6 +119,12 @@
     });
 
     OneSignalDeferred.push(function(onesignal) {
+        onesignal.User.addEventListener('change', function (event) {
+          showEventAlert('change', { event });
+        });
+    });
+
+    OneSignalDeferred.push(function(onesignal) {
       onesignal.Notifications.addEventListener('permissionChange', function (isSubscribed) {
         showEventAlert('permissionChange', { isSubscribed });
       });

--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -108,12 +108,16 @@
               }
           }
         });
-        onesignal.User.PushSubscription.addEventListener('subscriptionChange', function (event) {
-          showEventAlert('subscriptionChange', { event });
-        });
     });
 
     /* E V E N T   L I S T E N E R S */
+
+    OneSignalDeferred.push(function(onesignal) {
+        onesignal.User.PushSubscription.addEventListener('change', function (event) {
+          showEventAlert('change', { event });
+        });
+    });
+
     OneSignalDeferred.push(function(onesignal) {
       onesignal.Notifications.addEventListener('permissionChange', function (isSubscribed) {
         showEventAlert('permissionChange', { isSubscribed });

--- a/src/core/CoreModuleDirector.ts
+++ b/src/core/CoreModuleDirector.ts
@@ -18,6 +18,7 @@ import FuturePushSubscriptionRecord from '../page/userModel/FuturePushSubscripti
 import User from '../onesignal/User';
 import OneSignal from '../onesignal/OneSignal';
 import Database from '../shared/services/Database';
+import EventHelper from '../shared/helpers/EventHelper';
 
 /* Contains OneSignal User-Model-specific logic*/
 
@@ -78,6 +79,7 @@ export class CoreModuleDirector {
         user.subscriptions as SubscriptionModel[],
         onesignalId,
       );
+      EventHelper.checkAndTriggerUserChanged();
     } catch (e) {
       Log.error(`Error hydrating user: ${e}`);
     }

--- a/src/page/models/UserChangeEvent.ts
+++ b/src/page/models/UserChangeEvent.ts
@@ -1,0 +1,10 @@
+type UserNamespaceProperties = {
+    onesignalId: string | undefined;
+    externalId: string | undefined;
+  };
+
+  type UserChangeEvent = {
+    current: UserNamespaceProperties;
+  };
+
+  export default UserChangeEvent;

--- a/src/page/models/UserChangeEvent.ts
+++ b/src/page/models/UserChangeEvent.ts
@@ -1,10 +1,10 @@
 type UserNamespaceProperties = {
-    onesignalId: string | undefined;
-    externalId: string | undefined;
-  };
+  onesignalId: string | undefined;
+  externalId: string | undefined;
+};
 
-  type UserChangeEvent = {
-    current: UserNamespaceProperties;
-  };
+type UserChangeEvent = {
+  current: UserNamespaceProperties;
+};
 
-  export default UserChangeEvent;
+export default UserChangeEvent;

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -227,7 +227,11 @@ export default class EventHelper {
   }
 
   static triggerUserChanged(change: UserChangeEvent) {
-    OneSignalEvent.trigger(OneSignal.EVENTS.SUBSCRIPTION_CHANGED, change, UserNamespace.emitter);
+    OneSignalEvent.trigger(
+      OneSignal.EVENTS.SUBSCRIPTION_CHANGED,
+      change,
+      UserNamespace.emitter,
+    );
   }
 
   static triggerNotificationClick(
@@ -326,10 +330,7 @@ export default class EventHelper {
     OneSignalUtils.logMethodCall('checkAndTriggerUserChanged');
 
     const userState = await Database.getUserState();
-    const {
-      previousOneSignalId,
-      previousExternalId,
-    } = userState;
+    const { previousOneSignalId, previousExternalId } = userState;
 
     const identityModel = await OneSignal.coreDirector.getIdentityModel();
     const currentOneSignalId = identityModel?.onesignalId;

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -9,12 +9,14 @@ import OneSignalUtils from '../utils/OneSignalUtils';
 import PromptsHelper from './PromptsHelper';
 import OneSignalEvent from '../services/OneSignalEvent';
 import SubscriptionChangeEvent from '../../page/models/SubscriptionChangeEvent';
+import UserChangeEvent from '../../page/models/UserChangeEvent';
 import MainHelper from './MainHelper';
 import {
   NotificationClickEvent,
   NotificationClickEventInternal,
 } from '../models/NotificationEvent';
 import { awaitOneSignalInitAndSupported } from '../utils/utils';
+import UserNamespace from '../../onesignal/UserNamespace';
 
 export default class EventHelper {
   static onNotificationPermissionChange() {
@@ -224,6 +226,10 @@ export default class EventHelper {
     OneSignalEvent.trigger(OneSignal.EVENTS.SUBSCRIPTION_CHANGED, change);
   }
 
+  static triggerUserChanged(change: UserChangeEvent) {
+    OneSignalEvent.trigger(OneSignal.EVENTS.SUBSCRIPTION_CHANGED, change, UserNamespace.emitter);
+  }
+
   static triggerNotificationClick(
     event: NotificationClickEventInternal,
   ): Promise<void> {
@@ -314,5 +320,39 @@ export default class EventHelper {
         }
       }
     }
+  }
+
+  static async checkAndTriggerUserChanged() {
+    OneSignalUtils.logMethodCall('checkAndTriggerUserChanged');
+
+    const userState = await Database.getUserState();
+    const {
+      previousOneSignalId,
+      previousExternalId,
+    } = userState;
+
+    const identityModel = await OneSignal.coreDirector.getIdentityModel();
+    const currentOneSignalId = identityModel?.onesignalId;
+    const currentExternalId = identityModel?.data?.external_id;
+
+    const didStateChange =
+      currentOneSignalId !== previousOneSignalId ||
+      currentExternalId !== previousExternalId;
+    if (!didStateChange) {
+      return;
+    }
+
+    userState.previousOneSignalId = currentOneSignalId;
+    userState.previousExternalId = currentExternalId;
+    await Database.setUserState(userState);
+
+    const change: UserChangeEvent = {
+      current: {
+        onesignalId: currentOneSignalId,
+        externalId: currentExternalId,
+      },
+    };
+    Log.info('User state changed: ', change);
+    EventHelper.triggerUserChanged(change);
   }
 }

--- a/src/shared/models/UserState.ts
+++ b/src/shared/models/UserState.ts
@@ -1,0 +1,6 @@
+class UserState {
+  previousOneSignalId: string | undefined;
+  previousExternalId: string | undefined;
+}
+
+export { UserState };

--- a/src/shared/services/Database.ts
+++ b/src/shared/services/Database.ts
@@ -249,8 +249,8 @@ export default class Database {
 
   async getUserState(): Promise<UserState> {
     const userState = new UserState();
-    userState.previousOneSignalId = "";
-    userState.previousExternalId = "";
+    userState.previousOneSignalId = '';
+    userState.previousExternalId = '';
     // previous<OneSignalId|ExternalId> are used to track changes to the user's state.
     // Displayed in the `current` & `previous` fields of the `userChange` event.
     userState.previousOneSignalId = await this.get<string>(

--- a/src/shared/services/Database.ts
+++ b/src/shared/services/Database.ts
@@ -3,6 +3,7 @@ import IndexedDb from './IndexedDb';
 
 import { AppConfig } from '../models/AppConfig';
 import { AppState, PendingNotificationClickEvents } from '../models/AppState';
+import { UserState } from '../models/UserState';
 import { IOSNotification } from '../models/OSNotification';
 import {
   OutcomesNotificationClicked,
@@ -244,6 +245,34 @@ export default class Database {
         }
       }
     }
+  }
+
+  async getUserState(): Promise<UserState> {
+    const userState = new UserState();
+    userState.previousOneSignalId = "";
+    userState.previousExternalId = "";
+    // previous<OneSignalId|ExternalId> are used to track changes to the user's state.
+    // Displayed in the `current` & `previous` fields of the `userChange` event.
+    userState.previousOneSignalId = await this.get<string>(
+      'Options',
+      'previousOneSignalId',
+    );
+    userState.previousExternalId = await this.get<string>(
+      'Options',
+      'previousExternalId',
+    );
+    return userState;
+  }
+
+  async setUserState(userState: UserState) {
+    await this.put('Options', {
+      key: 'previousOneSignalId',
+      value: userState.previousOneSignalId,
+    });
+    await this.put('Options', {
+      key: 'previousExternalId',
+      value: userState.previousExternalId,
+    });
   }
 
   async getSubscription(): Promise<Subscription> {
@@ -522,6 +551,14 @@ export default class Database {
 
   static async getAppState(): Promise<AppState> {
     return await Database.singletonInstance.getAppState();
+  }
+
+  static async setUserState(userState: UserState) {
+    return await Database.singletonInstance.setUserState(userState);
+  }
+
+  static async getUserState(): Promise<UserState> {
+    return await Database.singletonInstance.getUserState();
   }
 
   static async setAppConfig(appConfig: AppConfig) {

--- a/src/shared/services/OneSignalEvent.ts
+++ b/src/shared/services/OneSignalEvent.ts
@@ -2,6 +2,7 @@ import Environment from '../helpers/Environment';
 import SdkEnvironment from '../managers/SdkEnvironment';
 import Utils from '../context/Utils';
 import Log from '../libraries/Log';
+import Emitter from '../libraries/Emitter';
 
 const SILENT_EVENTS = [
   'notifyButtonHovering',
@@ -24,7 +25,7 @@ export default class OneSignalEvent {
    * @param eventName The string event name to be emitted.
    * @param data Any JavaScript variable to be passed with the event.
    */
-  static async trigger(eventName: string, data?: any) {
+  static async trigger(eventName: string, data?: any, emitter?: Emitter) {
     if (!Utils.contains(SILENT_EVENTS, eventName)) {
       const displayData = data;
       let env = Utils.capitalize(SdkEnvironment.getWindowEnv().toString());
@@ -42,7 +43,11 @@ export default class OneSignalEvent {
         if (OneSignal.initialized) return;
         else OneSignal.initialized = true;
       }
-      await OneSignal.emitter.emit(eventName, data);
+      if (emitter) {
+        await emitter.emit(eventName, data);
+      } else {
+        await OneSignal.emitter.emit(eventName, data);
+      }
     }
   }
 }

--- a/src/shared/services/OneSignalEvent.ts
+++ b/src/shared/services/OneSignalEvent.ts
@@ -24,6 +24,7 @@ export default class OneSignalEvent {
    * Triggers an internal event with optional custom data.
    * @param eventName The string event name to be emitted.
    * @param data Any JavaScript variable to be passed with the event.
+   * @param emitter Emitter to emit the event from.
    */
   static async trigger(eventName: string, data?: any, emitter?: Emitter) {
     if (!Utils.contains(SILENT_EVENTS, eventName)) {


### PR DESCRIPTION
# Description
## 1 Line Summary
Adds `change` event listener, `onesignalId` and `externalId` properties to OneSignal.User.

## Details
The User `change` event listener has the same name as the PushSubscription `change` event listener and should not be added to the same emitter because it will lead to both events being fired twice. 
Another emitter was added in the UserNamespace. All other namespaces still use the same static emitter from the OneSignal class.

The User emitter is static because there are two instances of UserNamespace where one is created on the property and again later when OneSignal initializes. When `addEventListener` is called by the dev, the event is being added before OneSignal initializes and to the property instance (`new UserNamespace(false)`). To keep the event on the new instance after initialization, the emitter is static.
```
OneSignal.ts
_initializeCoreModuleAndOSNamespace() {
  …
  OneSignal.User = new UserNamespace(true, subscription, permission); // initialize: boolean
}

static User = new UserNamespace(false); // initialize: boolean
```

Future considerations:
- Change `externalId` to be a property on `User`
- Add unit/integration tests
- Add an emitter for each namespace

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
Manually tested `OneSignal.User.onesignalId`, `OneSignal.User.externalId`, and User `change` event firing when calling login and logout on the OneSignal WebSDK Sandbox. 
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1158)
<!-- Reviewable:end -->
