### PR TITLE
[Fix] External Id hydration

### DIFF
--- a/__test__/unit/user/login.test.ts
+++ b/__test__/unit/user/login.test.ts
@@ -22,24 +22,13 @@ jest.mock('../../../src/shared/libraries/Log');
 describe('Login tests', () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    test.stub(
-      PropertiesExecutor.prototype,
-      'getOperationsFromCache',
-      Promise.resolve([]),
-    );
-    test.stub(
-      IdentityExecutor.prototype,
-      'getOperationsFromCache',
-      Promise.resolve([]),
-    );
-    test.stub(
-      SubscriptionExecutor.prototype,
-      'getOperationsFromCache',
-      Promise.resolve([]),
-    );
+    test.stub(PropertiesExecutor.prototype, 'getOperationsFromCache', []);
+    test.stub(IdentityExecutor.prototype, 'getOperationsFromCache', []);
+    test.stub(SubscriptionExecutor.prototype, 'getOperationsFromCache', []);
   });
 
   afterEach(() => {
+    jest.runOnlyPendingTimers();
     jest.resetAllMocks();
   });
 

--- a/src/core/CoreModule.ts
+++ b/src/core/CoreModule.ts
@@ -5,11 +5,13 @@ import { OSModelStoreFactory } from './modelRepo/OSModelStoreFactory';
 import Log from '../shared/libraries/Log';
 import { logMethodCall } from '../shared/utils/utils';
 import { SupportedModel } from './models/SupportedModels';
