### PR TITLE
Fix prompting again after closing notification permission prompt if site has its own ServiceWorker

### DIFF
--- a/__test__/unit/notifications/subscriptionmanager.test.ts
+++ b/__test__/unit/notifications/subscriptionmanager.test.ts
@@ -1,0 +1,32 @@
+import MockNotification from '../../support/mocks/MockNotification';
+import { SubscriptionManager } from '../../../src/shared/managers/SubscriptionManager';
+import { NotificationPermission } from '../../../src/shared/models/NotificationPermission';
+
+describe('SubscriptionManager', () => {
+  describe('requestNotificationPermission', () => {
+    beforeEach(() => {
+      window.Notification = MockNotification;
+    });
+
+    test('default', async () => {
+      MockNotification.permission = 'default';
+      expect(await SubscriptionManager.requestNotificationPermission()).toBe(
+        NotificationPermission.Default,
+      );
+    });
+
+    test('denied', async () => {
+      MockNotification.permission = 'denied';
+      expect(await SubscriptionManager.requestNotificationPermission()).toBe(
+        NotificationPermission.Denied,
+      );
+    });
+
+    test('granted', async () => {
+      MockNotification.permission = 'granted';
+      expect(await SubscriptionManager.requestNotificationPermission()).toBe(
+        NotificationPermission.Granted,
+      );
+    });
+  });
+});

