### PR TITLE
test: first pass of ServiceWorker tests

### DIFF
--- a/__test__/unit/sw/serviceWorker.test.ts
+++ b/__test__/unit/sw/serviceWorker.test.ts
@@ -1,7 +1,12 @@
 import { ServiceWorker } from '../../../src/sw/serviceWorker/ServiceWorker';
+import Database from '../../../src/shared/services/Database';
 
 // suppress all internal logging
 jest.mock('../../../src/shared/libraries/Log');
+
+// mock dependencies
+jest.mock('../../../src/shared/services/Database');
+jest.mock('../../../src/shared/utils/AwaitableTimeout');
 
 function chromeUserAgentDataBrands(): Array<{
   brand: string;
@@ -48,6 +53,305 @@ describe('ServiceWorker', () => {
       expect(
         ServiceWorker.requiresMacOS15ChromiumAfterDisplayWorkaround(),
       ).toBe(true);
+    });
+  });
+
+  describe('API', () => {
+    let mockSelf: any;
+
+    beforeEach(() => {
+      // Setup mock ServiceWorker global scope
+      mockSelf = {
+        registration: {
+          showNotification: jest.fn().mockResolvedValue(undefined),
+        },
+        clients: {
+          openWindow: jest.fn(),
+        }
+      };
+      global.self = mockSelf;
+
+      // Reset mocks between tests
+      jest.clearAllMocks();
+    });
+
+    describe('onPushReceived', () => {
+      beforeEach(() => {
+        // Mock parseOrFetchNotifications to return a controlled payload
+        jest.spyOn(ServiceWorker, 'parseOrFetchNotifications').mockResolvedValue([
+          {
+            title: 'Test Title',
+            body: 'Test Body',
+            icon: 'test-icon.png',
+            custom: {
+              i: 'test-uuid'
+            }
+          }
+        ]);
+
+        // Mock other required methods
+        jest.spyOn(ServiceWorker, 'getAppId').mockResolvedValue('test-app-id');
+        jest.spyOn(ServiceWorker, 'getPushSubscriptionId').mockResolvedValue('test-sub-id');
+        
+        // Mock Database
+        (Database.putNotificationReceivedForOutcomes as jest.Mock).mockResolvedValue(undefined);
+      });
+
+      it('should not show notification for undefined payload', async () => {
+        const mockPushEvent = {
+          data: {
+            json: () => undefined
+          },
+          waitUntil: jest.fn()
+        };
+
+        ServiceWorker.onPushReceived(mockPushEvent);
+        expect(mockSelf.registration.showNotification).not.toHaveBeenCalled();
+      });
+
+      it('should not show notification for empty payload', async () => {
+        const mockPushEvent = {
+          data: {
+            json: () => ({})
+          },
+          waitUntil: jest.fn()
+        };
+
+        ServiceWorker.onPushReceived(mockPushEvent);
+        expect(mockSelf.registration.showNotification).not.toHaveBeenCalled();
+      });
+
+      it('should not show notification for non-OneSignal payload', async () => {
+        const mockPushEvent = {
+          data: {
+            json: () => ({ title: 'Test Title' })
+          },
+          waitUntil: jest.fn()
+        };
+
+        ServiceWorker.onPushReceived(mockPushEvent);
+        expect(mockSelf.registration.showNotification).not.toHaveBeenCalled();
+      });
+
+      it('should show notification with valid OneSignal payload', async () => {
+        // Track the promise passed to waitUntil
+        let waitUntilPromise: Promise<any>;
+        
+        const mockPushEvent = {
+          data: {
+            json: () => ({
+              custom: {
+                i: 'test-uuid'
+              },
+              title: 'Test Title'
+            })
+          },
+          waitUntil: jest.fn((promise) => {
+            waitUntilPromise = promise;
+            return promise;
+          })
+        };
+
+        // Call onPushReceived
+        ServiceWorker.onPushReceived(mockPushEvent);
+        
+        // Wait for the waitUntil promise to complete
+        await waitUntilPromise;
+
+        expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
+          'Test Title',
+          expect.objectContaining({
+            data: expect.objectContaining({
+              id: expect.any(String)
+            })
+          })
+        );
+      });
+    });
+
+    describe('displayNotification', () => {
+      it('should set requireInteraction to true when persistNotification is true', async () => {
+        (Database.get as jest.Mock).mockResolvedValue({ value: true });
+
+        await ServiceWorker.displayNotification({
+          body: '',
+          confirmDelivery: false,
+          notificationId: 'test-id'
+        });
+
+        expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            requireInteraction: true
+          })
+        );
+      });
+
+      it('should set requireInteraction to true when persistNotification is undefined', async () => {
+        (Database.get as jest.Mock).mockResolvedValue(undefined);
+
+        await ServiceWorker.displayNotification({
+          body: '',
+          confirmDelivery: false,
+          notificationId: 'test-id'
+        });
+
+        expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            requireInteraction: true
+          })
+        );
+      });
+
+      it('should set requireInteraction to true when persistNotification is "force"', async () => {
+        (Database.get as jest.Mock).mockResolvedValue({ value: 'force' });
+
+        await ServiceWorker.displayNotification({
+          body: '',
+          confirmDelivery: false,
+          notificationId: 'test-id'
+        });
+
+        expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            requireInteraction: true
+          })
+        );
+      });
+
+      it('should set requireInteraction to false when persistNotification is false', async () => {
+        (Database.get as jest.Mock).mockResolvedValue({ value: false });
+
+        await ServiceWorker.displayNotification({
+          body: '',
+          confirmDelivery: false,
+          notificationId: 'test-id'
+        });
+
+        expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            requireInteraction: false
+          })
+        );
+      });
+    });
+
+    describe('onNotificationClicked', () => {
+      beforeEach(() => {
+        // Mock fetch for API calls
+        global.fetch = jest.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ success: true })
+        });
+      });
+
+      it('should send notification PUT request when clicked', async () => {
+        const notificationId = 'test-notification-id';
+        const mockNotificationEvent = {
+          notification: {
+            data: { id: notificationId },
+            close: jest.fn()
+          }
+        };
+
+        await ServiceWorker.onNotificationClicked(mockNotificationEvent);
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          expect.stringContaining(`/api/v1/notifications/${notificationId}`),
+          expect.objectContaining({
+            method: 'PUT',
+            body: expect.any(String)
+          })
+        );
+      });
+
+      it('should execute webhooks when notification is clicked', async () => {
+        const notificationId = 'test-notification-id';
+        const mockNotificationEvent = {
+          notification: {
+            data: { id: notificationId },
+            close: jest.fn()
+          }
+        };
+
+        const executeWebhooksSpy = jest.spyOn(ServiceWorker, 'executeWebhooks');
+        await ServiceWorker.onNotificationClicked(mockNotificationEvent);
+
+        expect(executeWebhooksSpy).toHaveBeenCalledWith(
+          'notification.clicked',
+          expect.objectContaining({ id: notificationId })
+        );
+      });
+
+      it('should open window when notification is clicked', async () => {
+        const notificationId = 'test-notification-id';
+        const mockNotificationEvent = {
+          notification: {
+            data: { id: notificationId },
+            close: jest.fn()
+          }
+        };
+
+        await ServiceWorker.onNotificationClicked(mockNotificationEvent);
+        expect(mockSelf.clients.openWindow).toHaveBeenCalled();
+      });
+    });
+
+    describe('sendConfirmedDelivery', () => {
+      beforeEach(() => {
+        // Mock fetch for API calls
+        global.fetch = jest.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ success: true })
+        });
+      });
+
+      it('should send confirmed delivery when feature flag is true', async () => {
+        const notificationId = 'test-notification-id';
+        
+        await ServiceWorker.sendConfirmedDelivery({
+          notificationId,
+          confirmDelivery: true,
+          body: ''
+        });
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          expect.stringContaining(`/api/v1/notifications/${notificationId}/report_received`),
+          expect.any(Object)
+        );
+      });
+
+      it('should not send confirmed delivery when feature flag is false', async () => {
+        const notificationId = 'test-notification-id';
+        
+        await ServiceWorker.sendConfirmedDelivery({
+          notificationId,
+          confirmDelivery: false,
+          body: ''
+        });
+
+        expect(global.fetch).not.toHaveBeenCalled();
+      });
+
+      it('should include device_type in confirmed delivery request', async () => {
+        const notificationId = 'test-notification-id';
+        
+        await ServiceWorker.sendConfirmedDelivery({
+          notificationId,
+          confirmDelivery: true,
+          body: ''
+        });
+
+        expect(global.fetch).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            body: expect.stringContaining('"device_type":5')
+          })
+        );
+      });
     });
   });
 });

