### PR TITLE
Fix issue with logout called after init

### DIFF
--- a/__test__/setupTests.ts
+++ b/__test__/setupTests.ts
@@ -4,3 +4,8 @@ afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 global.isSecureContext = true;
+
+Object.defineProperty(global, 'location', {
+  value: new URL('https://localhost:3000'),
+  writable: true,
+});

--- a/__test__/support/environment/TestContext.ts
+++ b/__test__/support/environment/TestContext.ts
@@ -1,16 +1,16 @@
+import deepmerge from 'deepmerge';
+import ConfigManager from '../../../src/page/managers/ConfigManager';
 import { RecursivePartial } from '../../../src/shared/context/Utils';
 import {
-  ConfigIntegrationKind,
-  ServerAppConfig,
-  NotificationClickMatchBehavior,
-  NotificationClickActionBehavior,
-  AppUserConfig,
   AppConfig,
+  AppUserConfig,
+  ConfigIntegrationKind,
+  NotificationClickActionBehavior,
+  NotificationClickMatchBehavior,
+  ServerAppConfig,
 } from '../../../src/shared/models/AppConfig';
 import { DelayedPromptType } from '../../../src/shared/models/Prompts';
 import { APP_ID } from '../constants';
-import deepmerge from 'deepmerge';
-import ConfigManager from '../../../src/page/managers/ConfigManager';
 import { TestEnvironmentConfig } from './TestEnvironment';
 
 export default class TestContext {
@@ -40,7 +40,7 @@ export default class TestContext {
           autoResubscribe: true,
           siteInfo: {
             name: 'localhost https',
-            origin: 'https://localhost:3001',
+            origin: 'https://localhost:3000',
             proxyOrigin: undefined,
             defaultIconUrl: null,
             proxyOriginEnabled: true,
@@ -141,7 +141,7 @@ export default class TestContext {
           },
           welcomeNotification: {
             enable: true,
-            url: 'https://localhost:3001/?_osp=do_not_open',
+            url: 'https://localhost:3000/?_osp=do_not_open',
             title: 'localhost https',
             message: 'Thanks for subscribing!',
             urlEnabled: false,
@@ -150,7 +150,7 @@ export default class TestContext {
             'BDPplk0FjgsEPIG7Gi2-zbjpBGgM_RJ4c99tWbNvxv7VSKIUV1KA7UUaRsTuBpcTEuaPMjvz_kd8rZuQcgMepng',
           onesignal_vapid_public_key:
             'BMzCIzYqtgz2Bx7S6aPVK6lDWets7kGm-pgo2H4RixFikUaNIoPqjPBBOEWMAfeFjuT9mAvbe-lckGi6vvNEiW0',
-          origin: 'https://localhost:3001',
+          origin: 'https://localhost:3000',
           subdomain: undefined,
           outcomes: {
             direct: {

--- a/__test__/support/environment/TestEnvironment.ts
+++ b/__test__/support/environment/TestEnvironment.ts
@@ -1,26 +1,26 @@
+import { NotificationPermission } from 'src/shared/models/NotificationPermission';
+import OperationCache from '../../../src/core/caching/OperationCache';
+import { ModelName } from '../../../src/core/models/SupportedModels';
+import { RecursivePartial } from '../../../src/shared/context/Utils';
+import MainHelper from '../../../src/shared/helpers/MainHelper';
 import {
   AppUserConfig,
   ConfigIntegrationKind,
   ServerAppConfig,
 } from '../../../src/shared/models/AppConfig';
-import BrowserUserAgent from '../models/BrowserUserAgent';
-import {
-  resetDatabase,
-  initOSGlobals,
-  stubDomEnvironment,
-  stubNotification,
-  mockUserAgent,
-} from './TestEnvironmentHelpers';
-import OperationCache from '../../../src/core/caching/OperationCache';
-import { RecursivePartial } from '../../../src/shared/context/Utils';
-import { ModelName } from '../../../src/core/models/SupportedModels';
+import { DUMMY_ONESIGNAL_ID, DUMMY_PUSH_TOKEN } from '../constants';
 import {
   getDummyIdentityOSModel,
   getDummyPushSubscriptionOSModel,
 } from '../helpers/core';
-import MainHelper from '../../../src/shared/helpers/MainHelper';
-import { DUMMY_ONESIGNAL_ID, DUMMY_PUSH_TOKEN } from '../constants';
-import { NotificationPermission } from 'src/shared/models/NotificationPermission';
+import BrowserUserAgent from '../models/BrowserUserAgent';
+import {
+  initOSGlobals,
+  mockUserAgent,
+  resetDatabase,
+  stubDomEnvironment,
+  stubNotification,
+} from './TestEnvironmentHelpers';
 
 export interface TestEnvironmentConfig {
   userConfig?: AppUserConfig;

--- a/__test__/support/environment/TestEnvironmentHelpers.ts
+++ b/__test__/support/environment/TestEnvironmentHelpers.ts
@@ -20,9 +20,6 @@ import { TestEnvironmentConfig } from './TestEnvironment';
 
 declare const global: any;
 
-vi.mock('../../../src/shared/utils/bowserCastle', () => ({
-  bowserCastle: vi.fn(),
-}));
 const bowserCastleSpy = vi.spyOn(bowerCastleHelpers, 'bowserCastle');
 
 export function resetDatabase() {

--- a/index.html
+++ b/index.html
@@ -28,5 +28,11 @@
       This html file is for local development with hot-reloading. To preview the
       bundle, it will use a separate html file in the preview folder.
     </p>
+    <script>
+      // To check against race conditions
+      // OneSignalDeferred.push(async function (OneSignal) {
+      //   await OneSignal.logout();
+      // });
+    </script>
   </body>
 </html>

--- a/src/entries/pageSdkInit.test.ts
+++ b/src/entries/pageSdkInit.test.ts
@@ -55,8 +55,3 @@ describe('pageSdkInit', () => {
     expect(OneSignal.coreDirector).toBeDefined();
   });
 });
-
-Object.defineProperty(window, 'location', {
-  value: new URL('https://localhost:3000'),
-  writable: true,
-});

--- a/src/entries/pageSdkInit.test.ts
+++ b/src/entries/pageSdkInit.test.ts
@@ -1,0 +1,62 @@
+import { APP_ID } from '__test__/support/constants';
+import TestContext from '__test__/support/environment/TestContext';
+import { TestEnvironment } from '__test__/support/environment/TestEnvironment';
+import { server } from '__test__/support/mocks/server';
+import { http, HttpResponse } from 'msw';
+import { OneSignalDeferredLoadedCallback } from 'src/page/models/OneSignalDeferredLoadedCallback';
+import { ConfigIntegrationKind } from 'src/shared/models/AppConfig';
+
+vi.useFakeTimers();
+
+declare global {
+  interface Window {
+    OneSignalDeferred: OneSignalDeferredLoadedCallback[];
+  }
+}
+
+const serverConfig = TestContext.getFakeServerAppConfig(
+  ConfigIntegrationKind.Custom,
+);
+
+describe('pageSdkInit', () => {
+  beforeEach(async () => {
+    window.OneSignalDeferred = [];
+
+    server.use(
+      http.get('**/sync/*/web', ({ request }) => {
+        const url = new URL(request.url);
+        const callbackParam = url.searchParams.get('callback');
+        return new HttpResponse(
+          `${callbackParam}(${JSON.stringify(serverConfig)})`,
+          {
+            headers: {
+              'Content-Type': 'application/javascript',
+            },
+          },
+        );
+      }),
+    );
+    await TestEnvironment.initialize();
+  });
+
+  test('can handle init followed by logout', async () => {
+    window.OneSignalDeferred = [];
+    window.OneSignalDeferred.push(async function (OneSignal) {
+      await OneSignal.init({
+        appId: APP_ID,
+      });
+    });
+    window.OneSignalDeferred.push(async function (OneSignal) {
+      await OneSignal.logout();
+    });
+
+    await import('./pageSdkInit');
+    await vi.runOnlyPendingTimersAsync();
+    expect(OneSignal.coreDirector).toBeDefined();
+  });
+});
+
+Object.defineProperty(window, 'location', {
+  value: new URL('https://localhost:3000'),
+  writable: true,
+});

--- a/src/entries/pageSdkInit.ts
+++ b/src/entries/pageSdkInit.ts
@@ -43,4 +43,5 @@ function onesignalSdkInit() {
     existingOneSignalDeferred,
   );
 }
+
 onesignalSdkInit();

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -1,9 +1,17 @@
+import CoreModule from '../core/CoreModule';
+import { CoreModuleDirector } from '../core/CoreModuleDirector';
 import { EnvironmentInfoHelper } from '../page/helpers/EnvironmentInfoHelper';
 import ConfigManager from '../page/managers/ConfigManager';
+import LoginManager from '../page/managers/LoginManager';
 import Context from '../page/models/Context';
 import { EnvironmentInfo } from '../page/models/EnvironmentInfo';
+import { OneSignalDeferredLoadedCallback } from '../page/models/OneSignalDeferredLoadedCallback';
 import TimedLocalStorage from '../page/modules/TimedLocalStorage';
 import { ProcessOneSignalPushCalls } from '../page/utils/ProcessOneSignalPushCalls';
+import {
+  InvalidArgumentError,
+  InvalidArgumentReason,
+} from '../shared/errors/InvalidArgumentError';
 import { SdkInitError, SdkInitErrorKind } from '../shared/errors/SdkInitError';
 import Environment from '../shared/helpers/Environment';
 import EventHelper from '../shared/helpers/EventHelper';
@@ -12,27 +20,19 @@ import MainHelper from '../shared/helpers/MainHelper';
 import Emitter from '../shared/libraries/Emitter';
 import Log from '../shared/libraries/Log';
 import SdkEnvironment from '../shared/managers/SdkEnvironment';
-import { AppUserConfig, AppConfig } from '../shared/models/AppConfig';
+import { AppConfig, AppUserConfig } from '../shared/models/AppConfig';
 import { AppUserConfigNotifyButton } from '../shared/models/Prompts';
 import Database from '../shared/services/Database';
-import { logMethodCall } from '../shared/utils/utils';
 import OneSignalEvent from '../shared/services/OneSignalEvent';
-import NotificationsNamespace from './NotificationsNamespace';
-import CoreModule from '../core/CoreModule';
-import { CoreModuleDirector } from '../core/CoreModuleDirector';
-import UserNamespace from './UserNamespace';
-import SlidedownNamespace from './SlidedownNamespace';
-import LocalStorage from '../shared/utils/LocalStorage';
-import LoginManager from '../page/managers/LoginManager';
-import { SessionNamespace } from './SessionNamespace';
-import { OneSignalDeferredLoadedCallback } from '../page/models/OneSignalDeferredLoadedCallback';
-import DebugNamespace from './DebugNamesapce';
-import {
-  InvalidArgumentError,
-  InvalidArgumentReason,
-} from '../shared/errors/InvalidArgumentError';
-import { ONESIGNAL_EVENTS } from './OneSignalEvents';
 import { bowserCastle } from '../shared/utils/bowserCastle';
+import LocalStorage from '../shared/utils/LocalStorage';
+import { logMethodCall } from '../shared/utils/utils';
+import DebugNamespace from './DebugNamesapce';
+import NotificationsNamespace from './NotificationsNamespace';
+import { ONESIGNAL_EVENTS } from './OneSignalEvents';
+import { SessionNamespace } from './SessionNamespace';
+import SlidedownNamespace from './SlidedownNamespace';
+import UserNamespace from './UserNamespace';
 
 export default class OneSignal {
   static EVENTS = ONESIGNAL_EVENTS;
@@ -128,7 +128,6 @@ export default class OneSignal {
 
     InitHelper.errorIfInitAlreadyCalled();
     await OneSignal._initializeConfig(options);
-
     if (!OneSignal.config) {
       throw new Error('OneSignal config not initialized!');
     }
@@ -263,8 +262,8 @@ export default class OneSignal {
    * @Example
    *  OneSignalDeferred.push(function(onesignal) { onesignal.functionName(param1, param2); });
    */
-  static push(item: OneSignalDeferredLoadedCallback) {
-    ProcessOneSignalPushCalls.processItem(OneSignal, item);
+  static async push(item: OneSignalDeferredLoadedCallback) {
+    return ProcessOneSignalPushCalls.processItem(OneSignal, item);
   }
 
   static __doNotShowWelcomeNotification: boolean;

--- a/src/onesignal/OneSignalDeferred.ts
+++ b/src/onesignal/OneSignalDeferred.ts
@@ -5,7 +5,7 @@ import OneSignal from './OneSignal';
 // This way the site developer can use OneSignalDeferred.push without have to check
 //   if the SDK is loaded or not.
 export default class OneSignalDeferred {
-  static push(item: OneSignalDeferredLoadedCallback) {
-    OneSignal.push(item);
+  static async push(item: OneSignalDeferredLoadedCallback) {
+    return OneSignal.push(item);
   }
 }

--- a/src/page/helpers/EnvironmentInfoHelper.ts
+++ b/src/page/helpers/EnvironmentInfoHelper.ts
@@ -1,8 +1,8 @@
 import bowser from 'bowser';
-import { EnvironmentInfo } from '../models/EnvironmentInfo';
-import { Browser } from '../../shared/models/Browser';
 import Utils from '../../shared/context/Utils';
+import { Browser } from '../../shared/models/Browser';
 import { bowserCastle } from '../../shared/utils/bowserCastle';
+import { EnvironmentInfo } from '../models/EnvironmentInfo';
 
 /**
  * EnvironmentInfoHelper is used to save page ("browser") context environment information to

--- a/src/page/managers/ConfigManager.test.ts
+++ b/src/page/managers/ConfigManager.test.ts
@@ -19,12 +19,6 @@ vi.spyOn(OneSignalApi, 'jsonpLib').mockImplementation((url, fn) => {
   });
 });
 
-delete (window as any).location;
-(window as any).location = {
-  ...window.location,
-  origin: 'https://localhost:3000',
-};
-
 describe('ConfigManager', () => {
   beforeEach(async () => {
     await TestEnvironment.initialize();

--- a/src/page/managers/ConfigManager.test.ts
+++ b/src/page/managers/ConfigManager.test.ts
@@ -22,7 +22,7 @@ vi.spyOn(OneSignalApi, 'jsonpLib').mockImplementation((url, fn) => {
 delete (window as any).location;
 (window as any).location = {
   ...window.location,
-  origin: 'https://localhost:3001',
+  origin: 'https://localhost:3000',
 };
 
 describe('ConfigManager', () => {

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -1,20 +1,20 @@
-import OneSignalError from '../../shared/errors/OneSignalError';
-import { logMethodCall } from '../../shared/utils/utils';
-import OneSignal from '../../onesignal/OneSignal';
-import UserData from '../../core/models/UserData';
-import { RequestService } from '../../core/requestService/RequestService';
-import AliasPair from '../../core/requestService/AliasPair';
-import Log from '../../shared/libraries/Log';
 import { OSModel } from '../../core/modelRepo/OSModel';
 import { SupportedIdentity } from '../../core/models/IdentityModel';
-import MainHelper from '../../shared/helpers/MainHelper';
-import { awaitableTimeout } from '../../shared/utils/AwaitableTimeout';
-import { RETRY_BACKOFF } from '../../shared/api/RetryBackoff';
-import { isCompleteSubscriptionObject } from '../../core/utils/typePredicates';
-import UserDirector from '../../onesignal/UserDirector';
-import Database from '../../shared/services/Database';
-import LocalStorage from '../../shared/utils/LocalStorage';
 import { ModelName, SupportedModel } from '../../core/models/SupportedModels';
+import UserData from '../../core/models/UserData';
+import AliasPair from '../../core/requestService/AliasPair';
+import { RequestService } from '../../core/requestService/RequestService';
+import { isCompleteSubscriptionObject } from '../../core/utils/typePredicates';
+import OneSignal from '../../onesignal/OneSignal';
+import UserDirector from '../../onesignal/UserDirector';
+import { RETRY_BACKOFF } from '../../shared/api/RetryBackoff';
+import OneSignalError from '../../shared/errors/OneSignalError';
+import MainHelper from '../../shared/helpers/MainHelper';
+import Log from '../../shared/libraries/Log';
+import Database from '../../shared/services/Database';
+import { awaitableTimeout } from '../../shared/utils/AwaitableTimeout';
+import LocalStorage from '../../shared/utils/LocalStorage';
+import { logMethodCall } from '../../shared/utils/utils';
 
 export default class LoginManager {
   static async login(externalId: string, token?: string): Promise<void> {
@@ -131,7 +131,7 @@ export default class LoginManager {
 
   static async logout(): Promise<void> {
     // check if user is already logged out
-    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    const identityModel = OneSignal.coreDirector?.getIdentityModel();
     if (
       !identityModel ||
       !identityModel.data ||

--- a/src/page/models/OneSignalDeferredLoadedCallback.ts
+++ b/src/page/models/OneSignalDeferredLoadedCallback.ts
@@ -1,3 +1,5 @@
 import OneSignal from '../../onesignal/OneSignal';
 
-export type OneSignalDeferredLoadedCallback = (onesignal: OneSignal) => void;
+export type OneSignalDeferredLoadedCallback = (
+  onesignal: typeof OneSignal,
+) => void;

--- a/src/page/utils/ProcessOneSignalPushCalls.ts
+++ b/src/page/utils/ProcessOneSignalPushCalls.ts
@@ -6,7 +6,7 @@ export class ProcessOneSignalPushCalls {
     oneSignalInstance: IOneSignal,
     item: OneSignalDeferredLoadedCallback,
   ) {
-    if (typeof item === 'function') item(oneSignalInstance);
+    if (typeof item === 'function') return item(oneSignalInstance);
     else {
       throw new OneSignalError('Only accepts function type!');
     }

--- a/src/page/utils/ReplayCallsOnOneSignal.ts
+++ b/src/page/utils/ReplayCallsOnOneSignal.ts
@@ -6,7 +6,7 @@ import { OneSignalDeferredLoadedCallback } from '../models/OneSignalDeferredLoad
 export class ReplayCallsOnOneSignal {
   static async processOneSignalDeferredArray(
     onesignalDeferred: OneSignalDeferredLoadedCallback[],
-  ) {
+  ): Promise<void> {
     for (const item of onesignalDeferred) {
       try {
         await OneSignal.push(item);

--- a/src/page/utils/ReplayCallsOnOneSignal.ts
+++ b/src/page/utils/ReplayCallsOnOneSignal.ts
@@ -1,15 +1,15 @@
-import Log from '../../shared/libraries/Log';
 import OneSignal from '../../onesignal/OneSignal';
+import Log from '../../shared/libraries/Log';
 import { OneSignalDeferredLoadedCallback } from '../models/OneSignalDeferredLoadedCallback';
 
 // TODO: Renaming ReplayCallsOnOneSignal in a future commit
 export class ReplayCallsOnOneSignal {
-  static processOneSignalDeferredArray(
+  static async processOneSignalDeferredArray(
     onesignalDeferred: OneSignalDeferredLoadedCallback[],
-  ): void {
+  ) {
     for (const item of onesignalDeferred) {
       try {
-        OneSignal.push(item);
+        await OneSignal.push(item);
       } catch (e) {
         // Catch and log error here so other elements still run
         Log.error(e);

--- a/src/shared/api/OneSignalApi.ts
+++ b/src/shared/api/OneSignalApi.ts
@@ -1,8 +1,8 @@
 import JSONP from 'jsonp';
 import SdkEnvironment from '../managers/SdkEnvironment';
+import { ServerAppConfig } from '../models/AppConfig';
 import { WindowEnvironmentKind } from '../models/WindowEnvironmentKind';
 import OneSignalApiSW from './OneSignalApiSW';
-import { ServerAppConfig } from '../models/AppConfig';
 
 export default class OneSignalApi {
   static jsonpLib(


### PR DESCRIPTION
# Description
## 1 Line Summary
- Addresses #1202 where the Logout throws an error if called soon after init

## Details
- updated processOneSignalDeferredArray to await OneSignal.push so items are processed in order
- added tests for pageSDKInit for this use-case
- update logout to use optional chaining `OneSignal.coreDirector?.getIdentityModel` in case theres an unhandled async operation in init

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1235)
<!-- Reviewable:end -->
