### PR TITLE
chore: replace references to `express_webpack` with `preview`

### DIFF
--- a/docker/docker-entry-point.sh
+++ b/docker/docker-entry-point.sh
@@ -3,7 +3,7 @@
 # Installs dependencies to build SDK
 npm ci
 
-cd express_webpack
+cd preview
 
 # Installs dependencies to run Sandbox for dev env
 npm ci
@@ -11,7 +11,7 @@ npm ci
 # Sandbox cert generation
 npm run certs
 
-# Starts express_webpack node server
+# Starts preview node server
 npm start
 
 # Run the below 2 commands to rebuild the sdk

--- a/preview/README.md
+++ b/preview/README.md
@@ -15,7 +15,7 @@
 2. Follow the following instructions (also logged in console)
    - copy `dev-ssl.crt` from container to host with:
      ```
-     docker cp "$(docker-compose ps -q onesignal-web-sdk-dev)":sdk/express_webpack/certs/dev-ssl.crt .
+     docker cp "$(docker-compose ps -q onesignal-web-sdk-dev)":sdk/preview/certs/dev-ssl.crt .
      ```
      - If you're running the container in a VM, get the cert file onto the VM's host (e.g: use `scp`)
    - Add cert to system's trusted store

--- a/preview/certs/gen-cert.sh
+++ b/preview/certs/gen-cert.sh
@@ -1,10 +1,10 @@
 FILE=./certs/dev-ssl.crt
 if test -f "$FILE"; then
-  echo "express_webpack: dev-ssl.crt already exists."
-  echo "express_webpack: skipping SSL cert generation."
+  echo "preview: dev-ssl.crt already exists."
+  echo "preview: skipping SSL cert generation."
 else
-  echo "express_webpack:\n------ generating new SSL certs ------"
-  echo "copy dev-ssl.crt from container to host with:\n>   docker cp <containerId>:sdk/express_webpack/certs/dev-ssl.crt ."
+  echo "preview:\n------ generating new SSL certs ------"
+  echo "copy dev-ssl.crt from container to host with:\n>   docker cp <containerId>:sdk/preview/certs/dev-ssl.crt ."
   echo "macOS - add cert to keychain:\n>   sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/dev-ssl.crt\n"
   echo "Windows - add cert to cert store:\n> Import-Certificate -FilePath dev-ssl.crt -CertStoreLocation cert:\CurrentUser\Root"
   echo "restart browser\n--------------------------------------"

--- a/preview/package-lock.json
+++ b/preview/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "express_webpack",
+  "name": "preview",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "express_webpack",
+      "name": "preview",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/preview/package.json
+++ b/preview/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "express_webpack",
+  "name": "preview",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/preview/server.js
+++ b/preview/server.js
@@ -43,10 +43,10 @@ app.get('/push/onesignal/:file', (req, res) => {
 https
   .createServer(options, app)
   .listen(4001, () =>
-    console.info('express_webpack: listening on port 4001 (https)'),
+    console.info('preview: listening on port 4001 (https)'),
   );
 
 // http
 app.listen(4000, () =>
-  console.info('express_webpack: listening on port 4000 (http)'),
+  console.info('preview: listening on port 4000 (http)'),
 );


### PR DESCRIPTION
# Description
## 1 Line Summary

Removes some left-over references to `express_webpack`, which were removed in #1231 and #1232, with `preview`.

## Details

# Systems Affected
   - [X] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1237)
<!-- Reviewable:end -->