--- a/__test__/unit/sw/serviceWorker.test.ts
+++ b/__test__/unit/sw/serviceWorker.test.ts
@@ -170,7 +170,8 @@ describe('ServiceWorker', () => {
           'Test Title',
           expect.objectContaining({
             data: expect.objectContaining({
-              id: expect.any(String)
+              title: "Test Title",
+              notificationId: "test-uuid"
             })
           })
         );
@@ -178,17 +179,25 @@ describe('ServiceWorker', () => {
     });
 
     describe('displayNotification', () => {
-      it('should set requireInteraction to true when persistNotification is true', async () => {
-        (Database.get as jest.Mock).mockResolvedValue({ value: true });
+      beforeEach(() => {
+        // Reset mocks before each test
+        jest.clearAllMocks();
 
+        // Mock Database methods
+        (Database.get as jest.Mock).mockResolvedValue({ value: true });
+        (Database.getAppConfig as jest.Mock).mockResolvedValue({ appId: 'test-app-id' });
+      });
+
+      it('should set requireInteraction to true when persistNotification is true', async () => {
         await ServiceWorker.displayNotification({
           body: '',
+          title: 'Test Title',
           confirmDelivery: false,
           notificationId: 'test-id'
         });
 
         expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
-          expect.any(String),
+          'Test Title',
           expect.objectContaining({
             requireInteraction: true
           })
@@ -200,12 +209,13 @@ describe('ServiceWorker', () => {
 
         await ServiceWorker.displayNotification({
           body: '',
+          title: 'Test Title',
           confirmDelivery: false,
           notificationId: 'test-id'
         });
 
         expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
-          expect.any(String),
+          'Test Title',
           expect.objectContaining({
             requireInteraction: true
           })
@@ -217,12 +227,13 @@ describe('ServiceWorker', () => {
 
         await ServiceWorker.displayNotification({
           body: '',
+          title: 'Test Title',
           confirmDelivery: false,
           notificationId: 'test-id'
         });
 
         expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
-          expect.any(String),
+          'Test Title',
           expect.objectContaining({
             requireInteraction: true
           })
@@ -234,12 +245,13 @@ describe('ServiceWorker', () => {
 
         await ServiceWorker.displayNotification({
           body: '',
+          title: 'Test Title',
           confirmDelivery: false,
           notificationId: 'test-id'
         });
 
         expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(
-          expect.any(String),
+          'Test Title',
           expect.objectContaining({
             requireInteraction: false
           })

--- a/__test__/unit/sw/serviceWorker.test.ts
+++ b/__test__/unit/sw/serviceWorker.test.ts
@@ -78,21 +78,8 @@ describe('ServiceWorker', () => {
   });
 
   describe('API', () => {
-    let mockSelf: any;
 
-    beforeEach(() => {
-      // Setup mock ServiceWorker global scope
-      mockSelf = {
-        registration: {
-          showNotification: jest.fn().mockResolvedValue(undefined),
-        },
-        clients: {
-          openWindow: jest.fn(),
-        }
-      };
-      global.self = mockSelf;
-
-      // Reset mocks between tests
+    afterEach(() => {
       jest.clearAllMocks();
     });
 

--- a/__test__/unit/sw/serviceWorker.test.ts
+++ b/__test__/unit/sw/serviceWorker.test.ts
@@ -20,6 +20,27 @@ function chromeUserAgentDataBrands(): Array<{
 }
 
 describe('ServiceWorker', () => {
+  // Define the ServiceWorker global scope type
+  declare const self: ServiceWorkerGlobalScope;
+
+  // Create a mock self object
+  const mockSelf = {
+    registration: {
+      showNotification: jest.fn().mockResolvedValue(undefined),
+    },
+    clients: {
+      openWindow: jest.fn(),
+    }
+  } as unknown as ServiceWorkerGlobalScope;
+
+  beforeAll(() => {
+    // Set up the global ServiceWorker scope
+    Object.defineProperty(global, 'self', {
+      value: mockSelf,
+      writable: true
+    });
+  });
+
   describe('requiresMacOS15ChromiumAfterDisplayWorkaround', () => {
     test('navigator.userAgentData undefined', async () => {
       delete (navigator as any).userAgentData;

--- a/__test__/unit/sw/serviceWorker.test.ts
+++ b/__test__/unit/sw/serviceWorker.test.ts
@@ -185,6 +185,7 @@ describe('ServiceWorker', () => {
 
         // Mock Database methods
         (Database.get as jest.Mock).mockResolvedValue({ value: true });
+        (Database.put as jest.Mock).mockResolvedValue({ value: false });
         (Database.getAppConfig as jest.Mock).mockResolvedValue({ appId: 'test-app-id' });
       });
 
@@ -241,13 +242,11 @@ describe('ServiceWorker', () => {
       });
 
       it('should set requireInteraction to false when persistNotification is false', async () => {
-        (Database.get as jest.Mock).mockResolvedValue({ value: false });
-
+        await Database.put('Options', { key: 'persistNotification', value: false });
         await ServiceWorker.displayNotification({
           body: '',
-          title: 'Test Title',
           confirmDelivery: false,
-          notificationId: 'test-id'
+          notificationId: ''
         });
 
         expect(mockSelf.registration.showNotification).toHaveBeenCalledWith(


### PR DESCRIPTION
# Description
## 1 Line Summary

## Details

# Systems Affected
   - [ ] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---