--- a/src/shared/helpers/ServiceWorkerHelper.ts
+++ b/src/shared/helpers/ServiceWorkerHelper.ts
@@ -279,12 +279,6 @@ export enum ServiceWorkerActiveState {
    * No service worker is installed.
    */
   None = 'None',
-  /**
-   * Service workers are not supported in this environment. This status is used
-   * on HTTP pages where it isn't possible to know whether a service worker is
-   * installed or not or in any of the other states.
-   */
-  Indeterminate = 'Indeterminate',
 }
 
 export interface ServiceWorkerManagerConfig {

--- a/src/shared/libraries/WorkerMessenger.ts
+++ b/src/shared/libraries/WorkerMessenger.ts
@@ -197,7 +197,7 @@ export class WorkerMessenger {
     );
 
     const workerRegistration =
-      await this.context?.serviceWorkerManager.getRegistration();
+      await this.context?.serviceWorkerManager.getOneSignalRegistration();
     if (!workerRegistration) {
       Log.error(
         '`[Worker Messenger] [Page -> SW] Could not get ServiceWorkerRegistration to postMessage!',

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -750,7 +750,7 @@ export class SubscriptionManager {
     }
 
     const serviceWorkerRegistration =
-      await this.context.serviceWorkerManager.getRegistration();
+      await this.context.serviceWorkerManager.getOneSignalRegistration();
     if (!serviceWorkerRegistration) return false;
 
     // It's possible to get here in Safari 11.1+ version
@@ -834,17 +834,12 @@ export class SubscriptionManager {
       };
     }
 
-    const workerState =
-      await this.context.serviceWorkerManager.getActiveState();
     const workerRegistration =
-      await this.context.serviceWorkerManager.getRegistration();
+      await this.context.serviceWorkerManager.getOneSignalRegistration();
     const notificationPermission =
       await this.context.permissionManager.getNotificationPermission(
         this.context.appConfig.safariWebId,
       );
-    const isWorkerActive =
-      workerState === ServiceWorkerActiveState.OneSignalWorker;
-
     if (!workerRegistration) {
       /* You can't be subscribed without a service worker registration */
       return {
@@ -861,16 +856,14 @@ export class SubscriptionManager {
      * const isPushEnabled = !!(
      *   pushSubscription &&
      *   deviceId &&
-     *   notificationPermission === NotificationPermission.Granted &&
-     *   isWorkerActive
+     *   notificationPermission === NotificationPermission.Granted
      * );
      */
 
     const isPushEnabled = !!(
       isValidPushSubscription &&
       subscriptionToken &&
-      notificationPermission === NotificationPermission.Granted &&
-      isWorkerActive
+      notificationPermission === NotificationPermission.Granted
     );
 
     return {

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -333,7 +333,7 @@ export class SubscriptionManager {
     const results = await window.Notification.requestPermission();
     // TODO: Clean up our custom NotificationPermission enum
     //         in favor of TS union type NotificationPermission instead of converting
-    return NotificationPermission[results];
+    return results as NotificationPermission;
   }
 
   public async isAlreadyRegisteredWithOneSignal(): Promise<boolean> {

--- a/src/sw/helpers/ServiceWorkerUtilHelper.ts
+++ b/src/sw/helpers/ServiceWorkerUtilHelper.ts
@@ -5,7 +5,7 @@ export default class ServiceWorkerUtilHelper {
   // A  relative scope is required as a domain can have none to many service workers installed.
   static async getRegistration(
     scope: string,
-  ): Promise<ServiceWorkerRegistration | null | undefined> {
+  ): Promise<ServiceWorkerRegistration | undefined> {
     try {
       // Adding location.origin to negate the effects of a possible <base> html tag the page may have.
       const url = location.origin + scope;
@@ -17,7 +17,7 @@ export default class ServiceWorkerUtilHelper {
         scope,
         e,
       );
-      return null;
+      return undefined;
     }
   }
 

--- a/test/unit/managers/ServiceWorkerManager.ts
+++ b/test/unit/managers/ServiceWorkerManager.ts
@@ -5,10 +5,7 @@ import sinon, { SinonSandbox, SinonStub } from 'sinon';
 import nock from 'nock';
 import { ServiceWorkerManager } from '../../../src/shared/managers/ServiceWorkerManager';
 import { ServiceWorkerActiveState } from '../../../src/shared/helpers/ServiceWorkerHelper';
-import {
-  TestEnvironment,
-  TestEnvironmentConfig,
-} from '../../support/sdk/TestEnvironment';
+import { TestEnvironment } from '../../support/sdk/TestEnvironment';
 import Context from '../../../src/page/models/Context';
 import SdkEnvironment from '../../../src/shared/managers/SdkEnvironment';
 import { WindowEnvironmentKind } from '../../../src/shared/models/WindowEnvironmentKind';
@@ -25,7 +22,6 @@ import { ServiceWorkerRegistrationError } from '../../../src/shared/errors/Servi
 import OneSignalUtils from '../../../src/shared/utils/OneSignalUtils';
 import { MockServiceWorkerRegistration } from '../../support/mocks/service-workers/models/MockServiceWorkerRegistration';
 import { MockServiceWorker } from '../../support/mocks/service-workers/models/MockServiceWorker';
-import { ConfigIntegrationKind } from '../../../src/shared/models/AppConfig';
 import Environment from '../../../src/shared/helpers/Environment';
 import { MockServiceWorkerContainerWithAPIBan } from '../../support/mocks/service-workers/models/MockServiceWorkerContainerWithAPIBan';
 import Path from '../../../src/shared/models/Path';
@@ -374,12 +370,14 @@ test('Service worker failed to install due to 404 on host page. Send notificatio
 
 test('ServiceWorkerManager.getRegistration() returns valid instance when sw is registered', async (t) => {
   await navigator.serviceWorker.register('/Worker.js');
-  const result = await OneSignal.context.serviceWorkerManager.getRegistration();
+  const result =
+    await OneSignal.context.serviceWorkerManager.getOneSignalRegistration();
   t.truthy(result);
 });
 
 test('ServiceWorkerManager.getRegistration() returns undefined when sw is not registered ', async (t) => {
-  const result = await OneSignal.context.serviceWorkerManager.getRegistration();
+  const result =
+    await OneSignal.context.serviceWorkerManager.getOneSignalRegistration();
   t.is(result, undefined);
 });
 
@@ -395,6 +393,7 @@ test('ServiceWorkerManager.getRegistration() handles throws by returning null', 
       throw new Error('HTTP NOT SUPPORTED');
     }),
   );
-  const result = await OneSignal.context.serviceWorkerManager.getRegistration();
+  const result =
+    await OneSignal.context.serviceWorkerManager.getOneSignalRegistration();
   t.is(result, null);
 });


### PR DESCRIPTION
# Description
## 1 Line Summary
Fix prompting again after closing notification permission prompt if site has its own ServiceWorker.

## Details
This PR fixes two things related to this issue:
1. requestNotificationPermission() - this was always returning `undefined` due to a conversion bug
2. getRegistration() - did not check if the service worker was a OneSignal one, resulting in wrong assumptions being made.

# Validation
## Tests
Added a unit test for `requestNotificationPermission()`, this was always returning `undefined` before the changes in the first commit.

### Checklist
   - [X] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1192)
<!-- Reviewable:end -->
