### PR TITLE
Introduce language functions on User model

### DIFF
--- a/__test__/unit/user/user.test.ts
+++ b/__test__/unit/user/user.test.ts
@@ -54,4 +54,20 @@ describe('User tests', () => {
 
     expect(tags).toBe(tagsSample);
   });
+
+
+  test('getLanguage should return the correct user language', async () => {
+    await TestEnvironment.initialize();
+
+    const languageSample = 'fr'
+
+    const propertyModel = getDummyPropertyOSModel();
+    propertyModel.set('language', languageSample);
+    OneSignal.coreDirector.add(ModelName.Properties, propertyModel);
+
+    const user = User.createOrGetInstance();
+    const language = user.getLanguage();
+
+    expect(language).toBe(languageSample);
+  });
 });

--- a/src/onesignal/User.ts
+++ b/src/onesignal/User.ts
@@ -341,4 +341,27 @@ export default class User {
 
     return OneSignal.coreDirector.getPropertiesModel()?.data?.tags;
   }
+
+  public setLanguage(language: string): void {
+    logMethodCall('setLanguage', { language });
+
+    if (typeof language !== 'string') {
+      throw new InvalidArgumentError(
+        'language',
+        InvalidArgumentReason.WrongType,
+      );
+    }
+
+    if (!language) {
+      throw new InvalidArgumentError('language', InvalidArgumentReason.Empty);
+    }
+
+    const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
+    propertiesModel?.set('language', language);
+  }
+
+  public getLanguage(): string {
+    logMethodCall('getLanguage');
+    return OneSignal.coreDirector.getPropertiesModel()?.data?.language;
+  }
 }

--- a/src/onesignal/UserNamespace.ts
+++ b/src/onesignal/UserNamespace.ts
@@ -91,6 +91,14 @@ export default class UserNamespace extends EventListenerBase {
     return this._currentUser?.getTags() || {};
   }
 
+  public setLanguage(language: string): void {
+    this._currentUser?.setLanguage(language);
+  }
+
+  getLanguage(): string {
+    return this._currentUser?.getLanguage() || '';
+  }
+
   addEventListener(
     event: 'change',
     listener: (userChange: UserChangeEvent) => void,

--- a/src/onesignal/UserNamespace.ts
+++ b/src/onesignal/UserNamespace.ts
@@ -95,7 +95,7 @@ export default class UserNamespace extends EventListenerBase {
     this._currentUser?.setLanguage(language);
   }
 
-  getLanguage(): string {
+  public getLanguage(): string {
     return this._currentUser?.getLanguage() || '';
   }
 


### PR DESCRIPTION
# Description
This pull request introduces setLanguage and getLanguage on the user class + namespace, to set the language

## Details

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

# Validation
- Changes were tested in conjunction with the a running local dev server.

### Benefits
- Being able to set the within the front-end SDK without needing to manually send a request to the API or use the back-end SDK

## Tests
- Introduced a getLanguage test in user.test.ts

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1171)
<!-- Reviewable:end -->
