### PR TITLE
For for addEmail

### DIFF
--- a/src/core/CoreModuleDirector.ts
+++ b/src/core/CoreModuleDirector.ts
@@ -1,5 +1,15 @@
-import { logMethodCall } from '../shared/utils/utils';
+import SubscriptionHelper from '../../src/shared/helpers/SubscriptionHelper';
+import { NewRecordsState } from '../../src/shared/models/NewRecordsState';
+import OneSignal from '../onesignal/OneSignal';
+import User from '../onesignal/User';
+import FuturePushSubscriptionRecord from '../page/userModel/FuturePushSubscriptionRecord';
+import OneSignalError from '../shared/errors/OneSignalError';
+import EventHelper from '../shared/helpers/EventHelper';
+import MainHelper from '../shared/helpers/MainHelper';
 import Log from '../shared/libraries/Log';
+import { RawPushSubscription } from '../shared/models/RawPushSubscription';
+import Database from '../shared/services/Database';
+import { logMethodCall } from '../shared/utils/utils';
 import CoreModule from './CoreModule';
 import { OSModel } from './modelRepo/OSModel';
 import { SupportedIdentity } from './models/IdentityModel';
@@ -11,18 +21,8 @@ import {
   SupportedSubscription,
 } from './models/SubscriptionModels';
 import { ModelName, SupportedModel } from './models/SupportedModels';
-import { UserPropertiesModel } from './models/UserPropertiesModel';
 import UserData from './models/UserData';
-import OneSignalError from '../shared/errors/OneSignalError';
-import MainHelper from '../shared/helpers/MainHelper';
-import { RawPushSubscription } from '../shared/models/RawPushSubscription';
-import FuturePushSubscriptionRecord from '../page/userModel/FuturePushSubscriptionRecord';
-import User from '../onesignal/User';
-import OneSignal from '../onesignal/OneSignal';
-import Database from '../shared/services/Database';
-import EventHelper from '../shared/helpers/EventHelper';
-import SubscriptionHelper from '../../src/shared/helpers/SubscriptionHelper';
-import { NewRecordsState } from '../../src/shared/models/NewRecordsState';
+import { UserPropertiesModel } from './models/UserPropertiesModel';
 
 /* Contains OneSignal User-Model-specific logic*/
 
@@ -93,7 +93,7 @@ export class CoreModuleDirector {
       // subscriptions are duplicable, so we hydrate them separately
       // when hydrating, we should have the full subscription object (i.e. include ID from server)
       this._hydrateSubscriptions(
-        user.subscriptions as SubscriptionModel[],
+        user.subscriptions as SubscriptionModel[] | undefined,
         onesignalId,
         externalId,
       );
@@ -104,7 +104,7 @@ export class CoreModuleDirector {
   }
 
   private _hydrateSubscriptions(
-    subscriptions: SubscriptionModel[],
+    subscriptions: SubscriptionModel[] | undefined,
     onesignalId: string,
     externalId?: string,
   ): void {

--- a/src/core/models/UserData.ts
+++ b/src/core/models/UserData.ts
@@ -5,7 +5,7 @@ import { UserPropertiesModel } from './UserPropertiesModel';
 type UserData = {
   properties: UserPropertiesModel;
   identity: SupportedIdentity;
-  subscriptions: SupportedSubscription[];
+  subscriptions?: SupportedSubscription[];
 };
 
 export default UserData;

--- a/src/core/utils/typePredicates.ts
+++ b/src/core/utils/typePredicates.ts
@@ -66,7 +66,7 @@ export function isFutureSubscriptionObject(obj: {
   return obj?.type !== undefined;
 }
 
-export function isCompleteSubscriptionObject(obj: {
+export function isCompleteSubscriptionObject(obj?: {
   type?: string;
   id?: string;
 }): obj is SubscriptionModel {

--- a/src/entries/pageSdkInit.test.ts
+++ b/src/entries/pageSdkInit.test.ts
@@ -1,4 +1,4 @@
-import { APP_ID } from '__test__/support/constants';
+import { APP_ID, DUMMY_ONESIGNAL_ID } from '__test__/support/constants';
 import TestContext from '__test__/support/environment/TestContext';
 import { TestEnvironment } from '__test__/support/environment/TestEnvironment';
 import { server } from '__test__/support/mocks/server';
@@ -90,7 +90,9 @@ describe('pageSdkInit', () => {
         HttpResponse.json(
           {
             properties: {},
-            identity: {},
+            identity: {
+              onesignal_id: DUMMY_ONESIGNAL_ID,
+            },
             subscriptions: undefined,
           } satisfies UserData,
           { status: 200 },

--- a/src/onesignal/UserDirector.ts
+++ b/src/onesignal/UserDirector.ts
@@ -1,15 +1,15 @@
 import { OSModel } from '../core/modelRepo/OSModel';
 import { SupportedIdentity } from '../core/models/IdentityModel';
+import { SupportedSubscription } from '../core/models/SubscriptionModels';
 import { ModelName, SupportedModel } from '../core/models/SupportedModels';
 import UserData from '../core/models/UserData';
+import { RequestService } from '../core/requestService/RequestService';
+import { isCompleteSubscriptionObject } from '../core/utils/typePredicates';
 import Environment from '../shared/helpers/Environment';
 import MainHelper from '../shared/helpers/MainHelper';
 import Log from '../shared/libraries/Log';
 import { logMethodCall } from '../shared/utils/utils';
 import User from './User';
-import { RequestService } from '../core/requestService/RequestService';
-import { SupportedSubscription } from '../core/models/SubscriptionModels';
-import { isCompleteSubscriptionObject } from '../core/utils/typePredicates';
 
 export default class UserDirector {
   static async initializeUser(isTemporary?: boolean): Promise<void> {
@@ -117,11 +117,11 @@ export default class UserDirector {
         const onesignalId = userData.identity?.onesignal_id;
 
         if (onesignalId) {
-          OneSignal.coreDirector.getNewRecordsState().add(onesignalId);
+          OneSignal.coreDirector.getNewRecordsState()?.add(onesignalId);
         }
 
-        const payloadSubcriptionToken = userData.subscriptions[0].token;
-        const resultSubscription = result.subscriptions.find(
+        const payloadSubcriptionToken = userData.subscriptions?.[0]?.token;
+        const resultSubscription = result.subscriptions?.find(
           (sub) => sub.token === payloadSubcriptionToken,
         );
 
@@ -129,7 +129,7 @@ export default class UserDirector {
           if (isCompleteSubscriptionObject(resultSubscription)) {
             OneSignal.coreDirector
               .getNewRecordsState()
-              .add(resultSubscription.id);
+              ?.add(resultSubscription.id);
           }
         }
       }


### PR DESCRIPTION
# Description
## 1 Line Summary
- Adds optional chaining for createUserOnServer method when using addEmail

## Details
When creating a user on the server for the first time, the subscriptions array may not existing. So doing calls like `OneSignal.User.addEmail(<someemail>)` for a new user will throw an error.

# Systems Affected
   - [ ] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---
