### PR TITLE
Web SDK Refactor: Add More Operations

### DIFF
--- a/src/core/executors/constants.ts
+++ b/src/core/executors/constants.ts
@@ -1,4 +1,10 @@
 export const OPERATION_NAME = {
   SET_ALIAS: 'set-alias',
   DELETE_ALIAS: 'delete-alias',
+  SET_TAG: 'set-tag',
+  DELETE_TAG: 'delete-tag',
+  SET_PROPERTY: 'set-property',
+  TRACK_SESSION_START: 'track-session-start',
+  TRACK_SESSION_END: 'track-session-end',
+  TRACK_PURCHASE: 'track-purchase',
 } as const;

--- a/src/core/executors/constants.ts
+++ b/src/core/executors/constants.ts
@@ -6,5 +6,5 @@ export const OPERATION_NAME = {
   SET_PROPERTY: 'set-property',
   TRACK_SESSION_START: 'track-session-start',
   TRACK_SESSION_END: 'track-session-end',
-  TRACK_PURCHASE: 'track-purchase',
+  REFRESH_USER: 'refresh-user',
 } as const;

--- a/src/core/modelRepo/OperationModelStore.ts
+++ b/src/core/modelRepo/OperationModelStore.ts
@@ -5,6 +5,7 @@ import { DeleteAliasOperation } from '../operations/DeleteAliasOperation';
 import { DeleteTagOperation } from '../operations/DeleteTagOperation';
 import { Operation } from '../operations/Operation';
 import { SetAliasOperation } from '../operations/SetAliasOperation';
+import { SetPropertyOperation } from '../operations/SetPropertyOperation';
 import { SetTagOperation } from '../operations/SetTagOperation';
 import { ModelStore } from './ModelStore';
 
