### PR TITLE
Fix logic for adding email/sms subscriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,14 @@
       //     });
       //   });
       // }, 5000);
+
+      // For testing addEmail / addSms records
+      window.OneSignalDeferred = window.OneSignalDeferred || [];
+      OneSignalDeferred.push(async function (OneSignal) {
+        await OneSignal.login('spicy-new');
+        OneSignal.User.addEmail('jd@mail.com');
+        // OneSignal.User.addSms('6191234567');
+      });
     </script>
   </body>
 </html>

--- a/src/core/CoreModuleDirector.ts
+++ b/src/core/CoreModuleDirector.ts
@@ -171,6 +171,7 @@ export class CoreModuleDirector {
     modelStores[modelName].add(model, propagate);
   }
 
+
   public remove(modelName: ModelName, modelId: string): void {
     logMethodCall('CoreModuleDirector.remove', { modelName, modelId });
     const modelStores = this.getModelStores();

--- a/src/core/modelRepo/OSModelStore.ts
+++ b/src/core/modelRepo/OSModelStore.ts
@@ -1,14 +1,14 @@
-import { OSModel } from './OSModel';
 import Subscribable from '../Subscribable';
+import { CoreChangeType } from '../models/CoreChangeType';
 import {
-  ModelStoreChange,
   ModelStoreAdded,
+  ModelStoreChange,
+  ModelStoreHydrated,
   ModelStoreRemoved,
   ModelStoreUpdated,
-  ModelStoreHydrated,
 } from '../models/ModelStoreChange';
-import { CoreChangeType } from '../models/CoreChangeType';
 import { isOSModel, isOSModelUpdatedArgs } from '../utils/typePredicates';
+import { OSModel } from './OSModel';
 
 export class OSModelStore<Model> extends Subscribable<ModelStoreChange<Model>> {
   public models: { [key: string]: OSModel<Model> } = {};


### PR DESCRIPTION
# Description
## 1 Line Summary
- checks for existing subscriptions before adding new ones for email and sms


# Systems Affected
   - [ ] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---
