### PR TITLE
Fix logout() when push subscription doesn't exists

### DIFF
--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -143,12 +143,20 @@ export default class LoginManager {
     const pushSubModel =
       await OneSignal.coreDirector.getPushSubscriptionModel();
     await OneSignal.coreDirector.resetModelRepoAndCache();
+
+    // Initialize as a local User, as we don't have a push subscription to create a remote anonymous user.
+    if (pushSubModel === undefined) {
+      await UserDirector.initializeUser(true);
+      return;
+    }
+
     // add the push subscription model back to the repo since we need at least 1 sub to create a new user
     OneSignal.coreDirector.add(
       ModelName.PushSubscriptions,
       pushSubModel as OSModel<SupportedModel>,
       false,
     );
+    // Initialize as non-local, make a request to OneSignal to create a new anonymous user
     await UserDirector.initializeUser(false);
   }
 


### PR DESCRIPTION
# Description
## One-Line Summary
Fix OneSignal.logout() so it doesn't throw an error if there isn't a push subscription.

## Details
A push subscription only exists if the end-user accepted notifications at some point. `OneSignal.logout()` made this bad assumption it always existed.

The fix is to check this and create a local only user instead of making a call to OneSignal if there isn't a push subscription.

# Validation
## Tests
Tested on Chrome Version 128.0.6613.138 on Windows 11 23H2
Scenarios:
1. OneSignal.login("A");
2. OneSignal.User.addEmail("a@a.com");
3. OneSignal.logout();
4. OneSignal.User.addEmail("b@b.com");
5. Observe b@b.com was added to the correct User.

### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed
      - No current login / logout tests, there is another project to add test coverage to this flow.

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

---

## Related Tickets
* https://github.com/OneSignal/onesignal-vue3/issues/43
* https://github.com/OneSignal/react-onesignal/issues/140

---
