### PR TITLE
Fix Sync Call

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,10 @@ module.exports = async () => {
     forceExit: true,
     bail: true,
     testEnvironment: 'jsdom',
+    moduleNameMapper: {
+      '^src/(.*)$': '<rootDir>/src/$1',
+      '^__test__/(.*)$': '<rootDir>/__test__/$1',
+    },
     // Run these files after jest has been
     // installed in the environment
     setupFilesAfterEnv: ['<rootDir>/__test__/jest/jest.setup.ts'], // use .js if you prefer JavaScript,

--- a/src/shared/api/OneSignalApiBase.ts
+++ b/src/shared/api/OneSignalApiBase.ts
@@ -136,6 +136,12 @@ export class OneSignalApiBase {
       return isValidUuid(parts[1]);
     }
 
+    // special case for sync
+    if (url.startsWith('sync/')) {
+      const parts = url.split('/');
+      return isValidUuid(parts[1]);
+    }
+
     if (body && typeof body['app_id'] === 'string') {
       return isValidUuid(body['app_id']);
     }

--- a/src/shared/api/OneSignalApiSW.test.ts
+++ b/src/shared/api/OneSignalApiSW.test.ts
@@ -1,0 +1,11 @@
+import { APP_ID } from '__test__/support/constants';
+import { OneSignalApiSW } from './OneSignalApiSW';
+
+// Temporary, can remove when adding new tests to ServiceWorker.test.ts
+describe('OneSignalApiSW', () => {
+  test('downloadServerAppConfig', async () => {
+    test.nock({});
+    const appConfig = await OneSignalApiSW.downloadServerAppConfig(APP_ID);
+    expect(appConfig).toBeDefined();
+  });
+});


### PR DESCRIPTION
# Description
## 1 Line Summary
Updates the one signal api base requestHasAppId method to have a special condition for the sync/ call since it does not start `/apps` or have `app_id` in the body which leads to an error when calling `downloadServerAppConfig.`

Ticket: https://app.asana.com/0/1208777190614537/1209414057669993
Related issue: https://github.com/OneSignal/OneSignal-WordPress-Plugin/issues/351

## Details
- updates `requestHasAppId` as described above

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1223)
<!-- Reviewable:end -->
