### PR TITLE
[Dev Env] Add Windows cert install instructions

### DIFF
--- a/express_webpack/README.md
+++ b/express_webpack/README.md
@@ -13,11 +13,10 @@
       ```
       docker cp "$(docker-compose ps -q onesignal-web-sdk-dev)":sdk/express_webpack/certs/dev-ssl.crt .
       ```
-   - If you're running the container in a VM, get the cert file onto the VM's host (e.g: use `scp`)
-   - add cert to keychain (mac OSX):
-      ```
-      sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain dev-ssl.crt
-      ```
+      - If you're running the container in a VM, get the cert file onto the VM's host (e.g: use `scp`)
+   - Add cert to system's trusted store
+        - macOS: `sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain dev-ssl.crt`
+        - Windows: `Import-Certificate -FilePath dev-ssl.crt -CertStoreLocation cert:\CurrentUser\Root`
 3. Make sure the common name (e.g: localhost, texas, oregon, etc...) maps to the correct IP in your `/etc/hosts` file
 4. Visit [https://localhost:4001?app_id=](https://localhost:4001?app_id=) and insert your app id as a URL query parameter
 

--- a/express_webpack/certs/gen-cert.sh
+++ b/express_webpack/certs/gen-cert.sh
@@ -5,9 +5,10 @@ if test -f "$FILE"; then
 else
   echo "express_webpack:\n------ generating new SSL certs ------"
   echo "copy dev-ssl.crt from container to host with:\n>   docker cp <containerId>:sdk/express_webpack/certs/dev-ssl.crt ."
-  echo "add cert to keychain (MacOSX):\n>   sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/dev-ssl.crt\n"
+  echo "macOS - add cert to keychain:\n>   sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/dev-ssl.crt\n"
+  echo "Windows - add cert to cert store:\n> Import-Certificate -FilePath dev-ssl.crt -CertStoreLocation cert:\CurrentUser\Root"
   echo "restart browser\n--------------------------------------"
-  
+
   # generate cert/key based on conf file
   # defaults to use Common Name: texas
   openssl req -config ./certs/ssl-cert-gen.conf -subj '/C=US/CN=texas' -new -x509 -newkey rsa:2048 -nodes -keyout certs/dev-ssl.key -days 365 -out certs/dev-ssl.crt


### PR DESCRIPTION
# Description
## 1 Line Summary
For the development sandbox environment, add Windows cert install instructions.

## Details

# Validation
## Tests
### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1173)
<!-- Reviewable:end -->
