### PR TITLE
Change the `sendSelfNotification` method to use local push functionality

### DIFF
--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -154,6 +154,12 @@
         })
     }
 
+    function sendSelfNotification() {
+        OneSignal.push(function() {
+            OneSignal.sendSelfNotification();
+        });
+    }
+
   </script>
 <head>
     <meta charset="utf-8">
@@ -189,6 +195,7 @@
     <button onclick="javascript:showSmsSlidedown();">Show Sms Slidedown</button>
     <button onclick="javascript:showEmailSlidedown();">Show Email Slidedown</button>
     <button onclick="javascript:showSmsAndEmailSlidedown();">Show Sms & Email Slidedown</button>
+    <button onclick="javascript:sendSelfNotification();">Send Self Notification</button>
     <br />
     <br />
     <div class='onesignal-customlink-container'></div>

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jest": "jest --coverage"
   },
   "config": {
-    "sdkVersion": "151605"
+    "sdkVersion": "151606"
   },
   "repository": {
     "type": "git",

--- a/src/OneSignal.ts
+++ b/src/OneSignal.ts
@@ -36,6 +36,7 @@ import {
   awaitOneSignalInitAndSupported,
   executeCallback,
   getConsoleStyle,
+  getPlatformNotificationIcon,
   isValidEmail,
   logMethodCall,
 } from './utils';
@@ -713,16 +714,16 @@ export default class OneSignal {
   /**
    * @PublicApi
    */
-  static async sendSelfNotification(title: string = 'OneSignal Test Message',
-                              message: string = 'This is an example notification.',
-                              url: string = `${new URL(location.href).origin}?_osp=do_not_open`,
-                              icon: URL,
-                              data: Map<String, any>,
-                              buttons: Array<NotificationActionButton>): Promise<void> {
+  static async sendSelfNotification(title = 'OneSignal Test Message',
+                              message = 'This is an example notification.',
+                              url = `${new URL(location.href).origin}?_osp=do_not_open`,
+                              icon?: string,
+                              data?: Record<string, any>,
+                              buttons?: Array<NotificationAction>): Promise<void> {
     await awaitOneSignalInitAndSupported();
     logMethodCall('sendSelfNotification', title, message, url, icon, data, buttons);
     const appConfig = await Database.getAppConfig();
-    const subscription = await Database.getSubscription();
+
     if (!appConfig.appId)
       throw new InvalidStateError(InvalidStateReason.MissingAppId);
     if (!(await OneSignal.isPushNotificationsEnabled()))
@@ -731,11 +732,32 @@ export default class OneSignal {
       throw new InvalidArgumentError('url', InvalidArgumentReason.Malformed);
     if (!ValidatorUtils.isValidUrl(icon, { allowEmpty: true, requireHttps: true }))
       throw new InvalidArgumentError('icon', InvalidArgumentReason.Malformed);
-
-    if (subscription.deviceId) {
-      await OneSignalApi.sendNotification(appConfig.appId, [subscription.deviceId], { en : title }, { en : message },
-                                               url, icon, data, buttons);
+    if (!icon) {
+      // get default icon
+      const icons = await MainHelper.getNotificationIcons();
+      icon = getPlatformNotificationIcon(icons);
     }
+
+    data = {
+      ...data,
+      url,
+      buttons
+    }
+
+    this.context.serviceWorkerManager.getRegistration().then(async (registration) => {
+      if (!registration) {
+        Log.error("Service worker registration not available.");
+        return;
+      }
+
+      const options = {
+        body: message,
+        data: data,
+        icon: icon,
+        actions: buttons,
+      };
+      registration.showNotification(title, options);
+    });
   }
 
   /**

--- a/src/helpers/EventHelper.ts
+++ b/src/helpers/EventHelper.ts
@@ -1,6 +1,5 @@
 import Event from '../Event';
 import LimitStore from '../LimitStore';
-import OneSignalApiShared from '../OneSignalApiShared';
 import Database from '../services/Database';
 import { ContextSWInterface } from "../models/ContextSW";
 import Log from '../libraries/Log';
@@ -84,8 +83,6 @@ export default class EventHelper {
     }
     EventHelper.sendingOrSentWelcomeNotification = true;
 
-    const { deviceId } = await Database.getSubscription();
-    const { appId } = await Database.getAppConfig();
     let title =
       welcome_notification_opts !== undefined &&
         welcome_notification_opts['title'] !== undefined &&
@@ -108,13 +105,11 @@ export default class EventHelper {
     message = BrowserUtils.decodeHtmlEntities(message);
 
     Log.debug('Sending welcome notification.');
-    OneSignalApiShared.sendNotification(
-      appId,
-      [deviceId],
-      { en: title },
-      { en: message },
+    OneSignal.sendSelfNotification(
+      title,
+      message,
       url,
-      null,
+      undefined,
       { __isOneSignalWelcomeNotification: true },
       undefined
     );


### PR DESCRIPTION
# Description
## 1 Line Summary
Change the `sendSelfNotification` method to use local push functionality.

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
- Call `OneSignal.sendSelfNotification()`
- See that the notification is shown

## Testing
```js
OneSignal.sendSelfNotification('Title', 'message', 'https://google.com', 'https://t3.ftcdn.net/jpg/03/08/73/34/360_F_308733458_QBzwMVu8ZzdGEp9Wwq1fAYaDgtP3UVwl.jpg', { test: 'foo' }, [{
    action: 'like-button',
    title: 'Like',
    icon: 'https://image.similarpng.com/very-thumbnail/2020/06/Icon-like-button-transparent-PNG.png'
}]);
```

| Feature           | Chrome | Firefox | Safari |
|-------------------|--------|---------|--------|
| Title             | ✅      | ❌       | ❌      |
| Message           | ✅      | ❌       | ❌      |
| Launch Url Click  | ✅      | ❌       | ❌      |
| Data              | ✅      | ❌       | ❌      |
| Button Displayed  | ✅      | ❌       | ❌      |
| Buttons Displayed | ✅      | ❌       | ❌      |
| Button Click      | ✅      | ❌       | ❌      |

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1182)
<!-- Reviewable:end -->
