### PR TITLE
160203 Release

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jest": "jest --coverage"
   },
   "config": {
-    "sdkVersion": "160202"
+    "sdkVersion": "160203"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release notes
### 🐛 Bug Fixes
- Fix prompting again after closing notification permission prompt if site has its own ServiceWorker. (https://github.com/OneSignal/OneSignal-Website-SDK/pull/1192)
- Fix `OneSignal.logout()` so it doesn't throw an error if there isn't a push subscription. (https://github.com/OneSignal/OneSignal-Website-SDK/pull/1194) 
- Fix outdated external ids caused by OneSignal returning the user's previous external id in its response for user GET requests when called quickly after the user was created. (https://github.com/OneSignal/OneSignal-Website-SDK/pull/1189)

### Dev Enhancements 
- Enforce some additional Typescript compile errors that were only IDE warnings. (https://github.com/OneSignal/OneSignal-Website-SDK/pull/1195)
- Fix `TypeError: Cannot destructure property 'lastKnownPushToken' of '(intermediate value)' as it is undefined.` in operation repo tests. (https://github.com/OneSignal/OneSignal-Website-SDK/pull/1196)
- Operation repo refactor that will help with the implementation of identity verification (https://github.com/OneSignal/OneSignal-Website-SDK/pull/1179)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1199)
<!-- Reviewable:end -->