@@ -43,6 +44,9 @@ export class OperationModelStore extends ModelStore<Operation> {
         break;
       case OPERATION_NAME.DELETE_TAG:
         operation = new DeleteTagOperation();
+        break;
+      case OPERATION_NAME.SET_PROPERTY:
+        operation = new SetPropertyOperation();
         break;
       default:
         throw new Error(`Unrecognized operation: ${operationName}`);

--- a/src/core/modelRepo/OperationModelStore.ts
+++ b/src/core/modelRepo/OperationModelStore.ts
@@ -4,6 +4,7 @@ import { OPERATION_NAME } from '../executors/constants';
 import { DeleteAliasOperation } from '../operations/DeleteAliasOperation';
 import { DeleteTagOperation } from '../operations/DeleteTagOperation';
 import { Operation } from '../operations/Operation';
+import { RefreshUserOperation } from '../operations/RefreshUserOperation';
 import { SetAliasOperation } from '../operations/SetAliasOperation';
 import { SetPropertyOperation } from '../operations/SetPropertyOperation';
 import { SetTagOperation } from '../operations/SetTagOperation';
@@ -40,6 +41,9 @@ export class OperationModelStore extends ModelStore<Operation> {
         break;
       case OPERATION_NAME.DELETE_ALIAS:
         operation = new DeleteAliasOperation();
+        break;
+      case OPERATION_NAME.REFRESH_USER:
+        operation = new RefreshUserOperation();
         break;
       case OPERATION_NAME.SET_TAG:
         operation = new SetTagOperation();

--- a/src/core/modelRepo/OperationModelStore.ts
+++ b/src/core/modelRepo/OperationModelStore.ts
@@ -2,6 +2,7 @@ import Log from 'src/shared/libraries/Log';
 import { IPreferencesService } from 'src/types/preferences';
 import { OPERATION_NAME } from '../executors/constants';
 import { DeleteAliasOperation } from '../operations/DeleteAliasOperation';
+import { DeleteTagOperation } from '../operations/DeleteTagOperation';
 import { Operation } from '../operations/Operation';
 import { SetAliasOperation } from '../operations/SetAliasOperation';
 import { SetTagOperation } from '../operations/SetTagOperation';
@@ -39,6 +40,9 @@ export class OperationModelStore extends ModelStore<Operation> {
         break;
       case OPERATION_NAME.SET_TAG:
         operation = new SetTagOperation();
+        break;
+      case OPERATION_NAME.DELETE_TAG:
+        operation = new DeleteTagOperation();
         break;
       default:
         throw new Error(`Unrecognized operation: ${operationName}`);

--- a/src/core/modelRepo/OperationModelStore.ts
+++ b/src/core/modelRepo/OperationModelStore.ts
@@ -4,6 +4,7 @@ import { OPERATION_NAME } from '../executors/constants';
 import { DeleteAliasOperation } from '../operations/DeleteAliasOperation';
 import { Operation } from '../operations/Operation';
 import { SetAliasOperation } from '../operations/SetAliasOperation';
+import { SetTagOperation } from '../operations/SetTagOperation';
 import { ModelStore } from './ModelStore';
 
 export class OperationModelStore extends ModelStore<Operation> {
@@ -35,6 +36,9 @@ export class OperationModelStore extends ModelStore<Operation> {
         break;
       case OPERATION_NAME.DELETE_ALIAS:
         operation = new DeleteAliasOperation();
+        break;
+      case OPERATION_NAME.SET_TAG:
+        operation = new SetTagOperation();
         break;
       default:
         throw new Error(`Unrecognized operation: ${operationName}`);

--- a/src/core/modelRepo/OperationModelStore.ts
+++ b/src/core/modelRepo/OperationModelStore.ts
@@ -7,6 +7,7 @@ import { Operation } from '../operations/Operation';
 import { SetAliasOperation } from '../operations/SetAliasOperation';
 import { SetPropertyOperation } from '../operations/SetPropertyOperation';
 import { SetTagOperation } from '../operations/SetTagOperation';
+import { TrackSessionStartOperation } from '../operations/TrackSessionStartOperation';
 import { ModelStore } from './ModelStore';
 
 export class OperationModelStore extends ModelStore<Operation> {
@@ -47,6 +48,9 @@ export class OperationModelStore extends ModelStore<Operation> {
         break;
       case OPERATION_NAME.SET_PROPERTY:
         operation = new SetPropertyOperation();
+        break;
+      case OPERATION_NAME.TRACK_SESSION_START:
+        operation = new TrackSessionStartOperation();
         break;
       default:
         throw new Error(`Unrecognized operation: ${operationName}`);

--- a/src/core/modelRepo/OperationModelStore.ts
+++ b/src/core/modelRepo/OperationModelStore.ts
@@ -7,6 +7,7 @@ import { Operation } from '../operations/Operation';
 import { SetAliasOperation } from '../operations/SetAliasOperation';
 import { SetPropertyOperation } from '../operations/SetPropertyOperation';
 import { SetTagOperation } from '../operations/SetTagOperation';
+import { TrackSessionEndOperation } from '../operations/TrackSessionEndOperation';
 import { TrackSessionStartOperation } from '../operations/TrackSessionStartOperation';
 import { ModelStore } from './ModelStore';
 
@@ -51,6 +52,9 @@ export class OperationModelStore extends ModelStore<Operation> {
         break;
       case OPERATION_NAME.TRACK_SESSION_START:
         operation = new TrackSessionStartOperation();
+        break;
+      case OPERATION_NAME.TRACK_SESSION_END:
+        operation = new TrackSessionEndOperation();
         break;
       default:
         throw new Error(`Unrecognized operation: ${operationName}`);

--- a/src/core/operations/DeleteTagOperation.ts
+++ b/src/core/operations/DeleteTagOperation.ts
@@ -1,0 +1,77 @@
+import { IDManager } from 'src/shared/managers/IDManager';
+import { OPERATION_NAME } from '../executors/constants';
+import {
+  GroupComparisonType,
+  GroupComparisonValue,
+  Operation,
+} from './Operation';
+
+/**
+ * An Operation to delete a tag from the OneSignal backend. The tag will
+ * be associated to the user with the appId and onesignalId provided.
+ */
+export class DeleteTagOperation extends Operation {
+  constructor();
+  constructor(appId: string, onesignalId: string, key: string);
+  constructor(appId?: string, onesignalId?: string, key?: string) {
+    super(OPERATION_NAME.DELETE_TAG);
+    if (appId && onesignalId && key) {
+      this.appId = appId;
+      this.onesignalId = onesignalId;
+      this.key = key;
+    }
+  }
+
+  /**
+   * The application ID this subscription will be created under.
+   */
+  get appId(): string {
+    return this.getProperty<string>('appId');
+  }
+  private set appId(value: string) {
+    this.setProperty<string>('appId', value);
+  }
+
+  get onesignalId(): string {
+    return this.getProperty<string>('onesignalId');
+  }
+  private set onesignalId(value: string) {
+    this.setProperty<string>('onesignalId', value);
+  }
+
+  /**
+   * The tag key to delete.
+   */
+  get key(): string {
+    return this.getProperty<string>('key');
+  }
+  private set key(value: string) {
+    this.setProperty<string>('key', value);
+  }
+
+  override get createComparisonKey(): string {
+    return '';
+  }
+
+  override get modifyComparisonKey(): string {
+    return `${this.appId}.User.${this.onesignalId}`;
+  }
+
+  override get groupComparisonType(): GroupComparisonValue {
+    return GroupComparisonType.ALTER;
+  }
+
+  override get canStartExecute(): boolean {
+    return !IDManager.isLocalId(this.onesignalId);
+  }
+
+  override get applyToRecordId(): string {
+    return this.onesignalId;
+  }
+
+  override translateIds(map: Record<string, string>): void {
+    if (map[this.onesignalId]) {
+      this.onesignalId = map[this.onesignalId];
+    }
+  }
+}

--- a/src/core/operations/RefreshUserOperation.ts
+++ b/src/core/operations/RefreshUserOperation.ts
@@ -8,22 +8,22 @@ import {
 } from './Operation';
 
 /**
- * An Operation to track the ending of a session, related to a specific user.
+ * An Operation to retrieve a user from the OneSignal backend. The resulting user
+ * will replace the current user.
  */
-export class TrackSessionEndOperation extends Operation {
+export class RefreshUserOperation extends Operation {
   constructor();
-  constructor(appId: string, onesignalId: string, sessionTime: number);
-  constructor(appId?: string, onesignalId?: string, sessionTime?: number) {
-    super(OPERATION_NAME.TRACK_SESSION_END);
-    if (appId && onesignalId && sessionTime) {
+  constructor(appId: string, onesignalId: string);
+  constructor(appId?: string, onesignalId?: string) {
+    super(OPERATION_NAME.REFRESH_USER);
+    if (appId && onesignalId) {
       this.appId = appId;
       this.onesignalId = onesignalId;
-      this.sessionTime = sessionTime;
     }
   }
 
   /**
-   * The OneSignal appId the session was captured under.
+   * The application ID this subscription will be created under.
    */
   get appId(): string {
     return this.getProperty<string>('appId');
@@ -33,7 +33,7 @@ export class TrackSessionEndOperation extends Operation {
   }
 
   /**
-   * The OneSignal ID driving the session. This ID *may* be locally generated
+   * The user ID this subscription will be associated with. This ID *may* be locally generated
    * and can be checked via IDManager.isLocalId to ensure correct processing.
    */
   get onesignalId(): string {
@@ -43,26 +43,16 @@ export class TrackSessionEndOperation extends Operation {
     this.setProperty<string>('onesignalId', value);
   }
 
-  /**
-   * The amount of active time for the session, in milliseconds.
-   */
-  get sessionTime(): number {
-    return this.getProperty<number>('sessionTime');
-  }
-  private set sessionTime(value: number) {
-    this.setProperty<number>('sessionTime', value);
-  }
-
   override get createComparisonKey(): string {
-    return '';
+    return `${this.appId}.User.${this.onesignalId}.Refresh`;
   }
 
   override get modifyComparisonKey(): string {
-    return `${this.appId}.User.${this.onesignalId}`;
+    return `${this.appId}.User.${this.onesignalId}.Refresh`;
   }
 
   override get groupComparisonType(): GroupComparisonValue {
-    return GroupComparisonType.ALTER;
+    return GroupComparisonType.CREATE;
   }
 
   override get canStartExecute(): boolean {

--- a/src/core/operations/SetPropertyOperation.ts
+++ b/src/core/operations/SetPropertyOperation.ts
@@ -1,0 +1,98 @@
+import { IDManager } from 'src/shared/managers/IDManager';
+import { OPERATION_NAME } from '../executors/constants';
+
+import {
+  GroupComparisonType,
+  GroupComparisonValue,
+  Operation,
+} from './Operation';
+
+/**
+ * An Operation to update a property related to a specific user.
+ */
+export class SetPropertyOperation extends Operation {
+  constructor();
+  constructor(
+    appId: string,
+    onesignalId: string,
+    property: string,
+    value: unknown,
+  );
+  constructor(
+    appId?: string,
+    onesignalId?: string,
+    property?: string,
+    value?: unknown,
+  ) {
+    super(OPERATION_NAME.SET_PROPERTY);
+    if (appId && onesignalId && property) {
+      this.appId = appId;
+      this.onesignalId = onesignalId;
+      this.property = property;
+      this.value = value;
+    }
+  }
+
+  /**
+   * The OneSignal appId the purchase was captured under.
+   */
+  get appId(): string {
+    return this.getProperty<string>('appId');
+  }
+  private set appId(value: string) {
+    this.setProperty<string>('appId', value);
+  }
+
+  get onesignalId(): string {
+    return this.getProperty<string>('onesignalId');
+  }
+  private set onesignalId(value: string) {
+    this.setProperty<string>('onesignalId', value);
+  }
+
+  /**
+   * The property that is to be updated against the user.
+   */
+  get property(): string {
+    return this.getProperty<string>('property');
+  }
+  private set property(value: string) {
+    this.setProperty<string>('property', value);
+  }
+
+  /**
+   * The value of that property to update it to.
+   */
+  get value(): unknown {
+    return this.getProperty<unknown>('value');
+  }
+  private set value(value: unknown) {
+    this.setProperty<unknown>('value', value);
+  }
+
+  override get createComparisonKey(): string {
+    return '';
+  }
+
+  override get modifyComparisonKey(): string {
+    return `${this.appId}.User.${this.onesignalId}`;
+  }
+
+  override get groupComparisonType(): GroupComparisonValue {
+    return GroupComparisonType.ALTER;
+  }
+
+  override get canStartExecute(): boolean {
+    return !IDManager.isLocalId(this.onesignalId);
+  }
+
+  override get applyToRecordId(): string {
+    return this.onesignalId;
+  }
+
+  override translateIds(map: Record<string, string>): void {
+    if (map[this.onesignalId]) {
+      this.onesignalId = map[this.onesignalId];
+    }
+  }
+}

--- a/src/core/operations/SetTagOperation.ts
+++ b/src/core/operations/SetTagOperation.ts
@@ -1,0 +1,94 @@
+import { IDManager } from 'src/shared/managers/IDManager';
+import { OPERATION_NAME } from '../executors/constants';
+
+import {
+  GroupComparisonType,
+  GroupComparisonValue,
+  Operation,
+} from './Operation';
+
+/**
+ * An Operation to create/update a tag in the OneSignal backend. The tag will
+ * be associated to the user with the appId and onesignalId provided.
+ */
+export class SetTagOperation extends Operation {
+  constructor();
+  constructor(appId: string, onesignalId: string, key: string, value: string);
+  constructor(
+    appId?: string,
+    onesignalId?: string,
+    key?: string,
+    value?: string,
+  ) {
+    super(OPERATION_NAME.SET_TAG);
+    if (appId && onesignalId && key && value) {
+      this.appId = appId;
+      this.onesignalId = onesignalId;
+      this.key = key;
+      this.value = value;
+    }
+  }
+
+  /**
+   * The application ID this subscription will be created under.
+   */
+  get appId(): string {
+    return this.getProperty<string>('appId');
+  }
+  private set appId(value: string) {
+    this.setProperty<string>('appId', value);
+  }
+
+  get onesignalId(): string {
+    return this.getProperty<string>('onesignalId');
+  }
+  private set onesignalId(value: string) {
+    this.setProperty<string>('onesignalId', value);
+  }
+
+  /**
+   * The tag key.
+   */
+  get key(): string {
+    return this.getProperty<string>('key');
+  }
+  private set key(value: string) {
+    this.setProperty<string>('key', value);
+  }
+
+  /**
+   * The new/updated tag value.
+   */
+  get value(): string {
+    return this.getProperty<string>('value');
+  }
+  private set value(value: string) {
+    this.setProperty<string>('value', value);
+  }
+
+  override get createComparisonKey(): string {
+    return '';
+  }
+
+  override get modifyComparisonKey(): string {
+    return `${this.appId}.User.${this.onesignalId}`;
+  }
+
+  override get groupComparisonType(): GroupComparisonValue {
+    return GroupComparisonType.ALTER;
+  }
+
+  override get canStartExecute(): boolean {
+    return !IDManager.isLocalId(this.onesignalId);
+  }
+
+  override get applyToRecordId(): string {
+    return this.onesignalId;
+  }
+
+  override translateIds(map: Record<string, string>): void {
+    if (map[this.onesignalId]) {
+      this.onesignalId = map[this.onesignalId];
+    }
+  }
+}

--- a/src/core/operations/TrackSessionEndOperation.ts
+++ b/src/core/operations/TrackSessionEndOperation.ts
@@ -1,0 +1,81 @@
+import { IDManager } from 'src/shared/managers/IDManager';
+import { OPERATION_NAME } from '../executors/constants';
+
+import {
+  GroupComparisonType,
+  GroupComparisonValue,
+  Operation,
+} from './Operation';
+
+/**
+ * An Operation to track the ending of a session, related to a specific user.
+ */
+export class TrackSessionEndOperation extends Operation {
+  constructor();
+  constructor(appId: string, onesignalId: string, sessionTime: number);
+  constructor(appId?: string, onesignalId?: string, sessionTime?: number) {
+    super(OPERATION_NAME.TRACK_SESSION_END);
+    if (appId && onesignalId && sessionTime !== undefined) {
+      this.appId = appId;
+      this.onesignalId = onesignalId;
+      this.sessionTime = sessionTime;
+    }
+  }
+
+  /**
+   * The OneSignal appId the session was captured under.
+   */
+  get appId(): string {
+    return this.getProperty<string>('appId');
+  }
+  private set appId(value: string) {
+    this.setProperty<string>('appId', value);
+  }
+
+  /**
+   * The OneSignal ID driving the session. This ID *may* be locally generated
+   * and can be checked via IDManager.isLocalId to ensure correct processing.
+   */
+  get onesignalId(): string {
+    return this.getProperty<string>('onesignalId');
+  }
+  private set onesignalId(value: string) {
+    this.setProperty<string>('onesignalId', value);
+  }
+
+  /**
+   * The amount of active time for the session, in milliseconds.
+   */
+  get sessionTime(): number {
+    return this.getProperty<number>('sessionTime');
+  }
+  private set sessionTime(value: number) {
+    this.setProperty<number>('sessionTime', value);
+  }
+
+  override get createComparisonKey(): string {
+    return '';
+  }
+
+  override get modifyComparisonKey(): string {
+    return `${this.appId}.User.${this.onesignalId}`;
+  }
+
+  override get groupComparisonType(): GroupComparisonValue {
+    return GroupComparisonType.ALTER;
+  }
+
+  override get canStartExecute(): boolean {
+    return !IDManager.isLocalId(this.onesignalId);
+  }
+
+  override get applyToRecordId(): string {
+    return this.onesignalId;
+  }
+
+  override translateIds(map: Record<string, string>): void {
+    if (map[this.onesignalId]) {
+      this.onesignalId = map[this.onesignalId];
+    }
+  }
+}

--- a/src/core/operations/TrackSessionStartOperation.ts
+++ b/src/core/operations/TrackSessionStartOperation.ts
@@ -1,0 +1,69 @@
+import { IDManager } from 'src/shared/managers/IDManager';
+import { OPERATION_NAME } from '../executors/constants';
+import {
+  GroupComparisonType,
+  GroupComparisonValue,
+  Operation,
+} from './Operation';
+
+/**
+ * An Operation to track the starting of a session, related to a specific user.
+ */
+export class TrackSessionStartOperation extends Operation {
+  constructor();
+  constructor(appId: string, onesignalId: string);
+  constructor(appId?: string, onesignalId?: string) {
+    super(OPERATION_NAME.TRACK_SESSION_START);
+    if (appId && onesignalId) {
+      this.appId = appId;
+      this.onesignalId = onesignalId;
+    }
+  }
+
+  /**
+   * The OneSignal appId the session was captured under.
+   */
+  get appId(): string {
+    return this.getProperty<string>('appId');
+  }
+  private set appId(value: string) {
+    this.setProperty<string>('appId', value);
+  }
+
+  /**
+   * The OneSignal ID driving the session. This ID *may* be locally generated
+   * and can be checked via IDManager.isLocalId to ensure correct processing.
+   */
+  get onesignalId(): string {
+    return this.getProperty<string>('onesignalId');
+  }
+  private set onesignalId(value: string) {
+    this.setProperty<string>('onesignalId', value);
+  }
+
+  override get createComparisonKey(): string {
+    return '';
+  }
+
+  override get modifyComparisonKey(): string {
+    return `${this.appId}.User.${this.onesignalId}`;
+  }
+
+  override get groupComparisonType(): GroupComparisonValue {
+    return GroupComparisonType.ALTER;
+  }
+
+  override get canStartExecute(): boolean {
+    return !IDManager.isLocalId(this.onesignalId);
+  }
+
+  override get applyToRecordId(): string {
+    return this.onesignalId;
+  }
+
+  override translateIds(map: Record<string, string>): void {
+    if (map[this.onesignalId]) {
+      this.onesignalId = map[this.onesignalId];
+    }
+  }
+}


### PR DESCRIPTION
# Description
## 1 Line Summary

## Details

# Systems Affected
   - [ ] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---
