### PR TITLE
[Fix] Type Error in Operation Repo Tests

### DIFF
--- a/__test__/unit/core/operationRepo.test.ts
+++ b/__test__/unit/core/operationRepo.test.ts
@@ -2,6 +2,7 @@ import {
   DELTA_QUEUE_TIME_ADVANCE,
   DUMMY_MODEL_ID,
   DUMMY_ONESIGNAL_ID,
+  DUMMY_PUSH_TOKEN,
 } from '../../support/constants';
 import ModelCache from '../../../src/core/caching/ModelCache';
 import ExecutorBase from '../../../src/core/executors/ExecutorBase';
@@ -22,6 +23,7 @@ import {
 } from '../../support/helpers/core';
 import { TestEnvironment } from '../../support/environment/TestEnvironment';
 import { Operation } from '../../../src/core/operationRepo/Operation';
+import Database from '../../../src/shared/services/Database';
 
 let broadcastCount = 0;
 
@@ -197,6 +199,14 @@ describe('OperationRepo tests', () => {
 
   test('Update User Properties: -> one operation of change type: update', (done: jest.DoneCallback) => {
     test.stub(Operation, 'getInstanceWithModelReference');
+
+    test.stub(
+      Database,
+      'getAppState',
+      Promise.resolve({
+        lastKnownPushToken: DUMMY_PUSH_TOKEN,
+      }),
+    );
 
     const { modelRepo, operationRepo } = OneSignal.coreDirector.core;
     const executor = operationRepo?.executorStore.store[ModelName.Properties];


### PR DESCRIPTION
# Description
## 1 Line Summary
Fixes `TypeError: Cannot destructure property 'lastKnownPushToken' of '(intermediate value)' as it is undefined.` in operation repo tests.

## Details
Fixes `TypeError` from `operationRepo.tests.ts` when running `yarn test` by stubbing out `lastKnownPushToken`.

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1196)
<!-- Reviewable:end -->
