### PR TITLE
[Fix] User change remove event listener

### DIFF
--- a/src/onesignal/UserNamespace.ts
+++ b/src/onesignal/UserNamespace.ts
@@ -102,6 +102,6 @@ export default class UserNamespace extends EventListenerBase {
     event: 'change',
     listener: (userChange: UserChangeEvent) => void,
   ): void {
-    UserNamespace.emitter.on(event, listener);
+    UserNamespace.emitter.off(event, listener);
   }
 }


### PR DESCRIPTION
# Description
Fix user change event listener to remove itself on remove

## Details

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1166)
<!-- Reviewable:end -->
