### PR TITLE
Api/notification create removal

### DIFF
--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -33,6 +33,12 @@
     OneSignalDeferred.push(async function(onesignal) {
       await onesignal.init({
           appId,
+          welcomeNotification: {
+            disable: false,
+            title: "Custom Welcome Notification Title",
+            message: "Custom Welcome Notification Message",
+            url: "https://example.com",
+          },
           serviceWorkerParam: { scope: '/' + SERVICE_WORKER_PATH },
           serviceWorkerPath: SERVICE_WORKER_PATH + 'OneSignalSDKWorker.js',
           notifyButton: {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jest": "jest --coverage"
   },
   "config": {
-    "sdkVersion": "160201"
+    "sdkVersion": "160202"
   },
   "repository": {
     "type": "git",

--- a/src/shared/api/OneSignalApi.ts
+++ b/src/shared/api/OneSignalApi.ts
@@ -2,32 +2,9 @@ import JSONP from 'jsonp';
 import SdkEnvironment from '../managers/SdkEnvironment';
 import { WindowEnvironmentKind } from '../models/WindowEnvironmentKind';
 import OneSignalApiSW from './OneSignalApiSW';
-import OneSignalApiShared from './OneSignalApiShared';
 import { ServerAppConfig } from '../models/AppConfig';
 
 export default class OneSignalApi {
-  static sendNotification(
-    appId: string,
-    playerIds: Array<string>,
-    titles,
-    contents,
-    url,
-    icon,
-    data,
-    buttons,
-  ) {
-    return OneSignalApiShared.sendNotification(
-      appId,
-      playerIds,
-      titles,
-      contents,
-      url,
-      icon,
-      data,
-      buttons,
-    );
-  }
-
   static jsonpLib(
     url: string,
     fn: (err: Error, data: ServerAppConfig) => void,

--- a/src/shared/api/OneSignalApiShared.ts
+++ b/src/shared/api/OneSignalApiShared.ts
@@ -1,41 +1,8 @@
 import { OutcomeRequestData } from '../../page/models/OutcomeRequestData';
-import Utils from '../context/Utils';
 import Log from '../libraries/Log';
 import OneSignalApiBase from './OneSignalApiBase';
 
 export default class OneSignalApiShared {
-  static sendNotification(
-    appId: string,
-    playerIds: Array<string>,
-    titles,
-    contents,
-    url,
-    icon,
-    data,
-    buttons,
-  ) {
-    const params = {
-      app_id: appId,
-      contents: contents,
-      include_player_ids: playerIds,
-      isAnyWeb: true,
-      data: data,
-      web_buttons: buttons,
-    };
-    if (titles) {
-      (params as any).headings = titles;
-    }
-    if (url) {
-      (params as any).url = url;
-    }
-    if (icon) {
-      (params as any).chrome_web_icon = icon;
-      (params as any).firefox_icon = icon;
-    }
-    Utils.trimUndefined(params);
-    return OneSignalApiBase.post('notifications', params);
-  }
-
   static async sendOutcome(data: OutcomeRequestData): Promise<void> {
     Log.info('Outcome payload:', data);
     try {

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -177,7 +177,7 @@ export default class EventHelper {
       url,
       undefined,
       { __isOneSignalWelcomeNotification: true },
-      undefined
+      undefined,
     );
     OneSignalEvent.trigger(OneSignal.EVENTS.WELCOME_NOTIFICATION_SENT, {
       title: title,

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -146,7 +146,6 @@ export default class EventHelper {
       return;
     }
 
-    const { appId } = await Database.getAppConfig();
     let title =
       welcome_notification_opts !== undefined &&
       welcome_notification_opts['title'] !== undefined &&
@@ -172,15 +171,13 @@ export default class EventHelper {
     message = BrowserUtils.decodeHtmlEntities(message);
 
     Log.debug('Sending welcome notification.');
-    OneSignalApiShared.sendNotification(
-      appId,
-      [pushSubscriptionId],
-      { en: title },
-      { en: message },
+    MainHelper.showLocalNotification(
+      title,
+      message,
       url,
-      null,
-      { __isOneSignalWelcomeNotification: true },
       undefined,
+      { __isOneSignalWelcomeNotification: true },
+      undefined
     );
     OneSignalEvent.trigger(OneSignal.EVENTS.WELCOME_NOTIFICATION_SENT, {
       title: title,

--- a/src/shared/helpers/MainHelper.ts
+++ b/src/shared/helpers/MainHelper.ts
@@ -13,7 +13,10 @@ import Database from '../services/Database';
 import { PermissionUtils } from '../utils/PermissionUtils';
 import Environment from './Environment';
 import { getPlatformNotificationIcon, logMethodCall } from '../utils/utils';
-import { NotSubscribedError, NotSubscribedReason } from '../errors/NotSubscribedError';
+import {
+  NotSubscribedError,
+  NotSubscribedReason,
+} from '../errors/NotSubscribedError';
 import { InvalidArgumentError, InvalidArgumentReason } from '../errors/InvalidArgumentError';
 import { ValidatorUtils } from '../../page/utils/ValidatorUtils';
 
@@ -24,19 +27,29 @@ export default class MainHelper {
     url: string,
     icon?: string,
     data?: Record<string, any>,
-    buttons?: Array<any>
+    buttons?: Array<any>,
   ): Promise<void> {
-    logMethodCall('MainHelper:showLocalNotification: ', title, message, url, icon, data, buttons);
+    logMethodCall(
+      'MainHelper:showLocalNotification: ',
+      title,
+      message,
+      url,
+      icon,
+      data,
+      buttons,
+    );
 
     const appConfig = await Database.getAppConfig();
 
     if (!appConfig.appId)
       throw new InvalidStateError(InvalidStateReason.MissingAppId);
-    if (!(OneSignal.Notifications.permission))
+    if (!OneSignal.Notifications.permission)
       throw new NotSubscribedError(NotSubscribedReason.NoDeviceId);
     if (!ValidatorUtils.isValidUrl(url))
       throw new InvalidArgumentError('url', InvalidArgumentReason.Malformed);
-    if (!ValidatorUtils.isValidUrl(icon, { allowEmpty: true, requireHttps: true }))
+    if (
+      !ValidatorUtils.isValidUrl(icon, { allowEmpty: true, requireHttps: true })
+    )
       throw new InvalidArgumentError('icon', InvalidArgumentReason.Malformed);
     if (!icon) {
       // get default icon
@@ -47,26 +60,29 @@ export default class MainHelper {
     const convertButtonsToNotificationActionType = (buttons: Array<any>) => {
       const convertedButtons = [];
 
-      for (let i=0; i<buttons.length; i++) {
+      for (let i = 0; i < buttons.length; i++) {
         const button = buttons[i];
         convertedButtons.push({
           action: button.id,
           title: button.text,
           icon: button.icon,
-          url: button.url
+          url: button.url,
         });
       }
 
       return convertedButtons;
-    }
+    };
     const dataPayload = {
       data,
       url,
-      buttons: buttons ? convertButtonsToNotificationActionType(buttons) : undefined
-    }
+      buttons: buttons
+        ? convertButtonsToNotificationActionType(buttons)
+        : undefined,
+    };
 
-    OneSignal.context.serviceWorkerManager.getRegistration().then(
-      async (registration?: ServiceWorkerRegistration | null) => {
+    OneSignal.context.serviceWorkerManager
+      .getRegistration()
+      .then(async (registration?: ServiceWorkerRegistration | null) => {
         if (!registration) {
           Log.error('Service worker registration not available.');
           return;
@@ -76,11 +92,12 @@ export default class MainHelper {
           body: message,
           data: dataPayload,
           icon: icon,
-          actions: buttons ? convertButtonsToNotificationActionType(buttons) : [],
+          actions: buttons
+            ? convertButtonsToNotificationActionType(buttons)
+            : [],
         };
         registration.showNotification(title, options);
-      }
-    );
+      });
   }
 
   static async checkAndTriggerNotificationPermissionChanged() {

--- a/src/shared/helpers/MainHelper.ts
+++ b/src/shared/helpers/MainHelper.ts
@@ -17,7 +17,10 @@ import {
   NotSubscribedError,
   NotSubscribedReason,
 } from '../errors/NotSubscribedError';
-import { InvalidArgumentError, InvalidArgumentReason } from '../errors/InvalidArgumentError';
+import {
+  InvalidArgumentError,
+  InvalidArgumentReason,
+} from '../errors/InvalidArgumentError';
 import { ValidatorUtils } from '../../page/utils/ValidatorUtils';
 
 export default class MainHelper {

--- a/src/shared/helpers/MainHelper.ts
+++ b/src/shared/helpers/MainHelper.ts
@@ -12,8 +12,77 @@ import Utils from '../context/Utils';
 import Database from '../services/Database';
 import { PermissionUtils } from '../utils/PermissionUtils';
 import Environment from './Environment';
+import { getPlatformNotificationIcon, logMethodCall } from '../utils/utils';
+import { NotSubscribedError, NotSubscribedReason } from '../errors/NotSubscribedError';
+import { InvalidArgumentError, InvalidArgumentReason } from '../errors/InvalidArgumentError';
+import { ValidatorUtils } from '../../page/utils/ValidatorUtils';
 
 export default class MainHelper {
+  static async showLocalNotification(
+    title: string,
+    message: string,
+    url: string,
+    icon?: string,
+    data?: Record<string, any>,
+    buttons?: Array<any>
+  ): Promise<void> {
+    logMethodCall('MainHelper:showLocalNotification: ', title, message, url, icon, data, buttons);
+
+    const appConfig = await Database.getAppConfig();
+
+    if (!appConfig.appId)
+      throw new InvalidStateError(InvalidStateReason.MissingAppId);
+    if (!(OneSignal.Notifications.permission))
+      throw new NotSubscribedError(NotSubscribedReason.NoDeviceId);
+    if (!ValidatorUtils.isValidUrl(url))
+      throw new InvalidArgumentError('url', InvalidArgumentReason.Malformed);
+    if (!ValidatorUtils.isValidUrl(icon, { allowEmpty: true, requireHttps: true }))
+      throw new InvalidArgumentError('icon', InvalidArgumentReason.Malformed);
+    if (!icon) {
+      // get default icon
+      const icons = await MainHelper.getNotificationIcons();
+      icon = getPlatformNotificationIcon(icons);
+    }
+
+    const convertButtonsToNotificationActionType = (buttons: Array<any>) => {
+      const convertedButtons = [];
+
+      for (let i=0; i<buttons.length; i++) {
+        const button = buttons[i];
+        convertedButtons.push({
+          action: button.id,
+          title: button.text,
+          icon: button.icon,
+          url: button.url
+        });
+      }
+
+      return convertedButtons;
+    }
+    const dataPayload = {
+      data,
+      url,
+      buttons: buttons ? convertButtonsToNotificationActionType(buttons) : undefined
+    }
+
+    OneSignal.context.serviceWorkerManager.getRegistration().then(
+      async (registration?: ServiceWorkerRegistration | null) => {
+        if (!registration) {
+          Log.error('Service worker registration not available.');
+          return;
+        }
+
+        const options = {
+          body: message,
+          data: dataPayload,
+          icon: icon,
+          actions: buttons ? convertButtonsToNotificationActionType(buttons) : [],
+        };
+        registration.showNotification(title, options);
+      }
+    );
+  }
+
   static async checkAndTriggerNotificationPermissionChanged() {
     const previousPermission = await Database.get(
       'Options',

--- a/src/shared/services/Database.ts
+++ b/src/shared/services/Database.ts
@@ -129,7 +129,7 @@ export default class Database {
    * @param keypath
    */
   async put(table: OneSignalDbTable, keypath: any): Promise<void> {
-    await new Promise<void>((resolve, reject) => {
+    await new Promise<void>((resolve) => {
       this.database.put(table, keypath).then(() => resolve());
     });
     this.emitter.emit(Database.EVENTS.SET, keypath);

--- a/src/shared/services/IndexedDb.ts
+++ b/src/shared/services/IndexedDb.ts
@@ -109,7 +109,7 @@ export default class IndexedDb {
    *
    * Ref: https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase/onversionchange
    */
-  private onDatabaseVersionChange(_: IDBVersionChangeEvent): void {
+  private onDatabaseVersionChange(): void {
     Log.debug('IndexedDb: versionchange event');
   }
 
@@ -330,16 +330,19 @@ export default class IndexedDb {
     await this.ensureDatabaseOpen();
     return await new Promise((resolve, reject) => {
       try {
-        const request = this.database!.transaction([table], 'readwrite')
+        const request = this.database?.transaction([table], 'readwrite')
           .objectStore(table)
           .put(key);
-        request.onsuccess = () => {
-          resolve(key);
-        };
-        request.onerror = (e) => {
-          Log.error('Database PUT Transaction Error:', e);
-          reject(e);
-        };
+
+        if (request) {
+          request.onsuccess = () => {
+            resolve(key);
+          };
+          request.onerror = (e) => {
+            Log.error('Database PUT Transaction Error:', e);
+            reject(e);
+          };
+        }
       } catch (e) {
         Log.error('Database PUT Error:', e);
         reject(e);

--- a/src/shared/services/IndexedDb.ts
+++ b/src/shared/services/IndexedDb.ts
@@ -330,7 +330,8 @@ export default class IndexedDb {
     await this.ensureDatabaseOpen();
     return await new Promise((resolve, reject) => {
       try {
-        const request = this.database?.transaction([table], 'readwrite')
+        const request = this.database
+          ?.transaction([table], 'readwrite')
           .objectStore(table)
           .put(key);
 

--- a/src/shared/services/OneSignalEvent.ts
+++ b/src/shared/services/OneSignalEvent.ts
@@ -29,7 +29,7 @@ export default class OneSignalEvent {
   static async trigger(eventName: string, data?: any, emitter?: Emitter) {
     if (!Utils.contains(SILENT_EVENTS, eventName)) {
       const displayData = data;
-      let env = Utils.capitalize(SdkEnvironment.getWindowEnv().toString());
+      const env = Utils.capitalize(SdkEnvironment.getWindowEnv().toString());
 
       if (displayData || displayData === false) {
         Log.debug(`(${env}) » ${eventName}:`, displayData);

--- a/src/sw/serviceWorker/ServiceWorker.ts
+++ b/src/sw/serviceWorker/ServiceWorker.ts
@@ -193,7 +193,7 @@ export class ServiceWorker {
   static setupMessageListeners() {
     ServiceWorker.workerMessenger.on(
       WorkerMessengerCommand.WorkerVersion,
-      (_) => {
+      () => {
         Log.debug('[Service Worker] Received worker version message.');
         ServiceWorker.workerMessenger.broadcast(
           WorkerMessengerCommand.WorkerVersion,
@@ -241,7 +241,7 @@ export class ServiceWorker {
     );
     ServiceWorker.workerMessenger.on(
       WorkerMessengerCommand.AmpSubscriptionState,
-      async (_appConfigBundle: any) => {
+      async () => {
         Log.debug('[Service Worker] Received AMP subscription state message.');
         const pushSubscription =
           await self.registration.pushManager.getSubscription();


### PR DESCRIPTION
# One line summary
Remove `sendNotification` API calls and implement local notifications.

# Description
We removed all instances of the `sendNotification` API calls to clean up dead code. The notification system has been shifted to use local notifications.

## MainHelper
- Added `showLocalNotification` to `MainHelper` for the welcome notification mechanism, as we no longer have `sendSelfNotification`

## EventHelper
- Updated `EventHelper` to use the `MainHelper` local notification.

## Index.html
- Added welcome notification configuration.

## SDK Version
- Updated SDK to version 160202.

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
Tested locally:
- open webSDK sandbox with an app using custom code
- configure index.html to send a welcome notification
- subscribe

![Screenshot 2024-07-23 at 2 56 07 PM](https://github.com/user-attachments/assets/f807ed7e-875e-41de-be0f-148ab8abda7f)


### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1186)
<!-- Reviewable:end -->