+import { NewRecordsState } from '../shared/models/NewRecordsState';
 
 export default class CoreModule {
   public modelRepo?: ModelRepo;
   public operationRepo?: OperationRepo;
   public initPromise: Promise<void>;
+  public newRecordsState?: NewRecordsState;
 
   private modelCache: ModelCache;
   private initResolver: () => void = () => null;
@@ -25,7 +27,11 @@ export default class CoreModule {
       .then((allCachedOSModels) => {
         const modelStores = OSModelStoreFactory.build(allCachedOSModels);
         this.modelRepo = new ModelRepo(this.modelCache, modelStores);
-        this.operationRepo = new OperationRepo(this.modelRepo);
+        this.newRecordsState = new NewRecordsState();
+        this.operationRepo = new OperationRepo(
+          this.modelRepo,
+          this.newRecordsState,
+        );
         this.initResolver();
       })
       .catch((e) => {

--- a/src/core/CoreModuleDirector.ts
+++ b/src/core/CoreModuleDirector.ts
@@ -175,7 +175,7 @@ export class CoreModuleDirector {
   }
 
   /* G E T T E R S */
-  public getNewRecordsState(): NewRecordsState {
+  public getNewRecordsState(): NewRecordsState | undefined {
     return this.core.newRecordsState;
   }
 

--- a/src/core/CoreModuleDirector.ts
+++ b/src/core/CoreModuleDirector.ts
@@ -64,7 +64,7 @@ export class CoreModuleDirector {
   }
 
   public hydrateUser(user: UserData, externalId?: string): void {
-    logMethodCall('CoreModuleDirector.hydrateUser', { user });
+    logMethodCall('CoreModuleDirector.hydrateUser', { user, externalId });
     try {
       const identity = this.getIdentityModel();
       const properties = this.getPropertiesModel();
@@ -109,6 +109,8 @@ export class CoreModuleDirector {
   ): void {
     logMethodCall('CoreModuleDirector._hydrateSubscriptions', {
       subscriptions,
+      onesignalId,
+      externalId,
     });
 
     if (!subscriptions) {

--- a/src/core/CoreModuleDirector.ts
+++ b/src/core/CoreModuleDirector.ts
@@ -63,14 +63,13 @@ export class CoreModuleDirector {
     await this.core.resetModelRepoAndCache();
   }
 
-  public hydrateUser(user: UserData): void {
+  public hydrateUser(user: UserData, externalId?: string): void {
     logMethodCall('CoreModuleDirector.hydrateUser', { user });
     try {
       const identity = this.getIdentityModel();
       const properties = this.getPropertiesModel();
 
-      const { onesignal_id: onesignalId, external_id: externalId } =
-        user.identity;
+      const { onesignal_id: onesignalId } = user.identity;
 
       if (!onesignalId) {
         throw new OneSignalError('OneSignal ID is missing from user data');
@@ -83,6 +82,7 @@ export class CoreModuleDirector {
       if (externalId) {
         identity?.setExternalId(externalId);
         properties?.setExternalId(externalId);
+        user.identity.external_id = externalId;
       }
 
       // identity and properties models are always single, so we hydrate immediately (i.e. replace existing data)

--- a/src/core/CoreModuleDirector.ts
+++ b/src/core/CoreModuleDirector.ts
@@ -175,6 +175,9 @@ export class CoreModuleDirector {
   }
 
   /* G E T T E R S */
+  public getNewRecordsState(): NewRecordsState {
+    return this.core.newRecordsState;
+  }
 
   public getModelByTypeAndId(
     modelName: ModelName,

--- a/src/core/executors/ExecutorFactory.ts
+++ b/src/core/executors/ExecutorFactory.ts
@@ -1,3 +1,4 @@
+import { NewRecordsState } from '../../shared/models/NewRecordsState';
 import { Executor } from '../models/Executor';
 import { ExecutorConfig } from '../models/ExecutorConfig';
 import { ModelName, SupportedModel } from '../models/SupportedModels';
@@ -6,14 +7,17 @@ import { PropertiesExecutor } from './PropertiesExecutor';
 import { SubscriptionExecutor } from './SubscriptionExecutor';
 
 export class ExecutorFactory {
-  static build(executorConfig: ExecutorConfig<SupportedModel>): Executor {
+  static build(
+    executorConfig: ExecutorConfig<SupportedModel>,
+    newRecordsState: NewRecordsState,
+  ): Executor {
     switch (executorConfig.modelName) {
       case ModelName.Identity:
-        return new IdentityExecutor(executorConfig);
+        return new IdentityExecutor(executorConfig, newRecordsState);
       case ModelName.Properties:
-        return new PropertiesExecutor(executorConfig);
+        return new PropertiesExecutor(executorConfig, newRecordsState);
       case ModelName.Subscriptions:
-        return new SubscriptionExecutor(executorConfig);
+        return new SubscriptionExecutor(executorConfig, newRecordsState);
     }
   }
 }

--- a/src/core/executors/ExecutorStore.ts
+++ b/src/core/executors/ExecutorStore.ts
@@ -1,3 +1,4 @@
+import { NewRecordsState } from '../../shared/models/NewRecordsState';
 import { ModelName } from '../models/SupportedModels';
 import OSExecutor from './ExecutorBase';
 import { EXECUTOR_CONFIG_MAP } from './ExecutorConfigMap';
@@ -10,10 +11,10 @@ type ExecutorStoreInterface = {
 export class ExecutorStore {
   store: ExecutorStoreInterface = {};
 
-  constructor() {
+  constructor(newRecordsState: NewRecordsState) {
     Object.values(ModelName).forEach((modelName) => {
       const config = EXECUTOR_CONFIG_MAP[modelName as ModelName];
-      this.store[modelName] = ExecutorFactory.build(config);
+      this.store[modelName] = ExecutorFactory.build(config, newRecordsState);
     });
   }
 

--- a/src/core/executors/IdentityExecutor.ts
+++ b/src/core/executors/IdentityExecutor.ts
@@ -1,3 +1,4 @@
+import { NewRecordsState } from '../../shared/models/NewRecordsState';
 import OperationCache from '../caching/OperationCache';
 import { CoreChangeType } from '../models/CoreChangeType';
 import { PropertyDelta } from '../models/CoreDeltas';
@@ -8,8 +9,11 @@ import { isPropertyDelta } from '../utils/typePredicates';
 import ExecutorBase from './ExecutorBase';
 
 export class IdentityExecutor extends ExecutorBase {
-  constructor(executorConfig: ExecutorConfig<SupportedModel>) {
-    super(executorConfig);
+  constructor(
+    executorConfig: ExecutorConfig<SupportedModel>,
+    newRecordsState: NewRecordsState,
+  ) {
+    super(executorConfig, newRecordsState);
   }
 
   processDeltaQueue(): void {

--- a/src/core/executors/PropertiesExecutor.ts
+++ b/src/core/executors/PropertiesExecutor.ts
@@ -1,3 +1,4 @@
+import { NewRecordsState } from '../../shared/models/NewRecordsState';
 import ExecutorBase from './ExecutorBase';
 import { Operation } from '../operationRepo/Operation';
 import { CoreChangeType } from '../models/CoreChangeType';
@@ -6,8 +7,11 @@ import { ModelName, SupportedModel } from '../models/SupportedModels';
 import OperationCache from '../caching/OperationCache';
 
 export class PropertiesExecutor extends ExecutorBase {
-  constructor(executorConfig: ExecutorConfig<SupportedModel>) {
-    super(executorConfig);
+  constructor(
+    executorConfig: ExecutorConfig<SupportedModel>,
+    newRecordsState: NewRecordsState,
+  ) {
+    super(executorConfig, newRecordsState);
   }
 
   processDeltaQueue(): void {

--- a/src/core/executors/SubscriptionExecutor.ts
+++ b/src/core/executors/SubscriptionExecutor.ts
@@ -1,3 +1,4 @@
+import { NewRecordsState } from '../../shared/models/NewRecordsState';
 import OperationCache from '../caching/OperationCache';
 import { CoreChangeType } from '../models/CoreChangeType';
 import { CoreDelta } from '../models/CoreDeltas';
@@ -7,8 +8,11 @@ import { Operation } from '../operationRepo/Operation';
 import ExecutorBase from './ExecutorBase';
 
 export class SubscriptionExecutor extends ExecutorBase {
-  constructor(executorConfig: ExecutorConfig<SupportedModel>) {
-    super(executorConfig);
+  constructor(
+    executorConfig: ExecutorConfig<SupportedModel>,
+    newRecordsState: NewRecordsState,
+  ) {
+    super(executorConfig, newRecordsState);
   }
 
   processDeltaQueue(): void {

--- a/src/core/modelRepo/ModelRepo.ts
+++ b/src/core/modelRepo/ModelRepo.ts
@@ -60,6 +60,7 @@ export class ModelRepo extends Subscribable<CoreDelta<SupportedModel>> {
     this.broadcast({
       model: payload,
       changeType: CoreChangeType.Add,
+      applyToRecordId: payload?.applyToRecordId,
     });
   }
 
@@ -77,6 +78,7 @@ export class ModelRepo extends Subscribable<CoreDelta<SupportedModel>> {
     this.broadcast({
       model: payload,
       changeType: CoreChangeType.Remove,
+      applyToRecordId: payload?.applyToRecordId,
     });
   }
 
@@ -103,6 +105,7 @@ export class ModelRepo extends Subscribable<CoreDelta<SupportedModel>> {
         property: payload.property,
         oldValue: payload.oldValue,
         newValue: payload.newValue,
+        applyToRecordId: payload.model?.applyToRecordId,
       };
       this.broadcast(delta);
     }

--- a/src/core/modelRepo/OSModel.ts
+++ b/src/core/modelRepo/OSModel.ts
@@ -13,11 +13,11 @@ import { logMethodCall } from '../../shared/utils/utils';
 export class OSModel<Model> extends Subscribable<ModelStoreChange<Model>> {
   data: Model;
   modelId: string;
-
   onesignalId?: string;
   awaitOneSignalIdAvailable: Promise<string>;
   onesignalIdAvailableCallback?: (onesignalId: string) => void;
   externalId?: string;
+  applyToRecordId?: string;
 
   constructor(
     readonly modelName: ModelName,
@@ -53,6 +53,11 @@ export class OSModel<Model> extends Subscribable<ModelStoreChange<Model>> {
   public setExternalId(externalId?: string): void {
     logMethodCall('setExternalId', { externalId });
     this.externalId = externalId;
+  }
+
+  public setApplyToRecordId(applyToRecordId: string): void {
+    logMethodCall('setapplyToRecordId', { applyToRecordId });
+    this.applyToRecordId = applyToRecordId;
   }
 
   /**

--- a/src/core/models/CoreDeltas.ts
+++ b/src/core/models/CoreDeltas.ts
@@ -5,6 +5,7 @@ import { StringKeys } from './StringKeys';
 export type ModelDelta<Model> = {
   model: OSModel<Model>;
   changeType: CoreChangeType;
+  applyToRecordId?: string;
 };
 
 export interface PropertyDelta<Model> extends ModelDelta<Model> {

--- a/src/core/operationRepo/Operation.ts
+++ b/src/core/operationRepo/Operation.ts
@@ -13,6 +13,7 @@ export class Operation<Model> {
   model?: OSModel<Model>;
   jwtTokenAvailable: Promise<void>;
   jwtToken?: string | null;
+  applyToRecordId: string | undefined;
 
   constructor(
     readonly changeType: CoreChangeType,

--- a/src/core/operationRepo/Operation.ts
+++ b/src/core/operationRepo/Operation.ts
@@ -11,9 +11,9 @@ export class Operation<Model> {
   timestamp: number;
   payload?: Partial<SupportedModel>;
   model?: OSModel<Model>;
+  applyToRecordId?: string;
   jwtTokenAvailable: Promise<void>;
   jwtToken?: string | null;
-  applyToRecordId: string | undefined;
 
   constructor(
     readonly changeType: CoreChangeType,
@@ -23,6 +23,7 @@ export class Operation<Model> {
     this.operationId = Math.random().toString(36).substring(2);
     this.payload = deltas ? this.getPayload(deltas) : undefined;
     this.model = deltas ? deltas[deltas.length - 1].model : undefined;
+    this.applyToRecordId = deltas?.[deltas.length - 1]?.applyToRecordId;
     this.timestamp = Date.now();
     // eslint-disable-next-line no-async-promise-executor
     this.jwtTokenAvailable = new Promise<void>(async (resolve) => {

--- a/src/core/operationRepo/OperationRepo.ts
+++ b/src/core/operationRepo/OperationRepo.ts
@@ -3,15 +3,21 @@ import { ExecutorStore } from '../executors/ExecutorStore';
 import { CoreDelta } from '../models/CoreDeltas';
 import { SupportedModel } from '../models/SupportedModels';
 import { logMethodCall } from '../../shared/utils/utils';
+import { NewRecordsState } from '../../shared/models/NewRecordsState';
 
 export class OperationRepo {
   public executorStore: ExecutorStore;
+  public newRecordsState: NewRecordsState;
   private _unsubscribeFromModelRepo: () => void;
   private _deltaQueue: CoreDelta<SupportedModel>[] = [];
   static DELTAS_BATCH_PROCESSING_TIME = 1;
 
-  constructor(private modelRepo: ModelRepo) {
-    this.executorStore = new ExecutorStore();
+  constructor(
+    private modelRepo: ModelRepo,
+    newRecordsState: NewRecordsState,
+  ) {
+    this.newRecordsState = newRecordsState;
+    this.executorStore = new ExecutorStore(this.newRecordsState);
 
     this._unsubscribeFromModelRepo = this.modelRepo.subscribe(
       (delta: CoreDelta<SupportedModel>) => {

--- a/src/core/requestService/SubscriptionRequests.ts
+++ b/src/core/requestService/SubscriptionRequests.ts
@@ -25,13 +25,20 @@ export default class SubscriptionRequests {
     logMethodCall('SubscriptionRequests.addSubscription', operation);
 
     const appId = await MainHelper.getAppId();
-    const { subscription, aliasPair } = processSubscriptionOperation(operation);
+    const { subscription, aliasPair, subscriptionId } =
+      processSubscriptionOperation(operation);
 
     const response = await RequestService.createSubscription(
       { appId },
       aliasPair,
       { subscription },
     );
+
+    const status = response.status;
+    if (status >= 200 && status < 300) {
+      OneSignal.coreDirector.getNewRecordsState().add(subscriptionId);
+    }
+
     return SubscriptionRequests._processSubscriptionResponse(response);
   }
 

--- a/src/onesignal/User.ts
+++ b/src/onesignal/User.ts
@@ -82,8 +82,10 @@ export default class User {
       }
     });
 
+    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    identityModel?.setApplyToRecordId(identityModel?.onesignalId);
+
     Object.keys(aliases).forEach(async (label) => {
-      const identityModel = OneSignal.coreDirector.getIdentityModel();
       identityModel?.set(label, aliases[label]);
     });
   }
@@ -109,8 +111,10 @@ export default class User {
       throw new InvalidArgumentError('aliases', InvalidArgumentReason.Empty);
     }
 
+    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    identityModel?.setApplyToRecordId(identityModel?.onesignalId);
+
     aliases.forEach(async (alias) => {
-      const identityModel = OneSignal.coreDirector.getIdentityModel();
       identityModel?.set(alias, undefined);
     });
   }
@@ -349,6 +353,7 @@ export default class User {
       tagKeys.forEach((tagKey) => {
         tagsCopy[tagKey] = '';
       });
+      propertiesModel?.setApplyToRecordId(propertiesModel?.onesignalId);
       propertiesModel?.set('tags', tagsCopy);
     }
   }

--- a/src/onesignal/UserDirector.ts
+++ b/src/onesignal/UserDirector.ts
@@ -110,7 +110,30 @@ export default class UserDirector {
         userData,
       );
       user.isCreatingUser = false;
-      return response.result as UserData;
+      const status = response.status;
+      const result = response.result as UserData;
+
+      if (status >= 200 && status < 300) {
+        const onesignalId = userData.identity?.onesignal_id;
+
+        if (onesignalId) {
+          OneSignal.coreDirector.getNewRecordsState().add(onesignalId);
+        }
+
+        const payloadSubcriptionToken = userData.subscriptions[0].token;
+        const resultSubscription = result.subscriptions.find(
+          (sub) => sub.token === payloadSubcriptionToken,
+        );
+
+        if (resultSubscription) {
+          if (isCompleteSubscriptionObject(resultSubscription)) {
+            OneSignal.coreDirector
+              .getNewRecordsState()
+              .add(resultSubscription.id);
+          }
+        }
+      }
+      return result;
     } catch (e) {
       Log.error(e);
     }

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -224,7 +224,7 @@ export default class LoginManager {
       { appId, subscriptionId },
       userData,
     );
-    const result = response?.result as UserData;
+    const result = response?.result;
     const status = response?.status;
 
     if (status >= 200 && status < 300) {
@@ -242,7 +242,8 @@ export default class LoginManager {
 
       const payloadSubcriptionToken = userData.subscriptions?.[0]?.token;
       const resultSubscription = result.subscriptions?.find(
-        (sub) => sub.token === payloadSubcriptionToken,
+        (sub: { token: string | undefined }) =>
+          sub.token === payloadSubcriptionToken,
       );
 
       if (resultSubscription) {

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -224,10 +224,32 @@ export default class LoginManager {
       { appId, subscriptionId },
       userData,
     );
-    const result = response?.result;
+    const result = response?.result as UserData;
     const status = response?.status;
 
     if (status >= 200 && status < 300) {
+      const onesignalId = userData.identity?.onesignal_id;
+
+      const newRecordsState = OneSignal.coreDirector.getNewRecordsState();
+
+      if (!newRecordsState) {
+        Log.error(`UpsertUser: NewRecordsState is undefined`);
+      }
+
+      if (onesignalId) {
+        newRecordsState?.add(onesignalId);
+      }
+
+      const payloadSubcriptionToken = userData.subscriptions?.[0]?.token;
+      const resultSubscription = result.subscriptions?.find(
+        (sub) => sub.token === payloadSubcriptionToken,
+      );
+
+      if (resultSubscription) {
+        if (isCompleteSubscriptionObject(resultSubscription)) {
+          newRecordsState?.add(resultSubscription.id);
+        }
+      }
       Log.info('Successfully created user', result);
     } else if (status >= 400 && status < 500) {
       Log.error('Malformed request', result);
@@ -288,6 +310,15 @@ export default class LoginManager {
 
     if (identifyResponseStatus >= 200 && identifyResponseStatus < 300) {
       Log.info('identifyUser succeeded');
+
+      const newRecordsState = OneSignal.coreDirector.getNewRecordsState();
+
+      if (!newRecordsState) {
+        Log.error(`IdentifyUser: NewRecordsState is undefined`);
+      }
+
+      // External id takes time to update on server. Include as new record with current time
+      newRecordsState?.add(onesignalId, true);
     } else if (identifyResponseStatus === 409 && pushSubscriptionId) {
       return await this.transferSubscription(
         appId,

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -350,7 +350,7 @@ export default class LoginManager {
     onesignalId: string,
     externalId?: string,
   ): Promise<void> {
-    logMethodCall('LoginManager.fetchAndHydrate', { onesignalId });
+    logMethodCall('LoginManager.fetchAndHydrate', { onesignalId, externalId });
 
     const fetchUserResponse = await RequestService.getUser(
       { appId: await MainHelper.getAppId() },

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -101,7 +101,8 @@ export default class LoginManager {
           );
           return;
         }
-        await LoginManager.fetchAndHydrate(onesignalId);
+        // hydrating with local externalId as server could still be updating
+        await LoginManager.fetchAndHydrate(onesignalId, externalId);
       } catch (e) {
         Log.error(
           `Login: Error while identifying/upserting user: ${e.message}`,
@@ -111,7 +112,10 @@ export default class LoginManager {
           Log.debug('Login: Restoring old user data');
 
           try {
-            await LoginManager.fetchAndHydrate(onesignalIdBackup);
+            await LoginManager.fetchAndHydrate(
+              onesignalIdBackup,
+              currentExternalId,
+            );
           } catch (e) {
             Log.error(
               `Login: Error while restoring old user data: ${e.message}`,
@@ -342,7 +346,10 @@ export default class LoginManager {
     return { identity: identityResult };
   }
 
-  static async fetchAndHydrate(onesignalId: string): Promise<void> {
+  static async fetchAndHydrate(
+    onesignalId: string,
+    externalId?: string,
+  ): Promise<void> {
     logMethodCall('LoginManager.fetchAndHydrate', { onesignalId });
 
     const fetchUserResponse = await RequestService.getUser(
@@ -350,7 +357,7 @@ export default class LoginManager {
       new AliasPair(AliasPair.ONESIGNAL_ID, onesignalId),
     );
 
-    OneSignal.coreDirector.hydrateUser(fetchUserResponse?.result);
+    OneSignal.coreDirector.hydrateUser(fetchUserResponse?.result, externalId);
   }
 
   /**

--- a/src/shared/models/NewRecordsState.ts
+++ b/src/shared/models/NewRecordsState.ts
@@ -1,0 +1,29 @@
+/**
+ * Purpose: Keeps track of IDs that were just created on the backend.
+ * This list gets used to delay network calls to ensure upcoming
+ * requests are ready to be accepted by the backend.
+ */
+export class NewRecordsState {
+  // time in ms
+  OP_REPO_POST_CREATE_DELAY: number;
+  // Key = a string id
+  // Value = A Timestamp in ms of when the id was created
+  private records: Map<string, number> = new Map();
+
+  constructor(time = 3000) {
+    this.OP_REPO_POST_CREATE_DELAY = time;
+  }
+
+  public add(key: string, overwrite = false): void {
+    if (overwrite || this.records.get(key)) {
+      this.records.set(key, Date.now());
+    }
+  }
+
+  public canAccess(key: string): boolean {
+    const timeLastMovedOrCreated = this.records.get(key);
+    return timeLastMovedOrCreated
+      ? Date.now() - timeLastMovedOrCreated > this.OP_REPO_POST_CREATE_DELAY
+      : true;
+  }
+}


### PR DESCRIPTION
# Description
## 1 Line Summary
Fixes outdated external ids caused by OneSignal returning the user's previous external id in its response for user GET requests when called quickly after the user was created.

## Details
The server may still be updating and can return an outdated external Id from the getUser request. Instead of waiting for the updated external Id, we can hydrate the user with the local external Id as getting a response from the server means that the login was successful.

This PR also includes:
Adding a delay after creating a new user or push subscription as the OneSignal's backend can return incorrect 404 responses. 
- Adds a new records state to keep track of recently created users and subscriptions inorder to delay appropriate operations afterwards. The delay is needed because after the server creates the user/subscription, there is a small amount of time where the data is not up to date.
- The fix done in https://github.com/OneSignal/OneSignal-Android-SDK/pull/2059 and https://github.com/OneSignal/OneSignal-iOS-SDK/pull/1470

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1189)
<!-- Reviewable:end -->
