### PR TITLE
[Dev] Enable compile TypeScript checks; noUnusedLocals, noUnusedParameters, & strictFunctionTypes

### DIFF
--- a/build/config/tsconfig.base.json
+++ b/build/config/tsconfig.base.json
@@ -27,6 +27,7 @@
     "sourceRoot": "../..",
     "rootDir": "../..",
     "esModuleInterop": true,
+    "strictFunctionTypes": true,
     "baseUrl": "../..",
     "types": [
       "node"

--- a/build/config/tsconfig.base.json
+++ b/build/config/tsconfig.base.json
@@ -8,7 +8,7 @@
     "noImplicitAny": false,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noUnusedLocals": false,
+    "noUnusedLocals": true,
     "noUnusedParameters": false,
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,

--- a/build/config/tsconfig.base.json
+++ b/build/config/tsconfig.base.json
@@ -9,7 +9,7 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": false,
+    "noUnusedParameters": true,
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,

--- a/src/page/bell/Bell.ts
+++ b/src/page/bell/Bell.ts
@@ -494,9 +494,7 @@ export default class Bell {
 
     const isPushEnabled =
       await OneSignal.context.subscriptionManager.isPushNotificationsEnabled();
-    const doNotPrompt = DismissHelper.wasPromptOfTypeDismissed(
-      DismissPrompt.Push,
-    );
+    DismissHelper.wasPromptOfTypeDismissed(DismissPrompt.Push);
 
     // Resize to small instead of specified size if enabled, otherwise there's a jerking motion
     // where the bell, at a different size than small, jerks sideways to go from large -> small or medium -> small

--- a/src/page/bell/Dialog.ts
+++ b/src/page/bell/Dialog.ts
@@ -1,5 +1,3 @@
-import bowser from 'bowser';
-
 import OneSignalEvent from '../../shared/services/OneSignalEvent';
 import SdkEnvironment from '../../shared/managers/SdkEnvironment';
 import {

--- a/src/page/managers/PromptsManager.ts
+++ b/src/page/managers/PromptsManager.ts
@@ -6,7 +6,6 @@ import {
 } from '../../shared/config/constants';
 import { DismissHelper } from '../../shared/helpers/DismissHelper';
 import InitHelper from '../../shared/helpers/InitHelper';
-import MainHelper from '../../shared/helpers/MainHelper';
 import PromptsHelper from '../../shared/helpers/PromptsHelper';
 import Log from '../../shared/libraries/Log';
 import {

--- a/src/shared/helpers/EventHelper.ts
+++ b/src/shared/helpers/EventHelper.ts
@@ -1,4 +1,3 @@
-import OneSignalApiShared from '../api/OneSignalApiShared';
 import Log from '../libraries/Log';
 import { CustomLinkManager } from '../managers/CustomLinkManager';
 import { ContextSWInterface } from '../models/ContextSW';

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -242,7 +242,9 @@ export class SubscriptionManager {
    * @param rawPushSubscription The raw push subscription obtained from calling subscribe(). This
    * can be null, in which case OneSignal's device record is set to unsubscribed.
    *
-   * @param subscriptionState Describes whether the device record is subscribed, unsubscribed, or in
+   * @param subscriptionState TODO: This is no longer used here and needs some refactoring to
+   * put this back into place.
+   * Describes whether the device record is subscribed, unsubscribed, or in
    * another state. By default, this is set from the availability of rawPushSubscription (exists:
    * Subscribed, null: Unsubscribed). Other use cases may result in creation of a device record that
    * warrants a special subscription state. For example, a device ID can be retrieved by providing
@@ -251,7 +253,7 @@ export class SubscriptionManager {
    */
   public async registerSubscription(
     pushSubscription: RawPushSubscription,
-    subscriptionState?: SubscriptionStateKind,
+    _subscriptionState?: SubscriptionStateKind,
   ): Promise<Subscription> {
     /*
       This may be called after the RawPushSubscription has been serialized across a postMessage
@@ -477,6 +479,10 @@ export class SubscriptionManager {
         await this.context.serviceWorkerManager.installWorker();
     } catch (err) {
       if (err instanceof ServiceWorkerRegistrationError) {
+        // TODO: This doesn't register the subscription any more, most likely broke
+        // in some refactoring in the v16 major release. It would be useful if a
+        // subscription was created so the customer knows this failed by seeing
+        // subscriptions in this state on the OneSignal dashboard.
         if (err.status === 403) {
           await this.context.subscriptionManager.registerFailedSubscription(
             SubscriptionStateKind.ServiceWorkerStatus403,

--- a/src/shared/utils/Encoding.ts
+++ b/src/shared/utils/Encoding.ts
@@ -70,35 +70,6 @@ export function arrayBufferToBase64(arrayBuffer: ArrayBufferLike): string {
   return base64;
 }
 
-/**
- * From: https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/Base64_encoding_and_decoding
- */
-export function base64Encode(str) {
-  // first we use encodeURIComponent to get percent-encoded UTF-8,
-  // then we convert the percent encodings into raw bytes which
-  // can be fed into btoa.
-  return btoa(
-    encodeURIComponent(str).replace(
-      /%([0-9A-F]{2})/g,
-      function toSolidBytes(_match, p1) {
-        return String.fromCharCode(('0x' as any) + p1);
-      },
-    ),
-  );
-}
-
-export function base64Decode(str) {
-  // Going backwards: from bytestream, to percent-encoding, to original string.
-  return decodeURIComponent(
-    atob(str)
-      .split('')
-      .map(function (c) {
-        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
-      })
-      .join(''),
-  );
-}
-
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#encoding_for_rfc3986
 export function encodeRFC3986URIComponent(str: string): string {
   return encodeURIComponent(str).replace(

--- a/src/shared/utils/Encoding.ts
+++ b/src/shared/utils/Encoding.ts
@@ -80,7 +80,7 @@ export function base64Encode(str) {
   return btoa(
     encodeURIComponent(str).replace(
       /%([0-9A-F]{2})/g,
-      function toSolidBytes(match, p1) {
+      function toSolidBytes(_match, p1) {
         return String.fromCharCode(('0x' as any) + p1);
       },
     ),

--- a/src/shared/utils/utils.ts
+++ b/src/shared/utils/utils.ts
@@ -1,6 +1,5 @@
 import SdkEnvironment from '../managers/SdkEnvironment';
 import { WindowEnvironmentKind } from '../models/WindowEnvironmentKind';
-import Database from '../services/Database';
 import { OneSignalUtils } from './OneSignalUtils';
 import { PermissionUtils } from './PermissionUtils';
 import { Utils } from '../context/Utils';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "strictNullChecks": true,
     "checkJs": true,
     "noImplicitAny": true,
-    "noUnusedParameters": true,
     "strictPropertyInitialization": true,
     "baseUrl": ".",
     "types": ["jest", "node"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "strictNullChecks": true,
     "checkJs": true,
     "noImplicitAny": true,
-    "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strictPropertyInitialization": true,
     "baseUrl": ".",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strictPropertyInitialization": true,
-    "strictFunctionTypes": true,
     "baseUrl": ".",
     "types": ["jest", "node"]
   },


### PR DESCRIPTION
# Description
## One-Line Summary
Enforce some additional Typescript compile errors that were only IDE warnings.

## Details
Enable these TS config compile settings. noUnusedLocals, noUnusedParameters, & strictFunctionTypes

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [X] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [X] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1195)
<!-- Reviewable:end -->
