### PR TITLE
[Fix] Add OneSignal-Subscription-Id header to create user requests

### DIFF
--- a/__test__/unit/http/sdkVersion.test.ts
+++ b/__test__/unit/http/sdkVersion.test.ts
@@ -1,6 +1,10 @@
 import Environment from '../../../src/shared/helpers/Environment';
 import { RequestService } from '../../../src/core/requestService/RequestService';
-import { APP_ID, DUMMY_EXTERNAL_ID } from '../../support/constants';
+import {
+  APP_ID,
+  DUMMY_EXTERNAL_ID,
+  DUMMY_SUBSCRIPTION_ID,
+} from '../../support/constants';
 import { expectHeaderToBeSent } from '../../support/helpers/sdkVersion';
 import AliasPair from '../../../src/core/requestService/AliasPair';
 import { getDummyPushSubscriptionOSModel } from '../../support/helpers/core';
@@ -46,6 +50,20 @@ describe('Sdk Version Header Tests', () => {
     RequestService.createUser({ appId: APP_ID }, {});
     expectHeaderToBeSent();
   });
+  test('POST /users: header is sent', () => {
+    RequestService.createUser(
+      { appId: APP_ID },
+      { refresh_device_metadata: true },
+    );
+    expectHeaderToBeSent();
+  });
+  test('POST /users: header is sent with subscription id', () => {
+    RequestService.createUser(
+      { appId: APP_ID, subscriptionId: DUMMY_SUBSCRIPTION_ID },
+      {},
+    );
+    expectHeaderToBeSent();
+  });
   test('GET /users/by/<alias_label>/<alias_id>: header is sent', () => {
     RequestService.getUser(
       { appId: APP_ID },
@@ -56,6 +74,14 @@ describe('Sdk Version Header Tests', () => {
   test('PATCH /users/by/<alias_label>/<alias_id>: header is sent', () => {
     RequestService.updateUser(
       { appId: APP_ID },
+      new AliasPair(AliasPair.EXTERNAL_ID, DUMMY_EXTERNAL_ID),
+      {},
+    );
+    expectHeaderToBeSent();
+  });
+  test('PATCH /users/by/<alias_label>/<alias_id>: header is sent with subscription id', () => {
+    RequestService.updateUser(
+      { appId: APP_ID, subscriptionId: DUMMY_SUBSCRIPTION_ID },
       new AliasPair(AliasPair.EXTERNAL_ID, DUMMY_EXTERNAL_ID),
       {},
     );

--- a/src/core/requestService/CreateUserPayload.ts
+++ b/src/core/requestService/CreateUserPayload.ts
@@ -1,0 +1,10 @@
+import { SupportedIdentity } from '../models/IdentityModel';
+import { SupportedSubscription } from '../models/SubscriptionModels';
+import { UserPropertiesModel } from '../models/UserPropertiesModel';
+
+export type CreateUserPayload = {
+  properties?: UserPropertiesModel;
+  identity?: SupportedIdentity;
+  refresh_device_metadata?: boolean;
+  subscriptions?: SupportedSubscription[];
+};

--- a/src/core/requestService/RequestService.ts
+++ b/src/core/requestService/RequestService.ts
@@ -7,7 +7,7 @@ import {
 } from '../models/SubscriptionModels';
 import AliasPair from './AliasPair';
 import { UpdateUserPayload } from './UpdateUserPayload';
-import UserData from '../models/UserData';
+import { CreateUserPayload } from './CreateUserPayload';
 import { RequestMetadata } from '../models/RequestMetadata';
 import { encodeRFC3986URIComponent } from '../../shared/utils/Encoding';
 import OneSignalUtils from '../../shared/utils/OneSignalUtils';
@@ -26,7 +26,7 @@ export class RequestService {
    */
   static async createUser(
     requestMetadata: RequestMetadata,
-    requestBody: Partial<UserData>,
+    requestBody: CreateUserPayload,
   ): Promise<OneSignalApiBaseResponse> {
     const { appId, subscriptionId } = requestMetadata;
 
@@ -44,8 +44,7 @@ export class RequestService {
       headers = { ...headers, ...requestMetadata.jwtHeader };
     }
 
-    const refreshMetadata = { refresh_device_metadata: true };
-    requestBody = { ...requestBody, ...refreshMetadata };
+    requestBody['refresh_device_metadata'] = true;
 
     return OneSignalApiBase.post(`apps/${appId}/users`, requestBody, headers);
   }

--- a/src/core/requestService/RequestService.ts
+++ b/src/core/requestService/RequestService.ts
@@ -28,12 +28,26 @@ export class RequestService {
     requestMetadata: RequestMetadata,
     requestBody: Partial<UserData>,
   ): Promise<OneSignalApiBaseResponse> {
-    const { appId } = requestMetadata;
-    return OneSignalApiBase.post(
-      `apps/${appId}/users`,
-      requestBody,
-      requestMetadata.jwtHeader,
-    );
+    const { appId, subscriptionId } = requestMetadata;
+
+    const subscriptionHeader = subscriptionId
+      ? { 'OneSignal-Subscription-Id': subscriptionId }
+      : undefined;
+
+    let headers = {};
+
+    if (subscriptionHeader) {
+      headers = { ...headers, ...subscriptionHeader };
+    }
+
+    if (requestMetadata.jwtHeader) {
+      headers = { ...headers, ...requestMetadata.jwtHeader };
+    }
+
+    const refreshMetadata = { refresh_device_metadata: true };
+    requestBody = { ...requestBody, ...refreshMetadata };
+
+    return OneSignalApiBase.post(`apps/${appId}/users`, requestBody, headers);
   }
 
   /**

--- a/src/core/requestService/UserPropertyRequests.ts
+++ b/src/core/requestService/UserPropertyRequests.ts
@@ -13,6 +13,7 @@ import { RequestService } from './RequestService';
 import MainHelper from '../../shared/helpers/MainHelper';
 import OneSignalApiBaseResponse from '../../shared/api/OneSignalApiBaseResponse';
 import Log from '../../shared/libraries/Log';
+import { isCompleteSubscriptionObject } from '../utils/typePredicates';
 
 /**
  * This class contains logic for all the UserProperty model related requests that can be made to the OneSignal API
@@ -44,9 +45,21 @@ export default class UserPropertyRequests {
     );
 
     const appId = await MainHelper.getAppId();
-    const response = await RequestService.updateUser({ appId }, aliasPair, {
-      properties,
-    });
+    const pushSubscription =
+      await OneSignal.coreDirector.getPushSubscriptionModel();
+
+    let subscriptionId;
+    if (isCompleteSubscriptionObject(pushSubscription?.data)) {
+      subscriptionId = pushSubscription?.data.id;
+    }
+
+    const response = await RequestService.updateUser(
+      { appId, subscriptionId },
+      aliasPair,
+      {
+        properties,
+      },
+    );
     return UserPropertyRequests._processUserPropertyResponse(response);
   }
 

--- a/src/onesignal/UserDirector.ts
+++ b/src/onesignal/UserDirector.ts
@@ -9,6 +9,7 @@ import { logMethodCall } from '../shared/utils/utils';
 import User from './User';
 import { RequestService } from '../core/requestService/RequestService';
 import { SupportedSubscription } from '../core/models/SubscriptionModels';
+import { isCompleteSubscriptionObject } from '../core/utils/typePredicates';
 
 export default class UserDirector {
   static async initializeUser(isTemporary?: boolean): Promise<void> {
@@ -95,8 +96,19 @@ export default class UserDirector {
 
     try {
       const appId = await MainHelper.getAppId();
+      const pushSubscription =
+        await OneSignal.coreDirector.getPushSubscriptionModel();
+
+      let subscriptionId;
+      if (isCompleteSubscriptionObject(pushSubscription?.data)) {
+        subscriptionId = pushSubscription?.data.id;
+      }
+
       const userData = await UserDirector.getAllUserData();
-      const response = await RequestService.createUser({ appId }, userData);
+      const response = await RequestService.createUser(
+        { appId, subscriptionId },
+        userData,
+      );
       user.isCreatingUser = false;
       return response.result as UserData;
     } catch (e) {

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -185,7 +185,7 @@ export default class LoginManager {
 
     if (isIdentified) {
       // if started off identified, upsert a user
-      result = await this.upsertUser(userData);
+      result = await this.upsertUser(userData, subscriptionId);
     } else {
       // promoting anonymous user to identified user
       // from user data, we only use identity (and we remove all aliases except external_id)
@@ -196,23 +196,16 @@ export default class LoginManager {
 
   static async upsertUser(
     userData: Partial<UserData>,
+    subscriptionId?: string,
     retry = 5,
   ): Promise<UserData> {
-    logMethodCall('LoginManager.upsertUser', { userData });
+    logMethodCall('LoginManager.upsertUser', { userData, subscriptionId });
 
     if (retry === 0) {
       throw new OneSignalError('Login: upsertUser failed: max retries reached');
     }
 
     const appId = await MainHelper.getAppId();
-    const pushSubscription =
-      await OneSignal.coreDirector.getPushSubscriptionModel();
-
-    let subscriptionId;
-    if (isCompleteSubscriptionObject(pushSubscription?.data)) {
-      subscriptionId = pushSubscription?.data.id;
-    }
-
     const userDataCopy = JSON.parse(JSON.stringify(userData));
 
     // only accepts one alias, so remove other aliases only leaving external_id
@@ -232,7 +225,7 @@ export default class LoginManager {
     } else if (status >= 500) {
       Log.error('Server error. Retrying...');
       await awaitableTimeout(RETRY_BACKOFF[retry]);
-      return this.upsertUser(userDataCopy, retry - 1);
+      return this.upsertUser(userDataCopy, subscriptionId, retry - 1);
     }
 
     return result;

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -205,12 +205,23 @@ export default class LoginManager {
     }
 
     const appId = await MainHelper.getAppId();
+    const pushSubscription =
+      await OneSignal.coreDirector.getPushSubscriptionModel();
+
+    let subscriptionId;
+    if (isCompleteSubscriptionObject(pushSubscription?.data)) {
+      subscriptionId = pushSubscription?.data.id;
+    }
+
     const userDataCopy = JSON.parse(JSON.stringify(userData));
 
     // only accepts one alias, so remove other aliases only leaving external_id
     this.stripAliasesOtherThanExternalId(userData);
 
-    const response = await RequestService.createUser({ appId }, userData);
+    const response = await RequestService.createUser(
+      { appId, subscriptionId },
+      userData,
+    );
     const result = response?.result;
     const status = response?.status;
 


### PR DESCRIPTION
# Description
## 1 Line Summary
Adds OneSignal-Subscription-Id header to create user requests

## Details
- Adds OneSignal-Subscription-Id and `refresh_device_metadtat: true` header to user create requests
- Adds OneSignal-Subscription-Id header to all user update requests
  - Previously the header was only added to session related requests

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info
Added unit tests for refresh_device_metadata and OneSignal-Subscription-Id for create user and OneSignal-Subscription-Id for update user. 
Manually tested on the OneSignal WebSDK Sandbox: Create user requests from login to an identified user from an identified user (OneSignal-Subscription-Id and refresh_device_metadata sent) and fresh install (no OneSignal-Subscription-Id). Update user requests from adding tags (OneSignal-Subscription-Id sent).
### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1161)
<!-- Reviewable:end -->
