### PR TITLE
Web SDK Refactor: Add ModelStore Class

### DIFF
--- a/__test__/unit/core/operationCache.test.ts
+++ b/__test__/unit/core/operationCache.test.ts
@@ -1,13 +1,13 @@
+import { LegacyOperation } from 'src/core/operationRepo/LegacyOperation';
 import ModelCache from '../../../src/core/caching/ModelCache';
 import OperationCache from '../../../src/core/caching/OperationCache';
 import { CoreChangeType } from '../../../src/core/models/CoreChangeType';
 import { ModelName } from '../../../src/core/models/SupportedModels';
-import { Operation } from '../../../src/core/operationRepo/Operation';
+import { TestEnvironment } from '../../support/environment/TestEnvironment';
 import {
   getDummyIdentityOSModel,
   getMockDeltas,
 } from '../../support/helpers/core';
-import { TestEnvironment } from '../../support/environment/TestEnvironment';
 
 describe('OperationCache: operation results in correct operation queue result', () => {
   beforeEach(async () => {
@@ -23,7 +23,7 @@ describe('OperationCache: operation results in correct operation queue result', 
   });
 
   test('Add operation to cache -> operation queue +1', async () => {
-    const operation = new Operation(
+    const operation = new LegacyOperation(
       CoreChangeType.Add,
       ModelName.Identity,
       getMockDeltas(),
@@ -36,7 +36,7 @@ describe('OperationCache: operation results in correct operation queue result', 
   });
 
   test('Remove operation from cache -> operation queue -1', async () => {
-    const operation = new Operation(
+    const operation = new LegacyOperation(
       CoreChangeType.Add,
       ModelName.Identity,
       getMockDeltas(),
@@ -54,12 +54,12 @@ describe('OperationCache: operation results in correct operation queue result', 
   });
 
   test('Add multiple operations to cache -> operation queue +2', async () => {
-    const operation = new Operation(
+    const operation = new LegacyOperation(
       CoreChangeType.Add,
       ModelName.Identity,
       getMockDeltas(),
     );
-    const operation2 = new Operation(
+    const operation2 = new LegacyOperation(
       CoreChangeType.Add,
       ModelName.Identity,
       getMockDeltas(),
@@ -75,12 +75,12 @@ describe('OperationCache: operation results in correct operation queue result', 
   });
 
   test('Flush operation cache -> operation queue 0', async () => {
-    const operation = new Operation(
+    const operation = new LegacyOperation(
       CoreChangeType.Add,
       ModelName.Identity,
       getMockDeltas(),
     );
-    const operation2 = new Operation(
+    const operation2 = new LegacyOperation(
       CoreChangeType.Add,
       ModelName.Identity,
       getMockDeltas(),

--- a/__test__/unit/core/requestService/userPropertyRequests.test.ts
+++ b/__test__/unit/core/requestService/userPropertyRequests.test.ts
@@ -1,10 +1,10 @@
-import { Operation } from '../../../../src/core/operationRepo/Operation';
+import { LegacyOperation } from 'src/core/operationRepo/LegacyOperation';
+import { ExecutorResultFailNotRetriable } from '../../../../src/core/executors/ExecutorResult';
+import { OSModel } from '../../../../src/core/modelRepo/OSModel';
 import { CoreChangeType } from '../../../../src/core/models/CoreChangeType';
-import UserPropertyRequests from '../../../../src/core/requestService/UserPropertyRequests';
 import { ModelName } from '../../../../src/core/models/SupportedModels';
 import { UserPropertiesModel } from '../../../../src/core/models/UserPropertiesModel';
-import { OSModel } from '../../../../src/core/modelRepo/OSModel';
-import { ExecutorResultFailNotRetriable } from '../../../../src/core/executors/ExecutorResult';
+import UserPropertyRequests from '../../../../src/core/requestService/UserPropertyRequests';
 import Database from '../../../../src/shared/services/Database';
 
 const getJWTTokenSpy = vi.spyOn(Database.prototype, 'getJWTToken');
@@ -22,7 +22,7 @@ describe('User Property Request tests', () => {
       property: 'tags',
       newValue: { key: 'value' },
     };
-    const operation = new Operation<UserPropertiesModel>(
+    const operation = new LegacyOperation<UserPropertiesModel>(
       CoreChangeType.Update,
       ModelName.Properties,
       [delta],

--- a/src/core/caching/OperationCache.ts
+++ b/src/core/caching/OperationCache.ts
@@ -1,10 +1,10 @@
 import Log from '../../shared/libraries/Log';
 import { logMethodCall } from '../../shared/utils/utils';
 import { ModelName, SupportedModel } from '../models/SupportedModels';
-import { Operation } from '../operationRepo/Operation';
+import { LegacyOperation } from '../operationRepo/LegacyOperation';
 
 export default class OperationCache {
-  static enqueue<Model>(operation: Operation<Model>): void {
+  static enqueue<Model>(operation: LegacyOperation<Model>): void {
     logMethodCall('OperationCache.enqueue', { operation });
     const fromCache = localStorage.getItem('operationCache');
     const operations: { [key: string]: unknown } = fromCache
@@ -16,22 +16,23 @@ export default class OperationCache {
 
   static getOperationsWithModelName(
     modelName: ModelName,
-  ): Operation<SupportedModel>[] {
+  ): LegacyOperation<SupportedModel>[] {
     const fromCache = localStorage.getItem('operationCache');
-    const rawOperations: Operation<SupportedModel>[] = fromCache
+    const rawOperations: LegacyOperation<SupportedModel>[] = fromCache
       ? Object.values(JSON.parse(fromCache))
       : [];
-    const operations: Operation<SupportedModel>[] = [];
+    const operations: LegacyOperation<SupportedModel>[] = [];
 
     for (let i = 0; i < rawOperations.length; i++) {
       const rawOperation = rawOperations[i];
 
       try {
         // return an operation object with correct references (in particular reference to the model)
-        const operation = Operation.getInstanceWithModelReference(rawOperation);
+        const operation =
+          LegacyOperation.getInstanceWithModelReference(rawOperation);
 
         if (operation) {
-          operations.push(operation as Operation<SupportedModel>);
+          operations.push(operation as LegacyOperation<SupportedModel>);
         }
       } catch (e) {
         Log.warn(

--- a/src/core/executors/IdentityExecutor.ts
+++ b/src/core/executors/IdentityExecutor.ts
@@ -4,7 +4,7 @@ import { CoreChangeType } from '../models/CoreChangeType';
 import { PropertyDelta } from '../models/CoreDeltas';
 import { ExecutorConfig } from '../models/ExecutorConfig';
 import { ModelName, SupportedModel } from '../models/SupportedModels';
-import { Operation } from '../operationRepo/Operation';
+import { LegacyOperation } from '../operationRepo/LegacyOperation';
 import { isPropertyDelta } from '../utils/typePredicates';
 import ExecutorBase from './ExecutorBase';
 
@@ -46,7 +46,7 @@ export class IdentityExecutor extends ExecutorBase {
 
     if (addAndUpdatedDeltas.length > 0) {
       this._enqueueOperation(
-        new Operation<SupportedModel>(
+        new LegacyOperation<SupportedModel>(
           CoreChangeType.Add,
           ModelName.Identity,
           addAndUpdatedDeltas,
@@ -55,14 +55,18 @@ export class IdentityExecutor extends ExecutorBase {
     }
     if (removeDeltas.length > 0) {
       this._enqueueOperation(
-        new Operation(CoreChangeType.Remove, ModelName.Identity, removeDeltas),
+        new LegacyOperation(
+          CoreChangeType.Remove,
+          ModelName.Identity,
+          removeDeltas,
+        ),
       );
     }
 
     this._flushDeltas();
   }
 
-  getOperationsFromCache(): Operation<SupportedModel>[] {
+  getOperationsFromCache(): LegacyOperation<SupportedModel>[] {
     return OperationCache.getOperationsWithModelName(ModelName.Identity);
   }
 }

--- a/src/core/executors/PropertiesExecutor.ts
+++ b/src/core/executors/PropertiesExecutor.ts
@@ -1,10 +1,10 @@
 import { NewRecordsState } from '../../shared/models/NewRecordsState';
-import ExecutorBase from './ExecutorBase';
-import { Operation } from '../operationRepo/Operation';
+import OperationCache from '../caching/OperationCache';
 import { CoreChangeType } from '../models/CoreChangeType';
 import { ExecutorConfig } from '../models/ExecutorConfig';
 import { ModelName, SupportedModel } from '../models/SupportedModels';
-import OperationCache from '../caching/OperationCache';
+import { LegacyOperation } from '../operationRepo/LegacyOperation';
+import ExecutorBase from './ExecutorBase';
 
 export class PropertiesExecutor extends ExecutorBase {
   constructor(
@@ -20,7 +20,7 @@ export class PropertiesExecutor extends ExecutorBase {
     }
 
     this._enqueueOperation(
-      new Operation(
+      new LegacyOperation(
         CoreChangeType.Update,
         ModelName.Properties,
         this._deltaQueue,
@@ -29,7 +29,7 @@ export class PropertiesExecutor extends ExecutorBase {
     this._flushDeltas();
   }
 
-  getOperationsFromCache(): Operation<SupportedModel>[] {
+  getOperationsFromCache(): LegacyOperation<SupportedModel>[] {
     return OperationCache.getOperationsWithModelName(ModelName.Properties);
   }
 }

--- a/src/core/executors/SubscriptionExecutor.ts
+++ b/src/core/executors/SubscriptionExecutor.ts
@@ -4,7 +4,7 @@ import { CoreChangeType } from '../models/CoreChangeType';
 import { CoreDelta } from '../models/CoreDeltas';
 import { ExecutorConfig } from '../models/ExecutorConfig';
 import { ModelName, SupportedModel } from '../models/SupportedModels';
-import { Operation } from '../operationRepo/Operation';
+import { LegacyOperation } from '../operationRepo/LegacyOperation';
 import ExecutorBase from './ExecutorBase';
 
 export class SubscriptionExecutor extends ExecutorBase {
@@ -25,7 +25,7 @@ export class SubscriptionExecutor extends ExecutorBase {
         const deltas = changeSpecificDeltas[changeType];
         if (deltas.length > 0) {
           this._enqueueOperation(
-            new Operation(
+            new LegacyOperation(
               changeType as CoreChangeType,
               deltas[0].model.modelName,
               deltas,
@@ -38,7 +38,7 @@ export class SubscriptionExecutor extends ExecutorBase {
     this._flushDeltas();
   }
 
-  getOperationsFromCache(): Operation<SupportedModel>[] {
+  getOperationsFromCache(): LegacyOperation<SupportedModel>[] {
     return OperationCache.getOperationsWithModelName(ModelName.Subscriptions);
   }
 

--- a/src/core/modelRepo/ModelRepo.ts
+++ b/src/core/modelRepo/ModelRepo.ts
@@ -1,18 +1,19 @@
+import { logMethodCall } from '../../shared/utils/utils';
 import ModelCache from '../caching/ModelCache';
-import Subscribable from '../Subscribable';
 import { CoreChangeType } from '../models/CoreChangeType';
 import { CoreDelta } from '../models/CoreDeltas';
-import { ModelStoresMap } from '../models/ModelStoresMap';
-import { SupportedModel, ModelName } from '../models/SupportedModels';
 import {
-  ModelStoreChange,
   ModelStoreAdded,
+  ModelStoreChange,
+  ModelStoreHydrated,
   ModelStoreRemoved,
   ModelStoreUpdated,
-  ModelStoreHydrated,
 } from '../models/ModelStoreChange';
-import { logMethodCall } from '../../shared/utils/utils';
+import { ModelStoresMap } from '../models/ModelStoresMap';
+import { ModelName, SupportedModel } from '../models/SupportedModels';
+import Subscribable from '../Subscribable';
 
+// TODO: Remove this later as part of the Web SDK Refactor
 export class ModelRepo extends Subscribable<CoreDelta<SupportedModel>> {
   constructor(
     private modelCache: ModelCache,

--- a/src/core/modelRepo/ModelStore.ts
+++ b/src/core/modelRepo/ModelStore.ts
@@ -1,0 +1,209 @@
+import { EventProducer } from 'src/shared/helpers/EventProducer';
+import Log from 'src/shared/libraries/Log';
+import type { IEventNotifier } from 'src/types/events';
+import type { IModelStore, IModelStoreChangeHandler } from 'src/types/models';
+import {
+  PreferenceOneSignalKeys,
+  PreferenceStores,
+  type IPreferencesService,
+} from 'src/types/preferences';
+import type { IModelChangedHandler, Model, ModelChangedArgs } from './Model';
+
+/**
+ * The abstract implementation of a model store. Implements all but the `create` method,
+ * which must be implemented by the concrete class as this abstract implementation is not
+ * able to derive and instantiate the concrete model type being stored.
+ *
+ * Persistence
+ * -----------
+ * When persistence is enabled for this model store (i.e. a `name` and `_prefs` parameters
+ * are provided on initialization) any `Model` that has been added to the model store will
+ * be persisted, including any update to that model, when that property update drives a
+ * `IModelChangedHandler.onChanged` event. If a model property update does *not* drive
+ * a `IModelChangedHandler.onChanged` event but persistence is still desired, there is a
+ * `persist` method that can be called at any time.
+ *
+ * Instantiating this model store with persistence will load any previously persisted models
+ * as part of its initialization process.
+ */
+export abstract class ModelStore<TModel extends Model>
+  implements
+    IEventNotifier<IModelStoreChangeHandler<TModel>>,
+    IModelStore<TModel>,
+    IModelChangedHandler
+{
+  private changeSubscription: EventProducer<IModelStoreChangeHandler<TModel>> =
+    new EventProducer();
+  private models: TModel[] = [];
+  private hasLoadedFromCache = false;
+
+  /**
+   * @param name The persistable name of the model store. If not specified no persisting will occur.
+   * @param _prefs Preferences service for persistence
+   */
+  constructor(
+    public readonly name?: string,
+    private _prefs?: IPreferencesService,
+  ) {}
+
+  /**
+   * Create a model from JSON data
+   */
+  abstract create(json: object): TModel | null;
+
+  add(model: TModel, tag: string): void {
+    const oldModel = this.models.find((m) => m.id === model.id);
+    if (oldModel) this.removeItem(oldModel, tag);
+    this.addItem(model, tag);
+  }
+
+  addAt(index: number, model: TModel, tag: string): void {
+    const oldModel = this.models.find((m) => m.id === model.id);
+    if (oldModel) this.removeItem(oldModel, tag);
+    this.addItem(model, tag, index);
+  }
+
+  /**
+   * @returns list of read-only models, cloned for thread safety
+   */
+  list(): TModel[] {
+    return this.models;
+  }
+
+  get(id: string): TModel | undefined {
+    return this.models.find((m) => m.id === id);
+  }
+
+  remove(id: string, tag: string): void {
+    const model = this.models.find((m) => m.id === id);
+    if (!model) return;
+    this.removeItem(model, tag);
+  }
+
+  onChanged(args: ModelChangedArgs, tag: string): void {
+    this.persist();
+    this.changeSubscription.fire((handler) =>
+      handler.onModelUpdated(args, tag),
+    );
+  }
+
+  replaceAll(newModels: TModel[], tag: string): void {
+    this.clear(tag);
+    for (const model of newModels) {
+      this.add(model, tag);
+    }
+  }
+
+  clear(tag: string): void {
+    this.persist();
+
+    for (const item of this.models) {
+      // no longer listen for changes to this model
+      item.unsubscribe(this);
+      this.changeSubscription.fire((handler) =>
+        handler.onModelRemoved(item, tag),
+      );
+    }
+  }
+
+  private addItem(model: TModel, tag: string, index?: number): void {
+    if (index !== undefined) {
+      this.models.splice(index, 0, model);
+    } else {
+      this.models.push(model);
+    }
+
+    // listen for changes to this model
+    model.subscribe(this);
+
+    this.persist();
+
+    this.changeSubscription.fire((handler) => handler.onModelAdded(model, tag));
+  }
+
+  private removeItem(model: TModel, tag: string): void {
+    this.models = this.models.filter((m) => m !== model);
+
+    // no longer listen for changes to this model
+    model.unsubscribe(this);
+
+    this.persist();
+
+    this.changeSubscription.fire((handler) =>
+      handler.onModelRemoved(model, tag),
+    );
+  }
+
+  /**
+   * When models are loaded from the cache, they are added to the front of existing models.
+   * This is primarily to address operations which can enqueue before this method is called.
+   */
+  protected load(): void {
+    if (!this.name || !this._prefs) return;
+
+    const str = this._prefs.getValue<string>(
+      PreferenceStores.ONESIGNAL,
+      PreferenceOneSignalKeys.MODEL_STORE_PREFIX + this.name,
+      '[]',
+    );
+
+    const jsonArray = JSON.parse(str);
+    const shouldRePersist = this.models.length > 0;
+
+    for (let index = jsonArray.length - 1; index >= 0; index--) {
+      const newModel = this.create(jsonArray[index]);
+      if (!newModel) continue;
+
+      const hasExisting = this.models.some((m) => m.id === newModel.id);
+      if (hasExisting) {
+        Log.debug(
+          `ModelStore<${this.name}>: load - operation.id: ${newModel.id} already exists in the store.`,
+        );
+        continue;
+      }
+
+      this.models.unshift(newModel);
+      // listen for changes to this model
+      newModel.subscribe(this);
+    }
+
+    this.hasLoadedFromCache = true;
+
+    // optimization only: to avoid unnecessary writes
+    if (shouldRePersist) {
+      this.persist();
+    }
+  }
+
+  /**
+   * Any models added or changed before load is called are not persisted, to avoid overwriting the cache.
+   * The time between any changes and loading from cache should be minuscule so lack of persistence is safe.
+   * This is primarily to address operations which can enqueue before load() is called.
+   */
+  persist(): void {
+    if (!this.name || !this._prefs || !this.hasLoadedFromCache) return;
+
+    const jsonArray: unknown[] = [];
+    for (const model of this.models) {
+      jsonArray.push(model.toJSON());
+    }
+
+    this._prefs.setValue<string>(
+      PreferenceStores.ONESIGNAL,
+      PreferenceOneSignalKeys.MODEL_STORE_PREFIX + this.name,
+      JSON.stringify(jsonArray),
+    );
+  }
+
+  subscribe(handler: IModelStoreChangeHandler<TModel>): void {
+    this.changeSubscription.subscribe(handler);
+  }
+
+  unsubscribe(handler: IModelStoreChangeHandler<TModel>): void {
+    this.changeSubscription.unsubscribe(handler);
+  }
+
+  get hasSubscribers(): boolean {
+    return this.changeSubscription.hasSubscribers;
+  }
+}

--- a/src/core/modelRepo/ModelStore.ts
+++ b/src/core/modelRepo/ModelStore.ts
@@ -1,13 +1,16 @@
+// Implements logic similar to Android SDK's ModelStore
+// Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt
 import { EventProducer } from 'src/shared/helpers/EventProducer';
 import Log from 'src/shared/libraries/Log';
 import type { IEventNotifier } from 'src/types/events';
 import type { IModelStore, IModelStoreChangeHandler } from 'src/types/models';
-import {
-  PreferenceOneSignalKeys,
-  PreferenceStores,
-  type IPreferencesService,
-} from 'src/types/preferences';
-import type { IModelChangedHandler, Model, ModelChangedArgs } from './Model';
+import type { IPreferencesService } from 'src/types/preferences';
+import type {
+  IModelChangedHandler,
+  Model,
+  ModelChangedArgs,
+} from '../models/Model';
+const STORE = 'OneSignal_ModelStore';
 
 /**
  * The abstract implementation of a model store. Implements all but the `create` method,
@@ -141,11 +144,7 @@ export abstract class ModelStore<TModel extends Model>
   protected load(): void {
     if (!this.name || !this._prefs) return;
 
-    const str = this._prefs.getValue<string>(
-      PreferenceStores.ONESIGNAL,
-      PreferenceOneSignalKeys.MODEL_STORE_PREFIX + this.name,
-      '[]',
-    );
+    const str = this._prefs.getValue<string>(STORE, this.name, '[]');
 
     const jsonArray = JSON.parse(str);
     const shouldRePersist = this.models.length > 0;
@@ -188,11 +187,7 @@ export abstract class ModelStore<TModel extends Model>
       jsonArray.push(model.toJSON());
     }
 
-    this._prefs.setValue<string>(
-      PreferenceStores.ONESIGNAL,
-      PreferenceOneSignalKeys.MODEL_STORE_PREFIX + this.name,
-      JSON.stringify(jsonArray),
-    );
+    this._prefs.setValue<string>(STORE, this.name, JSON.stringify(jsonArray));
   }
 
   subscribe(handler: IModelStoreChangeHandler<TModel>): void {

--- a/src/core/modelRepo/OSModel.ts
+++ b/src/core/modelRepo/OSModel.ts
@@ -10,6 +10,7 @@ import { StringKeys } from '../models/StringKeys';
 import { ModelName, SupportedModel } from '../models/SupportedModels';
 import { OSModelUpdatedArgs } from './OSModelUpdatedArgs';
 
+// TODO: Remove this later as part of the Web SDK Refactor
 export class OSModel<Model> extends Subscribable<ModelStoreChange<Model>> {
   data: Model;
   modelId: string;

--- a/src/core/modelRepo/OSModelStore.ts
+++ b/src/core/modelRepo/OSModelStore.ts
@@ -1,15 +1,16 @@
-import { OSModel } from './OSModel';
 import Subscribable from '../Subscribable';
+import { CoreChangeType } from '../models/CoreChangeType';
 import {
-  ModelStoreChange,
   ModelStoreAdded,
+  ModelStoreChange,
+  ModelStoreHydrated,
   ModelStoreRemoved,
   ModelStoreUpdated,
-  ModelStoreHydrated,
 } from '../models/ModelStoreChange';
-import { CoreChangeType } from '../models/CoreChangeType';
 import { isOSModel, isOSModelUpdatedArgs } from '../utils/typePredicates';
+import { OSModel } from './OSModel';
 
+// TODO: Remove this later as part of the Web SDK Refactor
 export class OSModelStore<Model> extends Subscribable<ModelStoreChange<Model>> {
   public models: { [key: string]: OSModel<Model> } = {};
   public unsubscribeCallbacks: { [key: string]: () => void } = {};

--- a/src/core/modelRepo/OSModelStoreFactory.ts
+++ b/src/core/modelRepo/OSModelStoreFactory.ts
@@ -3,6 +3,7 @@ import { ModelName } from '../models/SupportedModels';
 import { OSModel } from './OSModel';
 import { OSModelStore } from './OSModelStore';
 
+// TODO: Remove this later as part of the Web SDK Refactor
 export class OSModelStoreFactory {
   static build<Model>(cachedModels?: {
     [key: string]: OSModel<Model>[];

--- a/src/core/modelRepo/OSModelUpdatedArgs.ts
+++ b/src/core/modelRepo/OSModelUpdatedArgs.ts
@@ -1,5 +1,6 @@
 import { OSModel } from './OSModel';
 
+// TODO: Remove this later as part of the Web SDK Refactor
 export class OSModelUpdatedArgs<Model> {
   constructor(
     public model: OSModel<Model>,

--- a/src/core/modelRepo/OperationModelStore.ts
+++ b/src/core/modelRepo/OperationModelStore.ts
@@ -12,9 +12,9 @@ export class OperationModelStore extends ModelStore<Operation> {
     this.load();
   }
 
-  protected create(jsonObject: Record<string, any> | null): Operation | null {
+  create(jsonObject: { name?: string } | null): Operation | null {
     if (jsonObject === null) {
-      Logging.error('null jsonObject sent to OperationModelStore.create');
+      Log.error('null jsonObject sent to OperationModelStore.create');
       return null;
     }
 
@@ -24,61 +24,19 @@ export class OperationModelStore extends ModelStore<Operation> {
 
     // Determine the type of operation based on the name property in the json
     let operation: Operation;
-    const operationName = jsonObject['name'];
+    // const operationName = jsonObject.name;
 
-    switch (operationName) {
-      case IdentityOperationExecutor.SET_ALIAS:
-        operation = new SetAliasOperation();
-        break;
-      case IdentityOperationExecutor.DELETE_ALIAS:
-        operation = new DeleteAliasOperation();
-        break;
-      case SubscriptionOperationExecutor.CREATE_SUBSCRIPTION:
-        operation = new CreateSubscriptionOperation();
-        break;
-      case SubscriptionOperationExecutor.UPDATE_SUBSCRIPTION:
-        operation = new UpdateSubscriptionOperation();
-        break;
-      case SubscriptionOperationExecutor.DELETE_SUBSCRIPTION:
-        operation = new DeleteSubscriptionOperation();
-        break;
-      case SubscriptionOperationExecutor.TRANSFER_SUBSCRIPTION:
-        operation = new TransferSubscriptionOperation();
-        break;
-      case LoginUserOperationExecutor.LOGIN_USER:
-        operation = new LoginUserOperation();
-        break;
-      case LoginUserFromSubscriptionOperationExecutor.LOGIN_USER_FROM_SUBSCRIPTION_USER:
-        operation = new LoginUserFromSubscriptionOperation();
-        break;
-      case RefreshUserOperationExecutor.REFRESH_USER:
-        operation = new RefreshUserOperation();
-        break;
-      case UpdateUserOperationExecutor.SET_TAG:
-        operation = new SetTagOperation();
-        break;
-      case UpdateUserOperationExecutor.DELETE_TAG:
-        operation = new DeleteTagOperation();
-        break;
-      case UpdateUserOperationExecutor.SET_PROPERTY:
-        operation = new SetPropertyOperation();
-        break;
-      case UpdateUserOperationExecutor.TRACK_SESSION_START:
-        operation = new TrackSessionStartOperation();
-        break;
-      case UpdateUserOperationExecutor.TRACK_SESSION_END:
-        operation = new TrackSessionEndOperation();
-        break;
-      case UpdateUserOperationExecutor.TRACK_PURCHASE:
-        operation = new TrackPurchaseOperation();
-        break;
-      default:
-        throw new Error(`Unrecognized operation: ${operationName}`);
-    }
+    // TODO: add in executors in later prs
+    // switch (operationName) {
+    //   default:
+    //     throw new Error(`Unrecognized operation: ${operationName}`);
+    // }
 
     // populate the operation with the data
+    // @ts-expect-error - TODO: add in executors in later prs
     operation.initializeFromJson(jsonObject);
 
+    // @ts-expect-error - TODO: add in executors in later prs
     return operation;
   }
 
@@ -89,16 +47,20 @@ export class OperationModelStore extends ModelStore<Operation> {
    *
    * @param object The JSON object that represents an Operation
    */
-  private isValidOperation(object: Record<string, unknown>): boolean {
+  private isValidOperation(object: {
+    name?: string;
+    onesignalId?: string;
+  }): boolean {
     const operationName = object.name;
     if (!operationName) {
       Log.error("jsonObject must have 'name' attribute");
       return false;
     }
 
-    const excluded = new Set([
-      LoginUserOperationExecutor.LOGIN_USER,
-      LoginUserFromSubscriptionOperationExecutor.LOGIN_USER_FROM_SUBSCRIPTION_USER,
+    const excluded = new Set<string>([
+      // TODO: Add these back in once the executors are implemented
+      // LoginUserOperationExecutor.LOGIN_USER,
+      // LoginUserFromSubscriptionOperationExecutor.LOGIN_USER_FROM_SUBSCRIPTION_USER,
     ]);
 
     // Must have onesignalId if it is not one of the excluded operations above

--- a/src/core/modelRepo/OperationModelStore.ts
+++ b/src/core/modelRepo/OperationModelStore.ts
@@ -1,30 +1,7 @@
 import Log from 'src/shared/libraries/Log';
 import { IPreferencesService } from 'src/types/preferences';
 import { Operation } from '../operationRepo/Operation';
-// import { ModelStore } from '../../common/modeling/ModelStore';
-// import { CreateSubscriptionOperation } from '../../user/operations/CreateSubscriptionOperation';
-// import { DeleteAliasOperation } from '../../user/operations/DeleteAliasOperation';
-// import { DeleteSubscriptionOperation } from '../../user/operations/DeleteSubscriptionOperation';
-// import { DeleteTagOperation } from '../../user/operations/DeleteTagOperation';
-// import { IdentityOperationExecutor } from '../../user/operations/executors/IdentityOperationExecutor';
-// import { LoginUserFromSubscriptionOperationExecutor } from '../../user/operations/executors/LoginUserFromSubscriptionOperationExecutor';
-// import { LoginUserOperationExecutor } from '../../user/operations/executors/LoginUserOperationExecutor';
-// import { RefreshUserOperationExecutor } from '../../user/operations/executors/RefreshUserOperationExecutor';
-// import { SubscriptionOperationExecutor } from '../../user/operations/executors/SubscriptionOperationExecutor';
-// import { UpdateUserOperationExecutor } from '../../user/operations/executors/UpdateUserOperationExecutor';
-// import { LoginUserFromSubscriptionOperation } from '../../user/operations/LoginUserFromSubscriptionOperation';
-// import { LoginUserOperation } from '../../user/operations/LoginUserOperation';
-// import { RefreshUserOperation } from '../../user/operations/RefreshUserOperation';
-// import { SetAliasOperation } from '../../user/operations/SetAliasOperation';
-// import { SetPropertyOperation } from '../../user/operations/SetPropertyOperation';
-// import { SetTagOperation } from '../../user/operations/SetTagOperation';
-// import { TrackPurchaseOperation } from '../../user/operations/TrackPurchaseOperation';
-// import { TrackSessionEndOperation } from '../../user/operations/TrackSessionEndOperation';
-// import { TrackSessionStartOperation } from '../../user/operations/TrackSessionStartOperation';
-// import { TransferSubscriptionOperation } from '../../user/operations/TransferSubscriptionOperation';
-// import { UpdateSubscriptionOperation } from '../../user/operations/UpdateSubscriptionOperation';
-// import { Operation } from '../operations/Operation';
-// import { IPreferencesService } from '../preferences/IPreferencesService';
+import { ModelStore } from './ModelStore';
 
 export class OperationModelStore extends ModelStore<Operation> {
   constructor(prefs: IPreferencesService) {

--- a/src/core/modelRepo/OperationModelStore.ts
+++ b/src/core/modelRepo/OperationModelStore.ts
@@ -1,0 +1,137 @@
+import Log from 'src/shared/libraries/Log';
+import { IPreferencesService } from 'src/types/preferences';
+import { Operation } from '../operationRepo/Operation';
+// import { ModelStore } from '../../common/modeling/ModelStore';
+// import { CreateSubscriptionOperation } from '../../user/operations/CreateSubscriptionOperation';
+// import { DeleteAliasOperation } from '../../user/operations/DeleteAliasOperation';
+// import { DeleteSubscriptionOperation } from '../../user/operations/DeleteSubscriptionOperation';
+// import { DeleteTagOperation } from '../../user/operations/DeleteTagOperation';
+// import { IdentityOperationExecutor } from '../../user/operations/executors/IdentityOperationExecutor';
+// import { LoginUserFromSubscriptionOperationExecutor } from '../../user/operations/executors/LoginUserFromSubscriptionOperationExecutor';
+// import { LoginUserOperationExecutor } from '../../user/operations/executors/LoginUserOperationExecutor';
+// import { RefreshUserOperationExecutor } from '../../user/operations/executors/RefreshUserOperationExecutor';
+// import { SubscriptionOperationExecutor } from '../../user/operations/executors/SubscriptionOperationExecutor';
+// import { UpdateUserOperationExecutor } from '../../user/operations/executors/UpdateUserOperationExecutor';
+// import { LoginUserFromSubscriptionOperation } from '../../user/operations/LoginUserFromSubscriptionOperation';
+// import { LoginUserOperation } from '../../user/operations/LoginUserOperation';
+// import { RefreshUserOperation } from '../../user/operations/RefreshUserOperation';
+// import { SetAliasOperation } from '../../user/operations/SetAliasOperation';
+// import { SetPropertyOperation } from '../../user/operations/SetPropertyOperation';
+// import { SetTagOperation } from '../../user/operations/SetTagOperation';
+// import { TrackPurchaseOperation } from '../../user/operations/TrackPurchaseOperation';
+// import { TrackSessionEndOperation } from '../../user/operations/TrackSessionEndOperation';
+// import { TrackSessionStartOperation } from '../../user/operations/TrackSessionStartOperation';
+// import { TransferSubscriptionOperation } from '../../user/operations/TransferSubscriptionOperation';
+// import { UpdateSubscriptionOperation } from '../../user/operations/UpdateSubscriptionOperation';
+// import { Operation } from '../operations/Operation';
+// import { IPreferencesService } from '../preferences/IPreferencesService';
+
+export class OperationModelStore extends ModelStore<Operation> {
+  constructor(prefs: IPreferencesService) {
+    super('operations', prefs);
+  }
+
+  loadOperations(): void {
+    this.load();
+  }
+
+  protected create(jsonObject: Record<string, any> | null): Operation | null {
+    if (jsonObject === null) {
+      Logging.error('null jsonObject sent to OperationModelStore.create');
+      return null;
+    }
+
+    if (!this.isValidOperation(jsonObject)) {
+      return null;
+    }
+
+    // Determine the type of operation based on the name property in the json
+    let operation: Operation;
+    const operationName = jsonObject['name'];
+
+    switch (operationName) {
+      case IdentityOperationExecutor.SET_ALIAS:
+        operation = new SetAliasOperation();
+        break;
+      case IdentityOperationExecutor.DELETE_ALIAS:
+        operation = new DeleteAliasOperation();
+        break;
+      case SubscriptionOperationExecutor.CREATE_SUBSCRIPTION:
+        operation = new CreateSubscriptionOperation();
+        break;
+      case SubscriptionOperationExecutor.UPDATE_SUBSCRIPTION:
+        operation = new UpdateSubscriptionOperation();
+        break;
+      case SubscriptionOperationExecutor.DELETE_SUBSCRIPTION:
+        operation = new DeleteSubscriptionOperation();
+        break;
+      case SubscriptionOperationExecutor.TRANSFER_SUBSCRIPTION:
+        operation = new TransferSubscriptionOperation();
+        break;
+      case LoginUserOperationExecutor.LOGIN_USER:
+        operation = new LoginUserOperation();
+        break;
+      case LoginUserFromSubscriptionOperationExecutor.LOGIN_USER_FROM_SUBSCRIPTION_USER:
+        operation = new LoginUserFromSubscriptionOperation();
+        break;
+      case RefreshUserOperationExecutor.REFRESH_USER:
+        operation = new RefreshUserOperation();
+        break;
+      case UpdateUserOperationExecutor.SET_TAG:
+        operation = new SetTagOperation();
+        break;
+      case UpdateUserOperationExecutor.DELETE_TAG:
+        operation = new DeleteTagOperation();
+        break;
+      case UpdateUserOperationExecutor.SET_PROPERTY:
+        operation = new SetPropertyOperation();
+        break;
+      case UpdateUserOperationExecutor.TRACK_SESSION_START:
+        operation = new TrackSessionStartOperation();
+        break;
+      case UpdateUserOperationExecutor.TRACK_SESSION_END:
+        operation = new TrackSessionEndOperation();
+        break;
+      case UpdateUserOperationExecutor.TRACK_PURCHASE:
+        operation = new TrackPurchaseOperation();
+        break;
+      default:
+        throw new Error(`Unrecognized operation: ${operationName}`);
+    }
+
+    // populate the operation with the data
+    operation.initializeFromJson(jsonObject);
+
+    return operation;
+  }
+
+  /**
+   * Checks if a JSON object is a valid Operation. Contains a check for onesignalId.
+   * This is a rare case that a cached Operation is missing the onesignalId,
+   * which would continuously cause crashes when the Operation is processed.
+   *
+   * @param object The JSON object that represents an Operation
+   */
+  private isValidOperation(object: Record<string, unknown>): boolean {
+    const operationName = object.name;
+    if (!operationName) {
+      Log.error("jsonObject must have 'name' attribute");
+      return false;
+    }
+
+    const excluded = new Set([
+      LoginUserOperationExecutor.LOGIN_USER,
+      LoginUserFromSubscriptionOperationExecutor.LOGIN_USER_FROM_SUBSCRIPTION_USER,
+    ]);
+
+    // Must have onesignalId if it is not one of the excluded operations above
+    if (!object.onesignalId && !excluded.has(operationName)) {
+      Log.error(
+        `${operationName} jsonObject must have 'onesignalId' attribute`,
+      );
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/core/operationRepo/LegacyOperation.ts
+++ b/src/core/operationRepo/LegacyOperation.ts
@@ -1,0 +1,117 @@
+import OneSignalError from '../../shared/errors/OneSignalError';
+import Database from '../../shared/services/Database';
+import { OSModel } from '../modelRepo/OSModel';
+import { CoreChangeType } from '../models/CoreChangeType';
+import { CoreDelta } from '../models/CoreDeltas';
+import { ModelName, SupportedModel } from '../models/SupportedModels';
+import { isPropertyDelta, isPureObject } from '../utils/typePredicates';
+
+export class LegacyOperation<Model> {
+  operationId: string;
+  timestamp: number;
+  payload?: Partial<SupportedModel>;
+  model?: OSModel<Model>;
+  applyToRecordId?: string;
+  jwtTokenAvailable: Promise<void>;
+  jwtToken?: string | null;
+
+  constructor(
+    readonly changeType: CoreChangeType,
+    readonly modelName: ModelName,
+    deltas?: CoreDelta<Model>[],
+  ) {
+    this.operationId = Math.random().toString(36).substring(2);
+    this.payload = deltas ? this.getPayload(deltas) : undefined;
+    this.model = deltas ? deltas[deltas.length - 1].model : undefined;
+    this.applyToRecordId = deltas?.[deltas.length - 1]?.applyToRecordId;
+    this.timestamp = Date.now();
+    // eslint-disable-next-line no-async-promise-executor
+    this.jwtTokenAvailable = new Promise<void>(async (resolve) => {
+      this.jwtToken = await Database.getJWTToken();
+      resolve();
+    });
+  }
+
+  private getPayload(deltas: CoreDelta<Model>[]): any {
+    // for update operations, we send the aggregated property-level changes
+    if (isPropertyDelta(deltas[0])) {
+      return this.aggregateDeltas(deltas);
+    }
+
+    // for add and remove operations, we send the model data itself
+    return deltas[0].model.data;
+  }
+
+  private aggregateDeltas(deltas: CoreDelta<Model>[]): {
+    [key: string]: unknown;
+  } {
+    const result: { [key: string]: Record<string, unknown> } = {};
+
+    deltas.forEach((delta) => {
+      if (isPropertyDelta(delta)) {
+        /**
+         * If the delta is a property delta, we need to check if the property is an object.
+         * If the object has been previously set, we need to merge the new value with the old value.
+         * Example:
+         * 1. Initial value: { a: { b: 1 } }
+         * 2. Delta 1: { a: { b: 2 } }
+         * 3. Delta 2: { a: { c: 3 } }
+         * 4. Result: { a: { b: 2, c: 3 } }
+         */
+        // eslint-disable-next-line no-prototype-builtins
+        const hasExistingProperty = result.hasOwnProperty(delta.property);
+        const newValueIsPureObject = isPureObject(delta.newValue);
+        const oldValueIsPureObject = isPureObject(delta.oldValue);
+        const isNewAndOldCompatible =
+          newValueIsPureObject === oldValueIsPureObject ||
+          delta.oldValue === undefined;
+
+        if (!isNewAndOldCompatible) {
+          throw new Error('Cannot merge incompatible values');
+        }
+
+        const shouldMergeExistingAndNew =
+          hasExistingProperty && newValueIsPureObject;
+
+        const mergedObject = { ...result[delta.property], ...delta.newValue };
+
+        result[delta.property] = shouldMergeExistingAndNew
+          ? mergedObject
+          : delta.newValue;
+      }
+    });
+    return result;
+  }
+
+  static getInstanceWithModelReference(
+    rawOperation: LegacyOperation<SupportedModel>,
+  ): LegacyOperation<SupportedModel> | undefined {
+    const { operationId, payload, modelName, changeType, timestamp, model } =
+      rawOperation;
+    if (!model) {
+      throw new OneSignalError('Operation.fromJSON: model is undefined');
+    }
+    const osModel = OneSignal.coreDirector?.getModelByTypeAndId(
+      modelName,
+      model.modelId,
+    );
+
+    if (!!osModel) {
+      const operation = new LegacyOperation<SupportedModel>(
+        changeType,
+        modelName,
+      );
+      operation.model = osModel;
+      operation.operationId = operationId;
+      operation.timestamp = timestamp;
+      operation.payload = payload;
+      operation.jwtToken = rawOperation.jwtToken;
+      operation.jwtTokenAvailable = Promise.resolve();
+      return operation;
+    } else {
+      throw new Error(
+        `Could not find model with id ${model.modelId} of type ${modelName}. Maybe user logged out?`,
+      );
+    }
+  }
+}

--- a/src/core/operationRepo/Operation.ts
+++ b/src/core/operationRepo/Operation.ts
@@ -1,10 +1,13 @@
-import { Model } from '../modelRepo/Model';
+import { Model } from '../models/Model';
 
 export const GroupComparisonType = {
   CREATE: 0,
   ALTER: 1,
   NONE: 2,
 } as const;
+
+export type GroupComparisonValue =
+  (typeof GroupComparisonType)[keyof typeof GroupComparisonType];
 
 export abstract class Operation extends Model {
   constructor(name: string) {
@@ -42,7 +45,7 @@ export abstract class Operation extends Model {
    * The comparison type to use when this operation is the starting operation, in terms of
    * which operations can be grouped with it.
    */
-  abstract get groupComparisonType(): typeof GroupComparisonType;
+  abstract get groupComparisonType(): GroupComparisonValue;
 
   /**
    * Whether the operation can currently execute given its current state.

--- a/src/core/operationRepo/OperationRepo.ts
+++ b/src/core/operationRepo/OperationRepo.ts
@@ -2,7 +2,6 @@ import Log from 'src/shared/libraries/Log';
 import { delay } from 'src/shared/utils/utils';
 import {
   ExecutionResult,
-  GroupComparisonType,
   IOperationExecutor,
   IOperationRepo,
   IStartableService,
@@ -10,12 +9,13 @@ import {
   OperationModelStore,
 } from 'src/types/operation';
 import { v4 as uuid } from 'uuid';
-import { type NewRecordsState } from './NewRecordsState';
 import {
   OP_REPO_DEFAULT_FAIL_RETRY_BACKOFF,
   OP_REPO_EXECUTION_INTERVAL,
   OP_REPO_POST_CREATE_DELAY,
 } from './constants';
+import { type NewRecordsState } from './NewRecordsState';
+import { GroupComparisonType } from './Operation';
 
 // Implements logic similar to Android SDK's OperationRepo & OperationQueueItem
 // Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationRepo.kt
@@ -269,11 +269,11 @@ export class OperationRepo implements IOperationRepo, IStartableService {
   ): OperationQueueItem[] {
     const ops = [startingOp];
 
-    if (startingOp.operation.groupComparisonType === GroupComparisonType.None)
+    if (startingOp.operation.groupComparisonType === GroupComparisonType.NONE)
       return ops;
 
     const startingKey =
-      startingOp.operation.groupComparisonType === GroupComparisonType.Create
+      startingOp.operation.groupComparisonType === GroupComparisonType.CREATE
         ? startingOp.operation.createComparisonKey
         : startingOp.operation.modifyComparisonKey;
 
@@ -282,7 +282,7 @@ export class OperationRepo implements IOperationRepo, IStartableService {
 
     for (const item of queueCopy) {
       const itemKey =
-        startingOp.operation.groupComparisonType === GroupComparisonType.Create
+        startingOp.operation.groupComparisonType === GroupComparisonType.CREATE
           ? item.operation.createComparisonKey
           : item.operation.modifyComparisonKey;
 

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -47,12 +47,12 @@ export interface IModelStore<TModel extends Model>
    * Add a model to the store.
    */
   add(model: TModel, tag?: string): void;
-  add(index: number, model: TModel, tag?: string): void;
+  addAt(index: number, model: TModel, tag?: string): void;
 
   /**
    * Get a model by id.
    */
-  get(id: string): TModel | null;
+  get(id: string): TModel | undefined;
 
   /**
    * Remove a model by id.

--- a/src/types/operation.ts
+++ b/src/types/operation.ts
@@ -1,10 +1,4 @@
 // Enums
-export enum GroupComparisonType {
-  Create,
-  Alter,
-  None,
-}
-
 export enum ExecutionResult {
   /**
    * The operation was executed successfully.

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -15,7 +15,7 @@ export interface IPreferencesService {
    *
    * @return the value in the preference store, or defValue if not previously saved.
    */
-  getValue<T>(store: string, key: string, defValue?: T | null): T | null;
+  getValue<T = unknown | null>(store: string, key: string, defValue?: T): T;
 
   /**
    * Save a value identified by the store and key provided.


### PR DESCRIPTION
# Description
Continuation of the [Web SDK Refactor project](https://docs.google.com/document/d/1JsbmxVM_n6K9nRXwbJf6mQr5h88qy_vIEiBGY0Ub_lE/edit?tab=t.0#heading=h.ojv84gskof17). This pr is focuses on porting the follow classes/types from the Android SDK: [ModelStore](https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt) , [OperationModelStore](https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/impl/OperationModelStore.kt)

## Details
- adds ModelStore class
- adds new addAt to ModelStore since cant have overloading for [add method](https://github.com/OneSignal/OneSignal-Android-SDK/blob/5249d8d78bbec6fb783f3f377bea29a55fabb797/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/ModelStore.kt#L55)
- adds OperationModelStore class but comment out the case options for the create method
- name old Operation to LegacyOperation

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1269)
<!-- Reviewable:end -->
