### PR TITLE
[Fix] Replace deprecated CSS 'push-button'. Adds type='button' to Custom Link Prompt.

### DIFF
--- a/src/page/stylesheets/reset.scss
+++ b/src/page/stylesheets/reset.scss
@@ -490,7 +490,7 @@
   font-family: arial, helvetica, sans-serif;
   font-size: small;
   background: white;
-  appearance: button; /* [Deprecation] The keyword 'push-button' specified to an 'appearance' property is not standardized. It will be removed in the future. */
+  appearance: button;
   color: buttontext;
   border: 1px #a6a6a6 solid;
   background: lightgrey; /* Old browsers */

--- a/src/page/stylesheets/reset.scss
+++ b/src/page/stylesheets/reset.scss
@@ -490,7 +490,7 @@
   font-family: arial, helvetica, sans-serif;
   font-size: small;
   background: white;
-  -webkit-appearance: push-button;
+  appearance: button; /* [Deprecation] The keyword 'push-button' specified to an 'appearance' property is not standardized. It will be removed in the future. */
   color: buttontext;
   border: 1px #a6a6a6 solid;
   background: lightgrey; /* Old browsers */

--- a/src/shared/managers/CustomLinkManager.ts
+++ b/src/shared/managers/CustomLinkManager.ts
@@ -114,6 +114,10 @@ export class CustomLinkManager {
         await this.handleClick(subscribeButton);
       });
 
+      // Adds type="button" to the Custom Link Button.
+      // This prevents this button submitting if included in a form.
+      subscribeButton.setAttribute('type', 'button');
+
       element.appendChild(subscribeButton);
     }
   }


### PR DESCRIPTION
# Description
- Fixes warning in console: `[Deprecation] The keyword 'push-button' specified to an 'appearance' property is not standardized. It will be removed in the future.`
- Adds `type="button"` to the Custom Link Button. This prevents this button submitting if included in a form.


## Details
Both long standing bugs.


# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
![image](https://github.com/OneSignal/OneSignal-Website-SDK/assets/3025406/3e026ba6-82e8-4b50-a9aa-fb3b845d81a1)

![image](https://github.com/OneSignal/OneSignal-Website-SDK/assets/3025406/90b2f6f9-0648-4910-a097-69e2f0ab5eea)



### Info

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1170)
<!-- Reviewable:end -->
