### PR TITLE
Operation repo refactor

### DIFF
--- a/__test__/support/constants.ts
+++ b/__test__/support/constants.ts
@@ -14,7 +14,7 @@
  * @constant {number} DELTA_QUEUE_TIME_ADVANCE - The time advance for the delta queue.
  */
 export const OPERATION_QUEUE_TIME_ADVANCE = 5001;
-export const DELTA_QUEUE_TIME_ADVANCE = 1001;
+export const DELTA_QUEUE_TIME_ADVANCE = 5001;
 
 /* S T R I N G   C O N S T A N T S */
 export const APP_ID = '34fcbe85-278d-4fd2-a4ec-0f80e95072c5';

--- a/__test__/support/constants.ts
+++ b/__test__/support/constants.ts
@@ -14,7 +14,7 @@
  * @constant {number} DELTA_QUEUE_TIME_ADVANCE - The time advance for the delta queue.
  */
 export const OPERATION_QUEUE_TIME_ADVANCE = 5001;
-export const DELTA_QUEUE_TIME_ADVANCE = 5001;
+export const DELTA_QUEUE_TIME_ADVANCE = 1001;
 
 /* S T R I N G   C O N S T A N T S */
 export const APP_ID = '34fcbe85-278d-4fd2-a4ec-0f80e95072c5';

--- a/__test__/support/constants.ts
+++ b/__test__/support/constants.ts
@@ -22,6 +22,7 @@ export const APP_ID = '34fcbe85-278d-4fd2-a4ec-0f80e95072c5';
 export const DUMMY_PUSH_TOKEN =
   'https://fcm.googleapis.com/fcm/send/01010101010101';
 export const DUMMY_ONESIGNAL_ID = '1111111111-2222222222-3333333333';
+export const DUMMY_ONESIGNAL_ID_2 = '2222222222-3333333333-4444444444';
 export const DUMMY_EXTERNAL_ID = 'rodrigo';
 export const DUMMY_EXTERNAL_ID_2 = 'iryna';
 export const DUMMY_SUBSCRIPTION_ID = '4444444444-5555555555-6666666666';

