### PR TITLE
Additional race condition handling in SessionManager with switching users

### DIFF
--- a/src/shared/managers/sessionManager/SessionManager.test.ts
+++ b/src/shared/managers/sessionManager/SessionManager.test.ts
@@ -7,6 +7,7 @@ import {
 } from '__test__/support/constants';
 import { setupLoginStubs } from '__test__/support/helpers/login';
 import LoginManager from 'src/page/managers/LoginManager';
+import { SessionOrigin } from 'src/shared/models/Session';
 
 describe('SessionManager', () => {
   describe('Switching Users', () => {
@@ -54,6 +55,86 @@ describe('SessionManager', () => {
 
       const winner = await Promise.race([loginPromise, sessionPromise]);
       expect(winner).toBe('logout');
+    });
+
+    test('handleOnBlur should wait for login promise', async () => {
+      const loginPromise = (async function () {
+        await LoginManager.login(DUMMY_EXTERNAL_ID);
+        return 'login';
+      })();
+
+      const sessionManager = new SessionManager(OneSignal.context);
+      const sessionPromise = (async function () {
+        await sessionManager.handleOnBlur(new Event('{}'));
+        return 'session';
+      })();
+
+      const winner = await Promise.race([loginPromise, sessionPromise]);
+      expect(winner).toBe('login');
+    });
+
+    test('handleOnBlur should wait for logout promise', async () => {
+      const loginPromise = (async function () {
+        await LoginManager.logout();
+        return 'logout';
+      })();
+
+      const sessionManager = new SessionManager(OneSignal.context);
+      const sessionPromise = (async function () {
+        await sessionManager.handleOnBlur(new Event('{}'));
+        return 'session';
+      })();
+
+      const winner = await Promise.race([loginPromise, sessionPromise]);
+      expect(winner).toBe('logout');
+    });
+
+    test('handleVisibilityChange should wait for login promise', async () => {
+      const loginPromise = (async function () {
+        await LoginManager.login(DUMMY_EXTERNAL_ID);
+        return 'login';
+      })();
+
+      const sessionManager = new SessionManager(OneSignal.context);
+      const sessionPromise = (async function () {
+        await sessionManager.handleVisibilityChange();
+        return 'session';
+      })();
+
+      const winner = await Promise.race([loginPromise, sessionPromise]);
+      expect(winner).toBe('login');
+    });
+
+    test('handleOnBeforeUnload should wait for login promise', async () => {
+      const loginPromise = (async function () {
+        await LoginManager.login(DUMMY_EXTERNAL_ID);
+        return 'login';
+      })();
+
+      const sessionManager = new SessionManager(OneSignal.context);
+      const sessionPromise = (async function () {
+        await sessionManager.handleOnBeforeUnload();
+        return 'session';
+      })();
+
+      const winner = await Promise.race([loginPromise, sessionPromise]);
+      expect(winner).toBe('login');
+    });
+
+    test('upsertSession should wait for login promise', async () => {
+      const loginPromise = (async function () {
+        await LoginManager.login(DUMMY_EXTERNAL_ID);
+        return 'login';
+      })();
+
+      const sessionManager = new SessionManager(OneSignal.context);
+      const sessionPromise = (async function () {
+        await sessionManager.upsertSession(SessionOrigin.UserCreate);
+        return 'session';
+      })();
+
+      const winner = await Promise.race([loginPromise, sessionPromise]);
+      expect(winner).toBe('login');
     });
   });
 });

--- a/src/shared/managers/sessionManager/SessionManager.ts
+++ b/src/shared/managers/sessionManager/SessionManager.ts
@@ -82,7 +82,7 @@ export class SessionManager implements ISessionManager {
     }
   }
 
-  async _getOneSignalAndSubscriptionIds(): Promise<{
+  private async _getOneSignalAndSubscriptionIds(): Promise<{
     onesignalId: string;
     subscriptionId: string;
   }> {
@@ -112,6 +112,8 @@ export class SessionManager implements ISessionManager {
   }
 
   async handleVisibilityChange(): Promise<void> {
+    await LoginManager.switchingUsersPromise;
+
     if (!User.singletonInstance?.hasOneSignalId) {
       return;
     }
@@ -171,6 +173,8 @@ export class SessionManager implements ISessionManager {
   }
 
   async handleOnBeforeUnload(): Promise<void> {
+    await LoginManager.switchingUsersPromise;
+
     if (!User.singletonInstance?.hasOneSignalId) {
       return;
     }
@@ -232,6 +236,8 @@ export class SessionManager implements ISessionManager {
   }
 
   async handleOnBlur(e: Event): Promise<void> {
+    await LoginManager.switchingUsersPromise;
+
     Log.debug('handleOnBlur', e);
     if (!User.singletonInstance?.hasOneSignalId) {
       return;
@@ -260,6 +266,8 @@ export class SessionManager implements ISessionManager {
   }
 
   async upsertSession(sessionOrigin: SessionOrigin): Promise<void> {
+    await LoginManager.switchingUsersPromise;
+
     if (User.singletonInstance?.hasOneSignalId) {
       const { onesignalId, subscriptionId } =
         await this._getOneSignalAndSubscriptionIds();


### PR DESCRIPTION
# Description
## 1 Line Summary
Extends on the work done in PR #1233, prevent bad states & errors with SessionManager while a login or logout is being processed.

## Details
Added race condition guards to all code that calls `_getOneSignalAndSubscriptionIds()` since this can throw anytime `LoginManger` is in the middle of switching users.

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [X] Don't use default export
   - [X] New interfaces are in model files

Functions:
   - [X] Don't use default export
   - [X] All function signatures have return types
   - [X] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [X] No Typescript warnings
   - [X] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [X] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [X] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1256)
<!-- Reviewable:end -->
