### PR TITLE
[Fix] add subscriptionId and url to webhook payloads

### DIFF
--- a/src/sw/webhooks/notifications/OSWebhookNotificationEventSender.ts
+++ b/src/sw/webhooks/notifications/OSWebhookNotificationEventSender.ts
@@ -11,19 +11,30 @@ export class OSWebhookNotificationEventSender {
     private readonly sender: OSWebhookSender = new OSWebhookSender(),
   ) {}
 
-  async click(event: NotificationClickEvent): Promise<void> {
-    return await this.sender.send(new OSWebhookPayloadNotificationClick(event));
-  }
-
-  async willDisplay(notification: IOSNotification): Promise<void> {
+  async click(
+    event: NotificationClickEvent,
+    subscriptionId: string | undefined,
+  ): Promise<void> {
     return await this.sender.send(
-      new OSWebhookPayloadNotificationWillDisplay(notification),
+      new OSWebhookPayloadNotificationClick(event, subscriptionId),
     );
   }
 
-  async dismiss(notification: IOSNotification): Promise<void> {
+  async willDisplay(
+    notification: IOSNotification,
+    subscriptionId: string | undefined,
+  ): Promise<void> {
     return await this.sender.send(
-      new OSWebhookPayloadNotificationDismiss(notification),
+      new OSWebhookPayloadNotificationWillDisplay(notification, subscriptionId),
+    );
+  }
+
+  async dismiss(
+    notification: IOSNotification,
+    subscriptionId: string | undefined,
+  ): Promise<void> {
+    return await this.sender.send(
+      new OSWebhookPayloadNotificationDismiss(notification, subscriptionId),
     );
   }
 }

--- a/src/sw/webhooks/notifications/payloads/OSWebhookPayloadNotificationClick.ts
+++ b/src/sw/webhooks/notifications/payloads/OSWebhookPayloadNotificationClick.ts
@@ -10,8 +10,14 @@ export class OSWebhookPayloadNotificationClick
   readonly content: string;
   readonly additionalData?: object;
   readonly actionId?: string;
+  readonly url?: string;
 
-  constructor(notificationClickEvent: NotificationClickEvent) {
+  readonly subscriptionId?: string;
+
+  constructor(
+    notificationClickEvent: NotificationClickEvent,
+    subscriptionId: string | undefined,
+  ) {
     const notification = notificationClickEvent.notification;
     this.notificationId = notification.notificationId;
     this.heading = notification.title;
@@ -19,5 +25,8 @@ export class OSWebhookPayloadNotificationClick
     this.additionalData = notification.additionalData;
 
     this.actionId = notificationClickEvent.result.actionId;
+    this.url = notificationClickEvent.result.url;
+
+    this.subscriptionId = subscriptionId;
   }
 }

--- a/src/sw/webhooks/notifications/payloads/OSWebhookPayloadNotificationDismiss.ts
+++ b/src/sw/webhooks/notifications/payloads/OSWebhookPayloadNotificationDismiss.ts
@@ -10,11 +10,20 @@ export class OSWebhookPayloadNotificationDismiss
   readonly content: string;
   readonly additionalData?: object;
   readonly actionId?: string;
+  readonly url?: string;
 
-  constructor(notification: IOSNotification) {
+  readonly subscriptionId?: string;
+
+  constructor(
+    notification: IOSNotification,
+    subscriptionId: string | undefined,
+  ) {
     this.notificationId = notification.notificationId;
     this.heading = notification.title;
     this.content = notification.body;
     this.additionalData = notification.additionalData;
+    this.url = notification.launchURL;
+
+    this.subscriptionId = subscriptionId;
   }
 }

--- a/src/sw/webhooks/notifications/payloads/OSWebhookPayloadNotificationWillDisplay.ts
+++ b/src/sw/webhooks/notifications/payloads/OSWebhookPayloadNotificationWillDisplay.ts
@@ -10,11 +10,20 @@ export class OSWebhookPayloadNotificationWillDisplay
   readonly content: string;
   readonly additionalData?: object;
   readonly actionId?: string;
+  readonly url?: string;
 
-  constructor(notification: IOSNotification) {
+  readonly subscriptionId?: string;
+
+  constructor(
+    notification: IOSNotification,
+    subscriptionId: string | undefined,
+  ) {
     this.notificationId = notification.notificationId;
     this.heading = notification.title;
     this.content = notification.body;
     this.additionalData = notification.additionalData;
+    this.url = notification.launchURL;
+
+    this.subscriptionId = subscriptionId;
   }
 }


### PR DESCRIPTION
# Description
## One-Line Summary
Add `subscriptionId` and `url` to webhook payloads; clicked, dismissed, and willDisplay.

## Details

# Validation
## Tests
Tested sending a few notifications ensuring the clicked, dismissed, and willDisplay fire with the new `subscriptionId` and `url` values filled in. In also tested the clicked with action buttons, ensuring the url in the webhook was the one clicked.

### Info

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1175)
<!-- Reviewable:end -->