--- a/__test__/support/environment/TestEnvironment.ts
+++ b/__test__/support/environment/TestEnvironment.ts
@@ -59,7 +59,7 @@ export class TestEnvironment {
 
     if (config.useMockPushSubscriptionModel) {
       OneSignal.coreDirector.add(
-        ModelName.PushSubscriptions,
+        ModelName.Subscriptions,
         getDummyPushSubscriptionOSModel(),
         false,
       );

--- a/__test__/support/helpers/core.ts
+++ b/__test__/support/helpers/core.ts
@@ -18,7 +18,7 @@ import { UserPropertiesModel } from '../../../src/core/models/UserPropertiesMode
 
 export function generateNewSubscription(modelId = '0000000000') {
   return new OSModel<SupportedSubscription>(
-    ModelName.EmailSubscriptions,
+    ModelName.Subscriptions,
     {
       type: SubscriptionType.Email,
       id: '123', // subscription id
@@ -51,7 +51,7 @@ export function getDummyPropertyOSModel(
 
 export function getDummyPushSubscriptionOSModel(): OSModel<SupportedSubscription> {
   return new OSModel<SupportedSubscription>(
-    ModelName.PushSubscriptions,
+    ModelName.Subscriptions,
     {
       type: SubscriptionType.ChromePush,
       id: DUMMY_SUBSCRIPTION_ID,

--- a/__test__/support/helpers/pushSubscription.ts
+++ b/__test__/support/helpers/pushSubscription.ts
@@ -22,7 +22,7 @@ export async function initializeWithPermission(
 
   const pushModel = getDummyPushSubscriptionOSModel();
   OneSignal.coreDirector.add(
-    ModelName.PushSubscriptions,
+    ModelName.Subscriptions,
     pushModel as OSModel<SupportedModel>,
     false,
   );

--- a/__test__/unit/core/executors.test.ts
+++ b/__test__/unit/core/executors.test.ts
@@ -64,7 +64,7 @@ describe('Executor tests', () => {
 
     core.modelRepo?.broadcast({
       changeType: CoreChangeType.Add,
-      model: new OSModel(ModelName.EmailSubscriptions, {}),
+      model: new OSModel(ModelName.Subscriptions, {}),
     });
 
     jest.runOnlyPendingTimers();

--- a/__test__/unit/core/modelCache.test.ts
+++ b/__test__/unit/core/modelCache.test.ts
@@ -119,10 +119,10 @@ describe('ModelCache tests', () => {
     const modelCache = new ModelCache();
     const model1 = new OSModel(ModelName.Identity, { id: 'test1' });
     const model2 = new OSModel(ModelName.Identity, { id: 'test2' });
-    const model3 = new OSModel(ModelName.EmailSubscriptions, { id: 'test3' });
+    const model3 = new OSModel(ModelName.Subscriptions, { id: 'test3' });
     await modelCache.add(ModelName.Identity, model1);
     await modelCache.add(ModelName.Identity, model2);
-    await modelCache.add(ModelName.EmailSubscriptions, model3);
+    await modelCache.add(ModelName.Subscriptions, model3);
     const cachedModels = await modelCache.getAndDecodeModelsWithModelName(
       ModelName.Identity,
     );

--- a/__test__/unit/core/modelRepo.test.ts
+++ b/__test__/unit/core/modelRepo.test.ts
@@ -47,15 +47,18 @@ describe('ModelRepo tests', () => {
       'processModelAdded',
     );
     const newSub = generateNewSubscription();
-    const emailSubModels = coreDirector.getEmailSubscriptionModels();
+    let emailSubModels = coreDirector.getEmailSubscriptionModels();
 
     expect(Object.keys(emailSubModels).length).toBe(0);
 
     coreDirector.add(
-      ModelName.EmailSubscriptions,
+      ModelName.Subscriptions,
       newSub as OSModel<SupportedModel>,
       true,
     );
+
+    emailSubModels = coreDirector.getEmailSubscriptionModels();
+
     expect(processModelAddedSpy).toHaveBeenCalledTimes(1);
     expect(Object.keys(emailSubModels).length).toBe(1);
   });
@@ -66,16 +69,20 @@ describe('ModelRepo tests', () => {
       'processModelRemoved',
     );
     const newSub = generateNewSubscription();
-    const emailSubModels = coreDirector.getEmailSubscriptionModels();
 
     coreDirector.add(
-      ModelName.EmailSubscriptions,
+      ModelName.Subscriptions,
       newSub as OSModel<SupportedModel>,
       true,
     );
+
+    let emailSubModels = coreDirector.getEmailSubscriptionModels();
+
     expect(Object.keys(emailSubModels).length).toBe(1);
 
-    coreDirector.remove(ModelName.EmailSubscriptions, newSub.modelId);
+    coreDirector.remove(ModelName.Subscriptions, newSub.modelId);
+    emailSubModels = coreDirector.getEmailSubscriptionModels();
+
     expect(processModelRemovedSpy).toHaveBeenCalledTimes(1);
     expect(Object.keys(emailSubModels).length).toBe(0);
   });
@@ -88,7 +95,7 @@ describe('ModelRepo tests', () => {
     );
     const newSub = generateNewSubscription();
     coreDirector.add(
-      ModelName.EmailSubscriptions,
+      ModelName.Subscriptions,
       newSub as OSModel<SupportedModel>,
       true,
     );
@@ -109,7 +116,7 @@ describe('ModelRepo tests', () => {
     });
     const newSub = generateNewSubscription();
     coreDirector.add(
-      ModelName.EmailSubscriptions,
+      ModelName.Subscriptions,
       newSub as OSModel<SupportedModel>,
       true,
     );
@@ -124,11 +131,11 @@ describe('ModelRepo tests', () => {
     });
 
     coreDirector.add(
-      ModelName.EmailSubscriptions,
+      ModelName.Subscriptions,
       newSub as OSModel<SupportedModel>,
       true,
     );
-    coreDirector.remove(ModelName.EmailSubscriptions, newSub.modelId);
+    coreDirector.remove(ModelName.Subscriptions, newSub.modelId);
   });
 
   test('ModelRepo update subscription -> delta is broadcasted twice', (done: jest.DoneCallback) => {
@@ -140,7 +147,7 @@ describe('ModelRepo tests', () => {
     });
 
     coreDirector.add(
-      ModelName.EmailSubscriptions,
+      ModelName.Subscriptions,
       newSub as OSModel<SupportedModel>,
       true,
     );
@@ -156,7 +163,7 @@ describe('ModelRepo tests', () => {
       done();
     });
     coreDirector.add(
-      ModelName.EmailSubscriptions,
+      ModelName.Subscriptions,
       newSub as OSModel<SupportedModel>,
       true,
     );
@@ -179,11 +186,11 @@ describe('ModelRepo tests', () => {
     });
 
     coreDirector.add(
-      ModelName.EmailSubscriptions,
+      ModelName.Subscriptions,
       newSub as OSModel<SupportedModel>,
       true,
     );
-    coreDirector.remove(ModelName.EmailSubscriptions, newSub.modelId);
+    coreDirector.remove(ModelName.Subscriptions, newSub.modelId);
   });
 
   test('ModelRepo update subscription -> delta is broadcasted with correct change type and payload', (done: jest.DoneCallback) => {
@@ -201,7 +208,7 @@ describe('ModelRepo tests', () => {
     });
 
     coreDirector.add(
-      ModelName.EmailSubscriptions,
+      ModelName.Subscriptions,
       newSub as OSModel<SupportedModel>,
       true,
     );
@@ -218,7 +225,7 @@ describe('ModelRepo tests', () => {
     const modelCacheAddSpy = jest.spyOn(ModelCache.prototype as any, 'add');
 
     coreDirector.add(
-      ModelName.EmailSubscriptions,
+      ModelName.Subscriptions,
       newSub as OSModel<SupportedModel>,
       true,
     );

--- a/__test__/unit/core/operationRepo.test.ts
+++ b/__test__/unit/core/operationRepo.test.ts
@@ -45,8 +45,21 @@ describe('OperationRepo tests', () => {
       onesignal_id: '123',
     });
     jest.useFakeTimers();
-    TestEnvironment.initialize();
+    await TestEnvironment.initialize();
     broadcastCount = 0;
+
+    const { operationRepo } = OneSignal.coreDirector.core;
+
+    const identityExecutor =
+      operationRepo?.executorStore.store[ModelName.Identity];
+    const propertiesExecutor =
+      operationRepo?.executorStore.store[ModelName.Properties];
+    const subscriptionExecutor =
+      operationRepo?.executorStore.store[ModelName.Subscriptions];
+
+    identityExecutor._operationQueue = [];
+    propertiesExecutor._operationQueue = [];
+    subscriptionExecutor._operationQueue = [];
   });
 
   afterEach(async () => {
@@ -79,8 +92,6 @@ describe('OperationRepo tests', () => {
     const executor =
       operationRepo?.executorStore.store[ModelName.Subscriptions];
 
-    executor._operationQueue = [];
-
     modelRepo?.subscribe(() => {
       broadcastCount += 1;
       passIfBroadcastNTimes(1, broadcastCount, done);
@@ -109,8 +120,6 @@ describe('OperationRepo tests', () => {
     const { modelRepo, operationRepo } = OneSignal.coreDirector.core;
     const executor =
       operationRepo?.executorStore.store[ModelName.Subscriptions];
-
-    executor._operationQueue = [];
 
     const processDeltaSpy = jest.spyOn(
       OperationRepo.prototype as any,
@@ -147,8 +156,6 @@ describe('OperationRepo tests', () => {
 
     const { modelRepo, operationRepo } = OneSignal.coreDirector.core;
     const executor = operationRepo?.executorStore.store[ModelName.Identity];
-
-    executor._operationQueue = [];
 
     const processDeltaSpy = jest.spyOn(
       OperationRepo.prototype as any,
@@ -216,8 +223,6 @@ describe('OperationRepo tests', () => {
 
     const { modelRepo, operationRepo } = OneSignal.coreDirector.core;
     const executor = operationRepo?.executorStore.store[ModelName.Properties];
-
-    executor._operationQueue = [];
 
     const processDeltaSpy = jest.spyOn(
       OperationRepo.prototype as any,

--- a/__test__/unit/core/operationRepo.test.ts
+++ b/__test__/unit/core/operationRepo.test.ts
@@ -79,6 +79,8 @@ describe('OperationRepo tests', () => {
     const executor =
       operationRepo?.executorStore.store[ModelName.EmailSubscriptions];
 
+    executor._operationQueue = [];
+
     modelRepo?.subscribe(() => {
       broadcastCount += 1;
       passIfBroadcastNTimes(1, broadcastCount, done);
@@ -107,6 +109,8 @@ describe('OperationRepo tests', () => {
     const { modelRepo, operationRepo } = OneSignal.coreDirector.core;
     const executor =
       operationRepo?.executorStore.store[ModelName.EmailSubscriptions];
+
+    executor._operationQueue = [];
 
     const processDeltaSpy = jest.spyOn(
       OperationRepo.prototype as any,
@@ -143,6 +147,8 @@ describe('OperationRepo tests', () => {
 
     const { modelRepo, operationRepo } = OneSignal.coreDirector.core;
     const executor = operationRepo?.executorStore.store[ModelName.Identity];
+
+    executor._operationQueue = [];
 
     const processDeltaSpy = jest.spyOn(
       OperationRepo.prototype as any,
@@ -210,6 +216,8 @@ describe('OperationRepo tests', () => {
 
     const { modelRepo, operationRepo } = OneSignal.coreDirector.core;
     const executor = operationRepo?.executorStore.store[ModelName.Properties];
+
+    executor._operationQueue = [];
 
     const processDeltaSpy = jest.spyOn(
       OperationRepo.prototype as any,

--- a/__test__/unit/core/operationRepo.test.ts
+++ b/__test__/unit/core/operationRepo.test.ts
@@ -77,7 +77,7 @@ describe('OperationRepo tests', () => {
   test('Model repo delta broadcast is received and processed by operation repo', (done: jest.DoneCallback) => {
     const { modelRepo, operationRepo } = OneSignal.coreDirector.core;
     const executor =
-      operationRepo?.executorStore.store[ModelName.EmailSubscriptions];
+      operationRepo?.executorStore.store[ModelName.Subscriptions];
 
     executor._operationQueue = [];
 
@@ -108,7 +108,7 @@ describe('OperationRepo tests', () => {
   test('Add Subscriptions: multiple delta broadcasts -> two operations of change type: add', (done: jest.DoneCallback) => {
     const { modelRepo, operationRepo } = OneSignal.coreDirector.core;
     const executor =
-      operationRepo?.executorStore.store[ModelName.EmailSubscriptions];
+      operationRepo?.executorStore.store[ModelName.Subscriptions];
 
     executor._operationQueue = [];
 

--- a/__test__/unit/core/osModel.test.ts
+++ b/__test__/unit/core/osModel.test.ts
@@ -39,7 +39,7 @@ describe('OSModel tests', () => {
     const encodedSub = newSub.encode();
     expect(encodedSub).toEqual({
       modelId: '0000000000',
-      modelName: ModelName.EmailSubscriptions,
+      modelName: ModelName.Subscriptions,
       type: SubscriptionType.Email,
       id: '123',
       token: 'myToken',
@@ -49,7 +49,7 @@ describe('OSModel tests', () => {
   test('Decode function returns decoded model', async () => {
     const encodedSub = {
       modelId: '0000000000',
-      modelName: ModelName.EmailSubscriptions,
+      modelName: ModelName.Subscriptions,
       type: SubscriptionType.Email,
       id: '123',
       token: 'myToken',
@@ -64,9 +64,7 @@ describe('OSModel tests', () => {
 
     // upstream bug workaround https://github.com/facebook/jest/issues/8475
     expect(JSON.stringify(decodedSub)).toEqual(
-      JSON.stringify(
-        new OSModel(ModelName.EmailSubscriptions, model, '0000000000'),
-      ),
+      JSON.stringify(new OSModel(ModelName.Subscriptions, model, '0000000000')),
     );
   });
 });

--- a/src/core/CoreModuleDirector.ts
+++ b/src/core/CoreModuleDirector.ts
@@ -21,6 +21,7 @@ import User from '../onesignal/User';
 import OneSignal from '../onesignal/OneSignal';
 import Database from '../shared/services/Database';
 import EventHelper from '../shared/helpers/EventHelper';
+import SubscriptionHelper from '../../src/shared/helpers/SubscriptionHelper';
 
 /* Contains OneSignal User-Model-specific logic*/
 
@@ -123,7 +124,7 @@ export class CoreModuleDirector {
        */
       const existingSubscription = !!subscription.token
         ? this.getSubscriptionOfTypeWithToken(
-            this.toSubscriptionChannel(subscription.type),
+            SubscriptionHelper.toSubscriptionChannel(subscription.type),
             subscription.token,
           )
         : undefined;
@@ -247,7 +248,7 @@ export class CoreModuleDirector {
 
     const pushSubscriptions = Object.fromEntries(
       Object.entries(subscriptionModels).filter(([, model]) =>
-        this.isPushSubscriptionType(model.data?.type),
+        SubscriptionHelper.isPushSubscriptionType(model.data?.type),
       ),
     );
 
@@ -366,35 +367,5 @@ export class CoreModuleDirector {
 
   private getModelStores(): ModelStoresMap<SupportedModel> {
     return this.core.modelRepo?.modelStores as ModelStoresMap<SupportedModel>;
-  }
-
-  /**
-   * Helper that checks if a given SubscriptionType is a push subscription.
-   */
-  public isPushSubscriptionType(type: SubscriptionType): boolean {
-    switch (type) {
-      case SubscriptionType.ChromePush:
-      case SubscriptionType.SafariPush:
-      case SubscriptionType.SafariLegacyPush:
-      case SubscriptionType.FirefoxPush:
-        return true;
-      default:
-        return false;
-    }
-  }
-
-  public toSubscriptionChannel(type: SubscriptionType) {
-    switch (type) {
-      case SubscriptionType.Email:
-        return SubscriptionChannel.Email;
-      case SubscriptionType.SMS:
-        return SubscriptionChannel.SMS;
-      default:
-        if (this.isPushSubscriptionType(type)) {
-          return SubscriptionChannel.Push;
-        }
-
-        return undefined;
-    }
   }
 }

--- a/src/core/caching/EncodedModel.ts
+++ b/src/core/caching/EncodedModel.ts
@@ -8,5 +8,6 @@ export default interface EncodedModel {
   modelId: string;
   modelName: ModelName;
   onesignalId?: string;
+  externalId?: string;
   [key: string]: unknown;
 }

--- a/src/core/executors/ExecutorBase.ts
+++ b/src/core/executors/ExecutorBase.ts
@@ -78,7 +78,6 @@ export default abstract class ExecutorBase {
   }
 
   protected _flushDeltas(): void {
-    logMethodCall('ExecutorBase._flushDeltas');
     this._deltaQueue = [];
   }
 

--- a/src/core/executors/ExecutorBase.ts
+++ b/src/core/executors/ExecutorBase.ts
@@ -28,17 +28,10 @@ export default abstract class ExecutorBase {
 
   private onlineStatus = true;
 
-  static DELTAS_BATCH_PROCESSING_TIME = 1;
   static OPERATIONS_BATCH_PROCESSING_TIME = 5;
   static RETRY_COUNT = 5;
 
   constructor(executorConfig: ExecutorConfig<SupportedModel>) {
-    setInterval(() => {
-      if (this._deltaQueue.length > 0) {
-        this.processDeltaQueue.call(this);
-      }
-    }, ExecutorBase.DELTAS_BATCH_PROCESSING_TIME * 1_000);
-
     setInterval(() => {
       Log.debug('OneSignal: checking for operations to process from cache');
       const cachedOperations = this.getOperationsFromCache();

--- a/src/core/executors/ExecutorConfigMap.ts
+++ b/src/core/executors/ExecutorConfigMap.ts
@@ -20,16 +20,8 @@ export const EXECUTOR_CONFIG_MAP: ExecutorConfigMap = {
     modelName: ModelName.Properties,
     update: UserPropertyRequests.updateUserProperties,
   },
-  [ModelName.PushSubscriptions]: {
-    modelName: ModelName.PushSubscriptions,
-    ...subscriptionConfig,
-  },
-  [ModelName.EmailSubscriptions]: {
-    modelName: ModelName.EmailSubscriptions,
-    ...subscriptionConfig,
-  },
-  [ModelName.SmsSubscriptions]: {
-    modelName: ModelName.SmsSubscriptions,
+  [ModelName.Subscriptions]: {
+    modelName: ModelName.Subscriptions,
     ...subscriptionConfig,
   },
 };

--- a/src/core/executors/ExecutorFactory.ts
+++ b/src/core/executors/ExecutorFactory.ts
@@ -6,6 +6,8 @@ import { PropertiesExecutor } from './PropertiesExecutor';
 import { SubscriptionExecutor } from './SubscriptionExecutor';
 
 export class ExecutorFactory {
+  static subscriptionExecutor?: SubscriptionExecutor = undefined;
+
   static build(executorConfig: ExecutorConfig<SupportedModel>): Executor {
     switch (executorConfig.modelName) {
       case ModelName.Identity:
@@ -15,7 +17,12 @@ export class ExecutorFactory {
       case ModelName.PushSubscriptions:
       case ModelName.EmailSubscriptions:
       case ModelName.SmsSubscriptions:
-        return new SubscriptionExecutor(executorConfig);
+        if (!ExecutorFactory.subscriptionExecutor) {
+          ExecutorFactory.subscriptionExecutor = new SubscriptionExecutor(
+            executorConfig,
+          );
+        }
+        return ExecutorFactory.subscriptionExecutor;
     }
   }
 }

--- a/src/core/executors/ExecutorFactory.ts
+++ b/src/core/executors/ExecutorFactory.ts
@@ -6,23 +6,14 @@ import { PropertiesExecutor } from './PropertiesExecutor';
 import { SubscriptionExecutor } from './SubscriptionExecutor';
 
 export class ExecutorFactory {
-  static subscriptionExecutor?: SubscriptionExecutor = undefined;
-
   static build(executorConfig: ExecutorConfig<SupportedModel>): Executor {
     switch (executorConfig.modelName) {
       case ModelName.Identity:
         return new IdentityExecutor(executorConfig);
       case ModelName.Properties:
         return new PropertiesExecutor(executorConfig);
-      case ModelName.PushSubscriptions:
-      case ModelName.EmailSubscriptions:
-      case ModelName.SmsSubscriptions:
-        if (!ExecutorFactory.subscriptionExecutor) {
-          ExecutorFactory.subscriptionExecutor = new SubscriptionExecutor(
-            executorConfig,
-          );
-        }
-        return ExecutorFactory.subscriptionExecutor;
+      case ModelName.Subscriptions:
+        return new SubscriptionExecutor(executorConfig);
     }
   }
 }

--- a/src/core/executors/ExecutorStore.ts
+++ b/src/core/executors/ExecutorStore.ts
@@ -19,8 +19,21 @@ export class ExecutorStore {
 
   // call processDeltaQueue on all executors immediately
   public forceDeltaQueueProcessingOnAllExecutors(): void {
+    let didSubscriptionExecutorProcessDeltaQueue = false;
+
     Object.values(this.store).forEach((executor) => {
+      if (
+        executor instanceof SubscriptionExecutor &&
+        didSubscriptionExecutorProcessDeltaQueue
+      ) {
+        return;
+      }
+
       executor.processDeltaQueue();
+
+      if (executor instanceof SubscriptionExecutor) {
+        didSubscriptionExecutorProcessDeltaQueue = true;
+      }
     });
   }
 }

--- a/src/core/executors/ExecutorStore.ts
+++ b/src/core/executors/ExecutorStore.ts
@@ -19,21 +19,8 @@ export class ExecutorStore {
 
   // call processDeltaQueue on all executors immediately
   public forceDeltaQueueProcessingOnAllExecutors(): void {
-    let didSubscriptionExecutorProcessDeltaQueue = false;
-
     Object.values(this.store).forEach((executor) => {
-      if (
-        executor instanceof SubscriptionExecutor &&
-        didSubscriptionExecutorProcessDeltaQueue
-      ) {
-        return;
-      }
-
       executor.processDeltaQueue();
-
-      if (executor instanceof SubscriptionExecutor) {
-        didSubscriptionExecutorProcessDeltaQueue = true;
-      }
     });
   }
 }

--- a/src/core/executors/SubscriptionExecutor.ts
+++ b/src/core/executors/SubscriptionExecutor.ts
@@ -35,17 +35,7 @@ export class SubscriptionExecutor extends ExecutorBase {
   }
 
   getOperationsFromCache(): Operation<SupportedModel>[] {
-    const smsOperations = OperationCache.getOperationsWithModelName(
-      ModelName.SmsSubscriptions,
-    );
-    const emailOperations = OperationCache.getOperationsWithModelName(
-      ModelName.EmailSubscriptions,
-    );
-    const pushSubOperations = OperationCache.getOperationsWithModelName(
-      ModelName.PushSubscriptions,
-    );
-
-    return [...smsOperations, ...emailOperations, ...pushSubOperations];
+    return OperationCache.getOperationsWithModelName(ModelName.Subscriptions);
   }
 
   private separateDeltasByChangeType(deltas: CoreDelta<SupportedModel>[]): {

--- a/src/core/modelRepo/OSModel.ts
+++ b/src/core/modelRepo/OSModel.ts
@@ -17,6 +17,7 @@ export class OSModel<Model> extends Subscribable<ModelStoreChange<Model>> {
   onesignalId?: string;
   awaitOneSignalIdAvailable: Promise<string>;
   onesignalIdAvailableCallback?: (onesignalId: string) => void;
+  externalId?: string;
 
   constructor(
     readonly modelName: ModelName,
@@ -28,6 +29,7 @@ export class OSModel<Model> extends Subscribable<ModelStoreChange<Model>> {
     this.modelName = modelName;
     this.data = data;
     this.onesignalId = undefined;
+    this.externalId = undefined;
 
     this.awaitOneSignalIdAvailable = new Promise<string>((resolve) => {
       this.onesignalIdAvailableCallback = resolve;
@@ -46,6 +48,11 @@ export class OSModel<Model> extends Subscribable<ModelStoreChange<Model>> {
     if (onesignalId) {
       this.onesignalIdAvailableCallback?.(onesignalId);
     }
+  }
+
+  public setExternalId(externalId?: string): void {
+    logMethodCall('setExternalId', { externalId });
+    this.externalId = externalId;
   }
 
   /**
@@ -92,7 +99,8 @@ export class OSModel<Model> extends Subscribable<ModelStoreChange<Model>> {
     const modelId = this.modelId as string;
     const modelName = this.modelName;
     const onesignalId = this.onesignalId;
-    return { modelId, modelName, onesignalId, ...this.data };
+    const externalId = this.externalId;
+    return { modelId, modelName, onesignalId, externalId, ...this.data };
   }
 
   /**
@@ -102,7 +110,8 @@ export class OSModel<Model> extends Subscribable<ModelStoreChange<Model>> {
    */
   static decode(encodedModel: EncodedModel): OSModel<SupportedModel> {
     logMethodCall('decode', { encodedModel });
-    const { modelId, modelName, onesignalId, ...data } = encodedModel;
+    const { modelId, modelName, onesignalId, externalId, ...data } =
+      encodedModel;
 
     const decodedModel = new OSModel<SupportedModel>(
       modelName as ModelName,
@@ -111,6 +120,7 @@ export class OSModel<Model> extends Subscribable<ModelStoreChange<Model>> {
     );
 
     decodedModel.setOneSignalId(onesignalId);
+    decodedModel.setExternalId(externalId);
     return decodedModel;
   }
 }

--- a/src/core/models/SubscriptionModels.ts
+++ b/src/core/models/SubscriptionModels.ts
@@ -12,6 +12,12 @@ export enum SubscriptionType {
   // There are other OneSignal types, but only including ones used here.
 }
 
+export enum SubscriptionChannel {
+  Email = 'Email',
+  SMS = 'SMS',
+  Push = 'Push',
+}
+
 export interface FutureSubscriptionModel {
   type: SubscriptionType;
   token?: string; // maps to legacy player.identifier

--- a/src/core/models/SupportedModels.ts
+++ b/src/core/models/SupportedModels.ts
@@ -5,7 +5,10 @@ import { UserPropertiesModel } from './UserPropertiesModel';
 export enum ModelName {
   Identity = 'identity',
   Properties = 'properties',
-  // TO DO: make singular
+  Subscriptions = 'subscriptions',
+}
+
+export enum LegacyModelName {
   PushSubscriptions = 'pushSubscriptions',
   EmailSubscriptions = 'emailSubscriptions',
   SmsSubscriptions = 'smsSubscriptions',

--- a/src/core/operationRepo/OperationRepo.ts
+++ b/src/core/operationRepo/OperationRepo.ts
@@ -40,7 +40,6 @@ export class OperationRepo {
   }
 
   private _flushDeltas(): void {
-    logMethodCall('OperationRepo._flushDeltas');
     this._deltaQueue = [];
   }
 

--- a/src/core/operationRepo/OperationRepo.ts
+++ b/src/core/operationRepo/OperationRepo.ts
@@ -60,11 +60,8 @@ export class OperationRepo {
       this.executorStore.store[modelName]?.enqueueDelta(delta);
     });
 
-    // for each executor
-    // TODO: fires SubscriptionExecutor.processDeltaQueue and SubscriptionExecutor._flushDeltas 3 times
-    // ExecutorStore has 3 ModelName for Subscriptions: smsSubscription, emailSubscription, pushSubscription
+    // for each executor: processDeltaQueue and flush
     this.forceDeltaQueueProcessingOnAllExecutors();
-    // executors flush is in the above method
 
     this._flushDeltas();
   }

--- a/src/core/operationRepo/OperationRepo.ts
+++ b/src/core/operationRepo/OperationRepo.ts
@@ -8,7 +8,7 @@ export class OperationRepo {
   public executorStore: ExecutorStore;
   private _unsubscribeFromModelRepo: () => void;
   private _deltaQueue: CoreDelta<SupportedModel>[] = [];
-  static DELTAS_BATCH_PROCESSING_TIME = 5;
+  static DELTAS_BATCH_PROCESSING_TIME = 1;
 
   constructor(private modelRepo: ModelRepo) {
     this.executorStore = new ExecutorStore();

--- a/src/core/operationRepo/OperationRepo.ts
+++ b/src/core/operationRepo/OperationRepo.ts
@@ -20,9 +20,7 @@ export class OperationRepo {
     );
 
     setInterval(() => {
-      if (this._deltaQueue.length > 0) {
-        this._processDeltaQueue();
-      }
+      this._processDeltaQueue();
     }, OperationRepo.DELTAS_BATCH_PROCESSING_TIME * 1_000);
   }
 

--- a/src/core/operationRepo/OperationRepo.ts
+++ b/src/core/operationRepo/OperationRepo.ts
@@ -7,6 +7,8 @@ import { logMethodCall } from '../../shared/utils/utils';
 export class OperationRepo {
   public executorStore: ExecutorStore;
   private _unsubscribeFromModelRepo: () => void;
+  private _deltaQueue: CoreDelta<SupportedModel>[] = [];
+  static DELTAS_BATCH_PROCESSING_TIME = 5;
 
   constructor(private modelRepo: ModelRepo) {
     this.executorStore = new ExecutorStore();
@@ -16,6 +18,12 @@ export class OperationRepo {
         this._processDelta(delta);
       },
     );
+
+    setInterval(() => {
+      if (this._deltaQueue.length > 0) {
+        this._processDeltaQueue();
+      }
+    }, OperationRepo.DELTAS_BATCH_PROCESSING_TIME * 1_000);
   }
 
   setModelRepoAndResubscribe(modelRepo: ModelRepo) {
@@ -33,9 +41,31 @@ export class OperationRepo {
     this.executorStore.forceDeltaQueueProcessingOnAllExecutors();
   }
 
+  private _flushDeltas(): void {
+    logMethodCall('OperationRepo._flushDeltas');
+    this._deltaQueue = [];
+  }
+
   private _processDelta(delta: CoreDelta<SupportedModel>): void {
-    logMethodCall('processDelta', { delta });
-    const { modelName } = delta.model;
-    this.executorStore.store[modelName]?.enqueueDelta(delta);
+    logMethodCall('OperationRepo._processDelta', { delta });
+    const deltaCopy = JSON.parse(JSON.stringify(delta));
+    this._deltaQueue.push(deltaCopy);
+  }
+
+  private _processDeltaQueue(): void {
+    logMethodCall('OperationRepo._processDeltaQueue');
+
+    this._deltaQueue.forEach((delta) => {
+      const { modelName } = delta.model;
+      this.executorStore.store[modelName]?.enqueueDelta(delta);
+    });
+
+    // for each executor
+    // TODO: fires SubscriptionExecutor.processDeltaQueue and SubscriptionExecutor._flushDeltas 3 times
+    // ExecutorStore has 3 ModelName for Subscriptions: smsSubscription, emailSubscription, pushSubscription
+    this.forceDeltaQueueProcessingOnAllExecutors();
+    // executors flush is in the above method
+
+    this._flushDeltas();
   }
 }

--- a/src/onesignal/User.ts
+++ b/src/onesignal/User.ts
@@ -135,7 +135,7 @@ export default class User {
       token: email,
     };
     const newSubscription = new OSModel<SupportedModel>(
-      ModelName.EmailSubscriptions,
+      ModelName.Subscriptions,
       subscription,
     );
 
@@ -150,14 +150,14 @@ export default class User {
         newSubscription.setExternalId(identityModel.data.external_id);
       }
       OneSignal.coreDirector.add(
-        ModelName.EmailSubscriptions,
+        ModelName.Subscriptions,
         newSubscription,
         true,
       );
     } else {
       // new user
       OneSignal.coreDirector.add(
-        ModelName.EmailSubscriptions,
+        ModelName.Subscriptions,
         newSubscription,
         false,
       );
@@ -192,7 +192,7 @@ export default class User {
     };
 
     const newSubscription = new OSModel<SupportedModel>(
-      ModelName.SmsSubscriptions,
+      ModelName.Subscriptions,
       subscription,
     );
 
@@ -207,14 +207,14 @@ export default class User {
         newSubscription.setExternalId(identityModel.data.external_id);
       }
       OneSignal.coreDirector.add(
-        ModelName.SmsSubscriptions,
+        ModelName.Subscriptions,
         newSubscription,
         true,
       );
     } else {
       // new user
       OneSignal.coreDirector.add(
-        ModelName.SmsSubscriptions,
+        ModelName.Subscriptions,
         newSubscription,
         false,
       );
@@ -226,6 +226,7 @@ export default class User {
         throw e;
       },
     );
+
     const identityModel = OneSignal.coreDirector.getIdentityModel();
     if (identityModel.data.external_id) {
       newSubscription.setExternalId(identityModel.data.external_id);
@@ -249,7 +250,7 @@ export default class User {
     modelIds.forEach(async (modelId) => {
       const model = emailSubscriptions[modelId];
       if (model.data?.token === email) {
-        OneSignal.coreDirector.remove(ModelName.EmailSubscriptions, modelId);
+        OneSignal.coreDirector.remove(ModelName.Subscriptions, modelId);
       }
     });
   }
@@ -273,7 +274,7 @@ export default class User {
     modelIds.forEach(async (modelId) => {
       const model = smsSubscriptions[modelId];
       if (model.data?.token === smsNumber) {
-        OneSignal.coreDirector.remove(ModelName.SmsSubscriptions, modelId);
+        OneSignal.coreDirector.remove(ModelName.Subscriptions, modelId);
       }
     });
   }

--- a/src/onesignal/User.ts
+++ b/src/onesignal/User.ts
@@ -145,6 +145,10 @@ export default class User {
     ) {
       // existing user
       newSubscription.setOneSignalId(User.singletonInstance?.onesignalId);
+      const identityModel = OneSignal.coreDirector.getIdentityModel();
+      if (identityModel.data.external_id) {
+        newSubscription.setExternalId(identityModel.data.external_id);
+      }
       OneSignal.coreDirector.add(
         ModelName.EmailSubscriptions,
         newSubscription,
@@ -165,6 +169,10 @@ export default class User {
         throw e;
       },
     );
+    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    if (identityModel.data.external_id) {
+      newSubscription.setExternalId(identityModel.data.external_id);
+    }
   }
 
   public async addSms(sms: string): Promise<void> {
@@ -194,6 +202,10 @@ export default class User {
     ) {
       // existing user
       newSubscription.setOneSignalId(User.singletonInstance?.onesignalId);
+      const identityModel = OneSignal.coreDirector.getIdentityModel();
+      if (identityModel.data.external_id) {
+        newSubscription.setExternalId(identityModel.data.external_id);
+      }
       OneSignal.coreDirector.add(
         ModelName.SmsSubscriptions,
         newSubscription,
@@ -214,6 +226,10 @@ export default class User {
         throw e;
       },
     );
+    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    if (identityModel.data.external_id) {
+      newSubscription.setExternalId(identityModel.data.external_id);
+    }
   }
 
   public removeEmail(email: string): void {

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -153,7 +153,7 @@ export default class LoginManager {
 
     // add the push subscription model back to the repo since we need at least 1 sub to create a new user
     OneSignal.coreDirector.add(
-      ModelName.PushSubscriptions,
+      ModelName.Subscriptions,
       pushSubModel as OSModel<SupportedModel>,
       false,
     );

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -142,6 +142,7 @@ export default class LoginManager {
     UserDirector.resetUserMetaProperties();
     const pushSubModel =
       await OneSignal.coreDirector.getPushSubscriptionModel();
+    pushSubModel?.setExternalId(undefined);
     await OneSignal.coreDirector.resetModelRepoAndCache();
 
     // Initialize as a local User, as we don't have a push subscription to create a remote anonymous user.

--- a/src/shared/helpers/SubscriptionHelper.ts
+++ b/src/shared/helpers/SubscriptionHelper.ts
@@ -10,6 +10,10 @@ import Log from '../libraries/Log';
 import { ContextSWInterface } from '../models/ContextSW';
 import SdkEnvironment from '../managers/SdkEnvironment';
 import { PermissionUtils } from '../utils/PermissionUtils';
+import {
+  SubscriptionChannel,
+  SubscriptionType,
+} from '../../../src/core/models/SubscriptionModels';
 
 export default class SubscriptionHelper {
   public static async registerForPush(): Promise<Subscription | null> {
@@ -42,5 +46,36 @@ export default class SubscriptionHelper {
     }
 
     return subscription;
+  }
+
+  /**
+   * Helper that checks if a given SubscriptionType is a push subscription.
+   */
+  public static isPushSubscriptionType(type: SubscriptionType): boolean {
+    switch (type) {
+      case SubscriptionType.ChromePush:
+      case SubscriptionType.SafariPush:
+      case SubscriptionType.SafariLegacyPush:
+      case SubscriptionType.FirefoxPush:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public static toSubscriptionChannel(
+    type: SubscriptionType,
+  ): SubscriptionChannel | undefined {
+    switch (type) {
+      case SubscriptionType.Email:
+        return SubscriptionChannel.Email;
+      case SubscriptionType.SMS:
+        return SubscriptionChannel.SMS;
+      default:
+        if (this.isPushSubscriptionType(type)) {
+          return SubscriptionChannel.Push;
+        }
+        return undefined;
+    }
   }
 }

--- a/src/sw/helpers/ModelCacheDirectAccess.ts
+++ b/src/sw/helpers/ModelCacheDirectAccess.ts
@@ -12,7 +12,7 @@ export class ModelCacheDirectAccess {
     token: string,
   ): Promise<string | undefined> {
     const pushSubscriptions = await Database.getAll<EncodedModel>(
-      ModelName.PushSubscriptions,
+      ModelName.Subscriptions,
     );
     for (const pushSubscription of pushSubscriptions) {
       if (pushSubscription['token'] === token) {


### PR DESCRIPTION
# Description
## 1 Line Summary
An operation repo refactor that will help with the implementation of identity verification

## Details
- Adds a delta queue to the operation repo to flush all executor deltas at the same time. Now the operation repo will be in charge of enqueuing deltas and passing the delta to its correct executor. Previously, each executor was in charge of enqueuing and flushing their own delta queue.
  - Makes it easier to implement pausing on the operation repo for Jwt when receiving an invalid token.
  - This change also aligns the Web SDK more with the iOS SDK's operation repo implementation.
- Groups push, sms, and email subscriptions under 1 executor. Previously push, sms, and email each had their own subscription executor.
  - Omits creating multiple subscription executors. Unnecessary now that there is only 1 flush from the operation repo that flushes all executors
  - Deprecates the `pushSubscription`, `smsSubscription`, and `emailSubscription` model names for 1 new name: `subscriptions`. This change requires a database upgrade.
- Adds external id property to operations
  - Will be used to retry operations for users with a valid Jwt token. Accessed through `Operation.model.externalId`
- Added to following tests below:

Unit Tests:
- v5 to v6 database migration for subscription records. If a user was already logged in v5, the external id is added to each subscription record in v6.
- Login test, where the external id is updated correctly for each model which will be used in deltas/operations.
  - Future work: add logout tests

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1179)
<!-- Reviewable:end -->
