### PR TITLE
fix: Correct payload to unbreak open link when clicking welcome notification

### DIFF
--- a/src/shared/helpers/MainHelper.ts
+++ b/src/shared/helpers/MainHelper.ts
@@ -77,7 +77,7 @@ export default class MainHelper {
     };
     const dataPayload = {
       data,
-      url,
+      launchURL: url,
       buttons: buttons
         ? convertButtonsToNotificationActionType(buttons)
         : undefined,


### PR DESCRIPTION
https://app.asana.com/0/1208719710991963/1208760940956731/f

This issue boiled down to the "Open link when clicking welcome notification" feature not working, when you clicked the notification is opened the 'default' URL, not the option set.

After doing a bunch of digging, I was able to confirm that we were saving that setting and then servcing it to the SDK via the sync API.

I was then able to trace it through:

1) src/shared/helpers/EventHelper.ts (onSubscriptionChanged_showWelcomeNotification)
2) src/shared/helpers/MainHelper.ts (MainHelper.showLocalNotification)

There we shovel that url into a dataPayload that we shovel into a service worker call.

That comes out the other side when you click the notifiction in:

3) src/sw/serviceWorker/ServiceWorker.ts (onNotificationClicked)

There we cast via:

const osNotification = event.notification.data as IOSNotification;

IOSNotification is defined to have:

```
readonly launchURL?: string;
```

However, the struct we created had:

```
    const dataPayload = {
      data,
      url,
      buttons: buttons
        ? convertButtonsToNotificationActionType(buttons)
        : undefined,
    };
```

url != launchURL

Fixing the payload made it start working.


# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

I only manually tested this. If we need automated tests, please show me where to get started.

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots

![image](https://github.com/user-attachments/assets/a1f31add-165e-4198-a436-d0cc3404f904)

![image](https://github.com/user-attachments/assets/af5af7fe-79fc-4b4a-8599-fae2a4d95688)

### Info

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets
https://app.asana.com/0/1208719710991963/1208760940956731/f
---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1207)
<!-- Reviewable:end -->
