### PR TITLE
CI fix: don't delete releases directory

### DIFF
--- a/build/scripts/publish.sh
+++ b/build/scripts/publish.sh
@@ -15,7 +15,6 @@ set -x
 
 pwd
 
-rm -rf build/releases
 mkdir -p build/releases
 
 # Copy files with the prefix


### PR DESCRIPTION
## 1 Line Summary
CI fix: don't delete `releases` directory so that we have both the staging & production builds in the final releases directory

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1214)
<!-- Reviewable:end -->
