### PR TITLE
160205 release

### DIFF
--- a/__test__/support/environment/TestContext.ts
+++ b/__test__/support/environment/TestContext.ts
@@ -134,7 +134,6 @@ export default class TestContext {
             enable: false,
           },
           serviceWorker: {
-            customizationEnabled: false,
             path: '/',
             workerName: 'OneSignalSDKWorker.js',
             registrationScope: '/',
@@ -294,7 +293,6 @@ export default class TestContext {
           kind: configIntegrationKind,
         },
         serviceWorker: {
-          customizationEnabled: false,
           path: '/',
           workerName: 'OneSignalSDKWorker.js',
           registrationScope: '/',

--- a/__test__/support/environment/TestContext.ts
+++ b/__test__/support/environment/TestContext.ts
@@ -294,10 +294,10 @@ export default class TestContext {
           kind: configIntegrationKind,
         },
         serviceWorker: {
-          path: undefined,
-          workerName: undefined,
-          registrationScope: undefined,
-          customizationEnabled: true,
+          customizationEnabled: false,
+          path: '/',
+          workerName: 'OneSignalSDKWorker.js',
+          registrationScope: '/',
         },
         setupBehavior: {
           allowLocalhostAsSecureOrigin: false,

--- a/__test__/unit/helpers/configHelper.test.ts
+++ b/__test__/unit/helpers/configHelper.test.ts
@@ -209,7 +209,7 @@ describe('ConfigHelper Tests', () => {
       serviceWorkerParam: { scope: '/' + SERVICE_WORKER_PATH },
       serviceWorkerPath: SERVICE_WORKER_PATH + 'OneSignalSDKWorker.js',
       serviceWorkerOverrideForTypical: true,
-    }
+    };
 
     const fakeServerConfig = TestContext.getFakeServerAppConfig(
       ConfigIntegrationKind.TypicalSite,
@@ -221,9 +221,13 @@ describe('ConfigHelper Tests', () => {
       fakeServerConfig,
     );
 
-    expect(finalConfig.serviceWorkerPath).toBe('push/onesignal/OneSignalSDKWorker.js');
-    expect(finalConfig.serviceWorkerParam).toEqual({ scope: '/push/onesignal/' });
-  })
+    expect(finalConfig.serviceWorkerPath).toBe(
+      'push/onesignal/OneSignalSDKWorker.js',
+    );
+    expect(finalConfig.serviceWorkerParam).toEqual({
+      scope: '/push/onesignal/',
+    });
+  });
 
   test('service worker config override (false) for typical site works', () => {
     const fakeUserConfig: AppUserConfig = {
@@ -231,7 +235,7 @@ describe('ConfigHelper Tests', () => {
       serviceWorkerParam: { scope: '/' + SERVICE_WORKER_PATH },
       serviceWorkerPath: SERVICE_WORKER_PATH + 'OneSignalSDKWorker.js',
       serviceWorkerOverrideForTypical: false,
-    }
+    };
 
     const fakeServerConfig = TestContext.getFakeServerAppConfig(
       ConfigIntegrationKind.TypicalSite,
@@ -245,5 +249,5 @@ describe('ConfigHelper Tests', () => {
 
     expect(finalConfig.serviceWorkerPath).toBe('OneSignalSDKWorker.js');
     expect(finalConfig.serviceWorkerParam).toEqual({ scope: '/' });
-  })
+  });
 });

--- a/__test__/unit/helpers/configHelper.test.ts
+++ b/__test__/unit/helpers/configHelper.test.ts
@@ -8,6 +8,8 @@ import { getFinalAppConfig } from '../../support/helpers/configHelper';
 import { ConfigHelper } from '../../../src/shared/helpers/ConfigHelper';
 import TestContext from '../../support/environment/TestContext';
 
+const SERVICE_WORKER_PATH = 'push/onesignal/';
+
 describe('ConfigHelper Tests', () => {
   beforeEach(async () => {
     await TestEnvironment.initialize();
@@ -200,4 +202,48 @@ describe('ConfigHelper Tests', () => {
     );
     expect(finalConfig.autoResubscribe).toBe(true);
   });
+
+  test('service worker config override (true) for typical site works', () => {
+    const fakeUserConfig: AppUserConfig = {
+      appId: getRandomUuid(),
+      serviceWorkerParam: { scope: '/' + SERVICE_WORKER_PATH },
+      serviceWorkerPath: SERVICE_WORKER_PATH + 'OneSignalSDKWorker.js',
+      serviceWorkerOverrideForTypical: true,
+    }
+
+    const fakeServerConfig = TestContext.getFakeServerAppConfig(
+      ConfigIntegrationKind.TypicalSite,
+    );
+
+    const finalConfig = ConfigHelper.getUserConfigForConfigIntegrationKind(
+      ConfigIntegrationKind.TypicalSite,
+      fakeUserConfig,
+      fakeServerConfig,
+    );
+
+    expect(finalConfig.serviceWorkerPath).toBe('push/onesignal/OneSignalSDKWorker.js');
+    expect(finalConfig.serviceWorkerParam).toEqual({ scope: '/push/onesignal/' });
+  })
+
+  test('service worker config override (false) for typical site works', () => {
+    const fakeUserConfig: AppUserConfig = {
+      appId: getRandomUuid(),
+      serviceWorkerParam: { scope: '/' + SERVICE_WORKER_PATH },
+      serviceWorkerPath: SERVICE_WORKER_PATH + 'OneSignalSDKWorker.js',
+      serviceWorkerOverrideForTypical: false,
+    }
+
+    const fakeServerConfig = TestContext.getFakeServerAppConfig(
+      ConfigIntegrationKind.TypicalSite,
+    );
+
+    const finalConfig = ConfigHelper.getUserConfigForConfigIntegrationKind(
+      ConfigIntegrationKind.TypicalSite,
+      fakeUserConfig,
+      fakeServerConfig,
+    );
+
+    expect(finalConfig.serviceWorkerPath).toBe('OneSignalSDKWorker.js');
+    expect(finalConfig.serviceWorkerParam).toEqual({ scope: '/' });
+  })
 });

--- a/build/scripts/publish.sh
+++ b/build/scripts/publish.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
+
 getPrefix() {
   if [ "$ENV" = "production" ]; then
     echo ""
   elif [ "$ENV" = "staging" ]; then
     echo "Staging-"
-  else [ "$ENV" = "development" ]
+  else
     echo "Dev-"
   fi
 }
@@ -14,10 +15,13 @@ set -x
 
 pwd
 
-mkdir build/releases
+rm -rf build/releases
+mkdir -p build/releases
 
+# Copy files with the prefix
 cp build/bundles/OneSignalSDK.page.js build/releases/$PREFIX"OneSignalSDK.page.js"
 cp build/bundles/OneSignalSDK.page.js.map build/releases/$PREFIX"OneSignalSDK.page.js.map"
+
 cp build/bundles/OneSignalSDK.page.es6.js build/releases/$PREFIX"OneSignalSDK.page.es6.js"
 cp build/bundles/OneSignalSDK.page.es6.js.map build/releases/$PREFIX"OneSignalSDK.page.es6.js.map"
 
@@ -27,7 +31,10 @@ cp build/bundles/OneSignalSDK.sw.js.map build/releases/$PREFIX"OneSignalSDK.sw.j
 cp build/bundles/OneSignalSDK.page.styles.css build/releases/$PREFIX"OneSignalSDK.page.styles.css"
 cp build/bundles/OneSignalSDK.page.styles.css.map build/releases/$PREFIX"OneSignalSDK.page.styles.css.map"
 
-if [ "$ENV" = "staging" ]; then
-  sed -i 's/sourceMappingURL=OneSignal/sourceMappingURL=Staging-OneSignal/' build/releases/Staging-*.js
-  sed -i 's/sourceMappingURL=OneSignal/sourceMappingURL=Staging-OneSignal/' build/releases/Staging-*.css
-fi
+# Update sourceMappingURL to include the prefix
+for file in build/releases/$PREFIX*.js build/releases/$PREFIX*.css; do
+  # Ensure we're only updating files with a sourceMappingURL
+  if grep -q "sourceMappingURL=" "$file"; then
+    sed -i "s|sourceMappingURL=OneSignal|sourceMappingURL=${PREFIX}OneSignal|g" "$file"
+  fi
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.4'
 services:
   onesignal-web-sdk-dev:
       image: onesignal/web-sdk-dev
@@ -6,7 +5,7 @@ services:
       build: .
       volumes:
         - .:/sdk:cached
-        - sdk-build:/sdk/build/releases
+        - ./build/releases:/sdk/build/releases
       ports:
           - published: 4001
             target: 4001

--- a/express_webpack/index.html
+++ b/express_webpack/index.html
@@ -41,6 +41,7 @@
           },
           serviceWorkerParam: { scope: '/' + SERVICE_WORKER_PATH },
           serviceWorkerPath: SERVICE_WORKER_PATH + 'OneSignalSDKWorker.js',
+          //serviceWorkerOverrideForTypical: true, // keep as example
           notifyButton: {
               enable: true
           },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "jest": "jest --coverage"
   },
   "config": {
-    "sdkVersion": "160204"
+    "sdkVersion": "160205"
   },
   "repository": {
     "type": "git",

--- a/src/shared/helpers/ConfigHelper.ts
+++ b/src/shared/helpers/ConfigHelper.ts
@@ -18,6 +18,7 @@ import {
   AppConfig,
   ConfigIntegrationKind,
   ServerAppPromptConfig,
+  ServiceWorkerConfigParams,
 } from '../models/AppConfig';
 import {
   AppUserConfigCustomLinkOptions,
@@ -481,6 +482,33 @@ export class ConfigHelper {
     };
   }
 
+  public static getServiceWorkerValues(
+    userConfig: AppUserConfig,
+    serverConfig: ServerAppConfig,
+  ): ServiceWorkerConfigParams {
+    const useUserOverride = userConfig.serviceWorkerOverrideForTypical;
+
+    const path = useUserOverride
+      ? Utils.getValueOrDefault(userConfig.path, serverConfig.config.serviceWorker.path)
+      : serverConfig.config.serviceWorker.path;
+
+    const serviceWorkerParam = useUserOverride
+      ? Utils.getValueOrDefault(userConfig.serviceWorkerParam, {
+          scope: serverConfig.config.serviceWorker.registrationScope,
+        })
+      : { scope: serverConfig.config.serviceWorker.registrationScope };
+
+    const serviceWorkerPath = useUserOverride
+      ? Utils.getValueOrDefault(userConfig.serviceWorkerPath, serverConfig.config.serviceWorker.workerName)
+      : serverConfig.config.serviceWorker.workerName;
+
+    return {
+      path,
+      serviceWorkerParam,
+      serviceWorkerPath,
+    };
+  }
+
   public static getUserConfigForConfigIntegrationKind(
     configIntegrationKind: ConfigIntegrationKind,
     userConfig: AppUserConfig,
@@ -490,19 +518,23 @@ export class ConfigHelper {
       configIntegrationKind,
     );
     switch (integrationCapabilities.configuration) {
-      case IntegrationConfigurationKind.Dashboard:
+      case IntegrationConfigurationKind.Dashboard: {
         /*
          Ignores code-based initialization configuration and uses dashboard configuration only.
         */
+        const {
+          path,
+          serviceWorkerPath,
+          serviceWorkerParam,
+        } = this.getServiceWorkerValues(userConfig, serverConfig);
+
         return {
           appId: serverConfig.app_id,
           autoRegister: false,
           autoResubscribe: serverConfig.config.autoResubscribe,
-          path: serverConfig.config.serviceWorker.path,
-          serviceWorkerPath: serverConfig.config.serviceWorker.workerName,
-          serviceWorkerParam: {
-            scope: serverConfig.config.serviceWorker.registrationScope,
-          },
+          path,
+          serviceWorkerPath,
+          serviceWorkerParam,
           subdomainName: serverConfig.config.siteInfo.proxyOrigin,
           promptOptions:
             this.getPromptOptionsForDashboardConfiguration(serverConfig),
@@ -612,6 +644,7 @@ export class ConfigHelper {
             unattributed: serverConfig.config.outcomes.unattributed,
           },
         };
+      }
       case IntegrationConfigurationKind.JavaScript: {
         /*
           Ignores dashboard configuration and uses code-based configuration only.

--- a/src/shared/helpers/ConfigHelper.ts
+++ b/src/shared/helpers/ConfigHelper.ts
@@ -489,7 +489,10 @@ export class ConfigHelper {
     const useUserOverride = userConfig.serviceWorkerOverrideForTypical;
 
     const path = useUserOverride
-      ? Utils.getValueOrDefault(userConfig.path, serverConfig.config.serviceWorker.path)
+      ? Utils.getValueOrDefault(
+          userConfig.path,
+          serverConfig.config.serviceWorker.path,
+        )
       : serverConfig.config.serviceWorker.path;
 
     const serviceWorkerParam = useUserOverride
@@ -499,7 +502,10 @@ export class ConfigHelper {
       : { scope: serverConfig.config.serviceWorker.registrationScope };
 
     const serviceWorkerPath = useUserOverride
-      ? Utils.getValueOrDefault(userConfig.serviceWorkerPath, serverConfig.config.serviceWorker.workerName)
+      ? Utils.getValueOrDefault(
+          userConfig.serviceWorkerPath,
+          serverConfig.config.serviceWorker.workerName,
+        )
       : serverConfig.config.serviceWorker.workerName;
 
     return {
@@ -522,11 +528,8 @@ export class ConfigHelper {
         /*
          Ignores code-based initialization configuration and uses dashboard configuration only.
         */
-        const {
-          path,
-          serviceWorkerPath,
-          serviceWorkerParam,
-        } = this.getServiceWorkerValues(userConfig, serverConfig);
+        const { path, serviceWorkerPath, serviceWorkerParam } =
+          this.getServiceWorkerValues(userConfig, serverConfig);
 
         return {
           appId: serverConfig.app_id,

--- a/src/shared/models/AppConfig.ts
+++ b/src/shared/models/AppConfig.ts
@@ -277,6 +277,6 @@ export interface ServerAppConfig {
 
 export type ServiceWorkerConfigParams = {
   path?: string;
-  serviceWorkerParam?: { scope: string },
+  serviceWorkerParam?: { scope: string };
   serviceWorkerPath?: string;
 };

--- a/src/shared/models/AppConfig.ts
+++ b/src/shared/models/AppConfig.ts
@@ -94,6 +94,7 @@ export interface AppUserConfig {
   allowLocalhostAsSecureOrigin?: boolean;
   pageUrl?: string;
   outcomes?: OutcomesConfig;
+  serviceWorkerOverrideForTypical?: boolean;
 }
 
 export interface AppUserConfigWelcomeNotification {
@@ -274,3 +275,9 @@ export interface ServerAppConfig {
 
   generated_at: number;
 }
+
+export type ServiceWorkerConfigParams = {
+  path?: string;
+  serviceWorkerParam?: { scope: string },
+  serviceWorkerPath?: string;
+};

--- a/src/shared/models/AppConfig.ts
+++ b/src/shared/models/AppConfig.ts
@@ -244,7 +244,6 @@ export interface ServerAppConfig {
       path?: string;
       workerName?: string;
       registrationScope?: string;
-      customizationEnabled: boolean;
     };
     setupBehavior?: {
       allowLocalhostAsSecureOrigin: false;


### PR DESCRIPTION
# Description
## 1 Line Summary
Add ability to override remote service worker config via new override param `serviceWorkerOverrideForTypical`.

## Details
### Service Worker Configuration
- Introduced a new parameter, **serviceWorkerOverrideForTypical**, to allow users to override server settings for typical sites.

### Build & Environment Improvements
#### `docker-compose.yml`
- Fixed **volume mounting** issues to ensure the `releases` directory on the host accurately reflects the container contents.
- Updated the **version property**, as the previous one was deprecated.

#### `publish.sh`
- Modified the script to ensure **sourceMappingUrl** comments are correctly applied in output files, improving compatibility across environments.

### Release Version
- Updated the version to `160205` as part of the release process.

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
Added test coverage. Tested locally.

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1213)
<!-- Reviewable:end -->
