### PR TITLE
[Fix] Webhook dismissed not firing, and willDisplay when set from the dashboard

### DIFF
--- a/src/shared/helpers/ConfigHelper.ts
+++ b/src/shared/helpers/ConfigHelper.ts
@@ -581,7 +581,7 @@ export class ConfigHelper {
           webhooks: {
             cors: serverConfig.config.webhooks.corsEnable,
             'notification.willDisplay':
-              serverConfig.config.webhooks.notificationWillDisplayHook,
+              serverConfig.config.webhooks.notificationDisplayedHook,
             'notification.clicked':
               serverConfig.config.webhooks.notificationClickedHook,
             'notification.dismissed':

--- a/src/shared/models/AppConfig.ts
+++ b/src/shared/models/AppConfig.ts
@@ -234,7 +234,7 @@ export interface ServerAppConfig {
       corsEnable?: boolean;
       notificationClickedHook?: string;
       notificationDismissedHook?: string;
-      notificationWillDisplayHook?: string;
+      notificationDisplayedHook?: string;
     };
     integration: {
       kind: ConfigIntegrationKind;

--- a/src/sw/webhooks/notifications/payloads/OSWebhookPayloadNotificationDismiss.ts
+++ b/src/sw/webhooks/notifications/payloads/OSWebhookPayloadNotificationDismiss.ts
@@ -4,7 +4,7 @@ import { IOSNotification } from '../../../../shared/models/OSNotification';
 export class OSWebhookPayloadNotificationDismiss
   implements IOSWebhookEventPayload
 {
-  readonly event: string = 'notification.dismiss';
+  readonly event: string = 'notification.dismissed';
   readonly notificationId: string;
   readonly heading?: string;
   readonly content: string;


### PR DESCRIPTION
# Description
## One-Line Summary
Fixed issues with webhooks not reading parameters correctly, causing the dismissed and willDisplay to not fire.

## Details
* dismissed - this one was not firing at all due to the reading the wrong key from indexedDB
* willDisplay - This one wasn't working if set from the dashboard, works fine with "custom code"


# Validation
## Tests

Tested all 3 notification events to ensure they fired on Chrome 123 on Windows 11 23H2; willDisplay, dismissed, and clicked. 

### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1174)
<!-- Reviewable:end -->
