### PR TITLE
Prevent race with switching users & handleOnFocus

### DIFF
--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -17,19 +17,17 @@ import LocalStorage from '../../shared/utils/LocalStorage';
 import { logMethodCall } from '../../shared/utils/utils';
 
 export default class LoginManager {
+  // Other internal classes should await on this if they access users
   static switchingUsersPromise: Promise<void> = Promise.resolve();
 
   static async login(externalId: string, token?: string): Promise<void> {
-    try {
-      // Prevents overlapting login/logout calls
-      await this.switchingUsersPromise;
-      this.switchingUsersPromise = this._login(externalId, token);
-    } catch (e) {
-      this.switchingUsersPromise = Promise.reject(e);
-    }
+    await (this.switchingUsersPromise = LoginManager._login(externalId, token));
   }
 
-  static async _login(externalId: string, token?: string): Promise<void> {
+  private static async _login(
+    externalId: string,
+    token?: string,
+  ): Promise<void> {
     const consentRequired = LocalStorage.getConsentRequired();
     const consentGiven = await Database.getConsentGiven();
 
@@ -142,16 +140,10 @@ export default class LoginManager {
   }
 
   static async logout(): Promise<void> {
-    try {
-      // Prevents overlapting login/logout calls
-      await this.switchingUsersPromise;
-      this.switchingUsersPromise = this._logout();
-    } catch (e) {
-      this.switchingUsersPromise = Promise.reject(e);
-    }
+    await (this.switchingUsersPromise = LoginManager._logout());
   }
 
-  static async _logout(): Promise<void> {
+  private static async _logout(): Promise<void> {
     // check if user is already logged out
     const identityModel = OneSignal.coreDirector?.getIdentityModel();
     if (

--- a/src/shared/managers/sessionManager/SessionManager.test.ts
+++ b/src/shared/managers/sessionManager/SessionManager.test.ts
@@ -1,45 +1,27 @@
-import { SessionManager } from './SessionManager';
 import { TestEnvironment } from '__test__/support/environment/TestEnvironment';
+import { SessionManager } from './SessionManager';
 
-import { stub } from '__test__/support/helpers/general';
-import { PropertiesExecutor } from 'src/core/executors/PropertiesExecutor';
-import { IdentityExecutor } from 'src/core/executors/IdentityExecutor';
-import { SubscriptionExecutor } from 'src/core/executors/SubscriptionExecutor';
-
-import { setupLoginStubs } from '__test__/support/helpers/login';
-import LoginManager from 'src/page/managers/LoginManager';
 import {
   DUMMY_EXTERNAL_ID,
   DUMMY_ONESIGNAL_ID,
 } from '__test__/support/constants';
-
-vi.mock('../../../src/shared/libraries/Log');
-stub(PropertiesExecutor.prototype, 'getOperationsFromCache', []);
-stub(IdentityExecutor.prototype, 'getOperationsFromCache', []);
-stub(SubscriptionExecutor.prototype, 'getOperationsFromCache', []);
+import { setupLoginStubs } from '__test__/support/helpers/login';
+import LoginManager from 'src/page/managers/LoginManager';
 
 describe('SessionManager', () => {
-  afterEach(() => {
-    vi.resetAllMocks();
-  });
-
   describe('Switching Users', () => {
     beforeEach(async () => {
       await TestEnvironment.initialize({
         useMockIdentityModel: true,
-        useMockPushSubscriptionModel: true,
       });
+
       setupLoginStubs();
-      stub(
-        LoginManager,
-        'identifyOrUpsertUser',
-        Promise.resolve({
-          identity: {
-            external_id: DUMMY_EXTERNAL_ID,
-            onesignal_id: DUMMY_ONESIGNAL_ID,
-          },
-        }),
-      );
+      vi.spyOn(LoginManager, 'identifyOrUpsertUser').mockResolvedValue({
+        identity: {
+          external_id: DUMMY_EXTERNAL_ID,
+          onesignal_id: DUMMY_ONESIGNAL_ID,
+        },
+      });
     });
 
     test('handleOnFocus should wait for login promise', async () => {

--- a/src/shared/managers/sessionManager/SessionManager.test.ts
+++ b/src/shared/managers/sessionManager/SessionManager.test.ts
@@ -1,0 +1,77 @@
+import { SessionManager } from './SessionManager';
+import { TestEnvironment } from '__test__/support/environment/TestEnvironment';
+
+import { stub } from '__test__/support/helpers/general';
+import { PropertiesExecutor } from 'src/core/executors/PropertiesExecutor';
+import { IdentityExecutor } from 'src/core/executors/IdentityExecutor';
+import { SubscriptionExecutor } from 'src/core/executors/SubscriptionExecutor';
+
+import { setupLoginStubs } from '__test__/support/helpers/login';
+import LoginManager from 'src/page/managers/LoginManager';
+import {
+  DUMMY_EXTERNAL_ID,
+  DUMMY_ONESIGNAL_ID,
+} from '__test__/support/constants';
+
+vi.mock('../../../src/shared/libraries/Log');
+stub(PropertiesExecutor.prototype, 'getOperationsFromCache', []);
+stub(IdentityExecutor.prototype, 'getOperationsFromCache', []);
+stub(SubscriptionExecutor.prototype, 'getOperationsFromCache', []);
+
+describe('SessionManager', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('Switching Users', () => {
+    beforeEach(async () => {
+      await TestEnvironment.initialize({
+        useMockIdentityModel: true,
+        useMockPushSubscriptionModel: true,
+      });
+      setupLoginStubs();
+      stub(
+        LoginManager,
+        'identifyOrUpsertUser',
+        Promise.resolve({
+          identity: {
+            external_id: DUMMY_EXTERNAL_ID,
+            onesignal_id: DUMMY_ONESIGNAL_ID,
+          },
+        }),
+      );
+    });
+
+    test('handleOnFocus should wait for login promise', async () => {
+      const loginPromise = (async function () {
+        await LoginManager.login(DUMMY_EXTERNAL_ID);
+        return 'login';
+      })();
+
+      const sessionManager = new SessionManager(OneSignal.context);
+      const sessionPromise = (async function () {
+        await sessionManager.handleOnFocus(new Event('{}'));
+        return 'session';
+      })();
+
+      const winner = await Promise.race([loginPromise, sessionPromise]);
+      expect(winner).toBe('login');
+    });
+
+    test('handleOnFocus should wait for logout promise', async () => {
+      const loginPromise = (async function () {
+        await LoginManager.logout();
+        return 'logout';
+      })();
+
+      const sessionManager = new SessionManager(OneSignal.context);
+      const sessionPromise = (async function () {
+        await sessionManager.handleOnFocus(new Event('{}'));
+        return 'session';
+      })();
+
+      const winner = await Promise.race([loginPromise, sessionPromise]);
+      expect(winner).toBe('logout');
+    });
+  });
+});

--- a/src/shared/managers/sessionManager/SessionManager.ts
+++ b/src/shared/managers/sessionManager/SessionManager.ts
@@ -1,22 +1,22 @@
+import AliasPair from '../../../core/requestService/AliasPair';
+import { RequestService } from '../../../core/requestService/RequestService';
+import { UpdateUserPayload } from '../../../core/requestService/UpdateUserPayload';
+import { isCompleteSubscriptionObject } from '../../../core/utils/typePredicates';
+import User from '../../../onesignal/User';
+import LoginManager from '../../../page/managers/LoginManager';
 import { ContextInterface } from '../../../page/models/Context';
+import Utils from '../../../shared/context/Utils';
+import OneSignalError from '../../../shared/errors/OneSignalError';
+import MainHelper from '../../helpers/MainHelper';
+import Log from '../../libraries/Log';
 import { WorkerMessengerCommand } from '../../libraries/WorkerMessenger';
-import { OneSignalUtils } from '../../utils/OneSignalUtils';
-import { SubscriptionStateKind } from '../../models/SubscriptionStateKind';
-import { ISessionManager } from './types';
 import {
   SessionOrigin,
   UpsertOrDeactivateSessionPayload,
 } from '../../models/Session';
-import MainHelper from '../../helpers/MainHelper';
-import Log from '../../libraries/Log';
-import { isCompleteSubscriptionObject } from '../../../core/utils/typePredicates';
-import OneSignalError from '../../../shared/errors/OneSignalError';
-import User from '../../../onesignal/User';
-import { RequestService } from '../../../core/requestService/RequestService';
-import AliasPair from '../../../core/requestService/AliasPair';
-import { UpdateUserPayload } from '../../../core/requestService/UpdateUserPayload';
-import Utils from '../../../shared/context/Utils';
-import LoginManager from '../../../page/managers/LoginManager';
+import { SubscriptionStateKind } from '../../models/SubscriptionStateKind';
+import { OneSignalUtils } from '../../utils/OneSignalUtils';
+import { ISessionManager } from './types';
 
 export class SessionManager implements ISessionManager {
   private context: ContextInterface;

--- a/src/shared/managers/sessionManager/SessionManager.ts
+++ b/src/shared/managers/sessionManager/SessionManager.ts
@@ -16,6 +16,7 @@ import { RequestService } from '../../../core/requestService/RequestService';
 import AliasPair from '../../../core/requestService/AliasPair';
 import { UpdateUserPayload } from '../../../core/requestService/UpdateUserPayload';
 import Utils from '../../../shared/context/Utils';
+import LoginManager from '../../../page/managers/LoginManager';
 
 export class SessionManager implements ISessionManager {
   private context: ContextInterface;
@@ -201,6 +202,8 @@ export class SessionManager implements ISessionManager {
   }
 
   async handleOnFocus(e: Event): Promise<void> {
+    await LoginManager.switchingUsersPromise;
+
     Log.debug('handleOnFocus', e);
     if (!User.singletonInstance?.hasOneSignalId) {
       return;


### PR DESCRIPTION
# Description
## 1 Line Summary
Prevent bad states & errors with SessionManager.handleOnFocus if the site's focus changes while a login or logout is being processed.

## Details
If the site focus changes when the login or logout fn is still running we can get errors with missing ids. To prevent this always await to ensure they are completed.

The most common way this can happen is if you call window.prompt() or window.alert() with 100ms before or after calling OneSignal.login()

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [X] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1233)
<!-- Reviewable:end -->
