### PR TITLE
test: explicitly assert for Log.error calls in `registerForPush`

### DIFF
--- a/__test__/unit/push/registerForPush.test.ts
+++ b/__test__/unit/push/registerForPush.test.ts
@@ -7,10 +7,18 @@ import BrowserUserAgent from '../../support/models/BrowserUserAgent';
 //stub dismisshelper
 jest.mock('../../../src/shared/helpers/DismissHelper');
 
+//stub log
+jest.mock('../../../src/shared/libraries/Log', () => ({
+  debug: jest.fn(),
+  trace: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
 describe('Register for push', () => {
   beforeEach(async () => {
     jest.useFakeTimers();
-    jest.spyOn(Log, 'error').mockImplementation(() => {})
     await TestEnvironment.initialize({
       addPrompts: true,
       userAgent: BrowserUserAgent.Default,
@@ -31,6 +39,7 @@ describe('Register for push', () => {
     expect(spy).not.toHaveBeenCalled();
     OneSignalEvent.trigger(OneSignal.EVENTS.SDK_INITIALIZED);
     await promise;
+    expect(Log.error).toHaveBeenCalled();
     expect(OneSignal.initialized).toBe(true);
     expect(spy).toHaveBeenCalledTimes(1);
   });
@@ -41,6 +50,7 @@ describe('Register for push', () => {
 
     const spy = jest.spyOn(InitHelper, 'registerForPushNotifications');
     await InitHelper.registerForPushNotifications();
+    expect(Log.error).toHaveBeenCalled();
     expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/__test__/unit/push/registerForPush.test.ts
+++ b/__test__/unit/push/registerForPush.test.ts
@@ -1,6 +1,7 @@
 import { TestEnvironment } from '../../support/environment/TestEnvironment';
 import InitHelper from '../../../src/shared/helpers/InitHelper';
 import OneSignalEvent from '../../../src/shared/services/OneSignalEvent';
+import Log from '../../../src/shared/libraries/Log';
 import BrowserUserAgent from '../../support/models/BrowserUserAgent';
 
 //stub dismisshelper
@@ -9,6 +10,7 @@ jest.mock('../../../src/shared/helpers/DismissHelper');
 describe('Register for push', () => {
   beforeEach(async () => {
     jest.useFakeTimers();
+    jest.spyOn(Log, 'error').mockImplementation(() => {})
     await TestEnvironment.initialize({
       addPrompts: true,
       userAgent: BrowserUserAgent.Default,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build:staging": "ENV=staging yarn transpile:sources && ENV=staging yarn bundle-sw && ENV=staging yarn bundle-sdk && ENV=staging yarn bundle-page-sdk-es6 && ENV=staging build/scripts/publish.sh",
     "build:prod": "ENV=production yarn transpile:sources && ENV=production yarn bundle-sw && ENV=production yarn bundle-sdk && ENV=production yarn bundle-page-sdk-es6 && bundlesize && ENV=production build/scripts/publish.sh",
     "test": "NODE_OPTIONS=\"--trace-warnings --unhandled-rejections=warn\" yarn run jest --detectOpenHandles --forceExit --runInBand",
+    "test:watch": "NODE_OPTIONS=\"--trace-warnings --unhandled-rejections=warn\" yarn run jest --detectOpenHandles --forceExit --runInBand --watch",
     "publish": "yarn clean && yarn build:prod && yarn",
     "build:dev-dev": "./build/scripts/build.sh -f development -t development -a localhost",
     "build:dev-prod": "./build/scripts/build.sh -f development -t production",


### PR DESCRIPTION
# Description
## 1 Line Summary

Explicitly tests for an error in the `registerForPush` test.

## Details

When running current tests, the following error is emitted:

```
  console.error
    PushPermissionNotGrantedError: The user dismissed the permission prompt.
        at SubscriptionManager.subscribeFcmFromPage (/Website-SDK/src/shared/managers/SubscriptionManager.ts:461:17)
        at SubscriptionManager.subscribe (/Website-SDK/src/shared/managers/SubscriptionManager.ts:162:13)
        at Function.internalRegisterForPush (/Website-SDK/src/shared/helpers/SubscriptionHelper.ts:30:35)
        at Function.registerForPush (/Website-SDK/src/shared/helpers/SubscriptionHelper.ts:20:12)
        at Function.registerForPushNotifications (/Website-SDK/src/shared/helpers/InitHelper.ts:104:5)
        at PromptsManager.internalShowNativePrompt (/Website-SDK/src/page/managers/PromptsManager.ts:188:5)
        at NotificationsNamespace.requestPermission (/Website-SDK/src/onesignal/NotificationsNamespace.ts:142:5)
        at PushSubscriptionNamespace.optIn (/Website-SDK/src/onesignal/PushSubscriptionNamespace.ts:96:7)
        at Object.<anonymous> (/Website-SDK/__test__/unit/push/registerForPush.test.ts:33:5) {
      reason: 1
    }
```

This change adds an assertion since the error is part of the test's [expected behavior](https://github.com/OneSignal/OneSignal-Website-SDK/pull/1206#issuecomment-2483933629).

~~Even though the error occurs, the [tests](https://github.com/OneSignal/OneSignal-Website-SDK/blob/main/__test__/unit/push/registerForPush.test.ts) still pass. For that reason, I assumed it's not part of the test's expected behavior. Please feel free to correct me if my understanding there is wrong.~~
 
~~**Note:** If needed we can add something like `expect(Log.error).toHaveBeenCalled()` to ensure that we are testing for the existence of the error.~~

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1206)
<!-- Reviewable:end -->
