### PR TITLE
Web SDK Refactor: Add CreateSubscriptionOperation Class

### DIFF
--- a/src/core/executors/constants.ts
+++ b/src/core/executors/constants.ts
@@ -1,10 +1,25 @@
 export const OPERATION_NAME = {
+  // Identity Operations
   SET_ALIAS: 'set-alias',
   DELETE_ALIAS: 'delete-alias',
+
+  // Tag Operations
   SET_TAG: 'set-tag',
   DELETE_TAG: 'delete-tag',
+
+  // Property Operations
   SET_PROPERTY: 'set-property',
+
+  // Session Operations
   TRACK_SESSION_START: 'track-session-start',
   TRACK_SESSION_END: 'track-session-end',
+
+  // User Operations
   REFRESH_USER: 'refresh-user',
+
+  // Subscription Operations
+  CREATE_SUBSCRIPTION: 'create-subscription',
+  UPDATE_SUBSCRIPTION: 'update-subscription',
+  DELETE_SUBSCRIPTION: 'delete-subscription',
+  TRANSFER_SUBSCRIPTION: 'transfer-subscription',
 } as const;

--- a/src/core/modelRepo/OperationModelStore.ts
+++ b/src/core/modelRepo/OperationModelStore.ts
@@ -1,6 +1,7 @@
 import Log from 'src/shared/libraries/Log';
 import { IPreferencesService } from 'src/types/preferences';
 import { OPERATION_NAME } from '../executors/constants';
+import { CreateSubscriptionOperation } from '../operations/CreateSubscriptionOperation';
 import { DeleteAliasOperation } from '../operations/DeleteAliasOperation';
 import { DeleteTagOperation } from '../operations/DeleteTagOperation';
 import { Operation } from '../operations/Operation';
@@ -11,7 +12,6 @@ import { SetTagOperation } from '../operations/SetTagOperation';
 import { TrackSessionEndOperation } from '../operations/TrackSessionEndOperation';
 import { TrackSessionStartOperation } from '../operations/TrackSessionStartOperation';
 import { ModelStore } from './ModelStore';
-
 export class OperationModelStore extends ModelStore<Operation> {
   constructor(prefs: IPreferencesService) {
     super('operations', prefs);
@@ -41,6 +41,9 @@ export class OperationModelStore extends ModelStore<Operation> {
         break;
       case OPERATION_NAME.DELETE_ALIAS:
         operation = new DeleteAliasOperation();
+        break;
+      case OPERATION_NAME.CREATE_SUBSCRIPTION:
+        operation = new CreateSubscriptionOperation();
         break;
       case OPERATION_NAME.REFRESH_USER:
         operation = new RefreshUserOperation();

--- a/src/core/operations/BaseAliasOperation.ts
+++ b/src/core/operations/BaseAliasOperation.ts
@@ -1,4 +1,3 @@
-import { IDManager } from 'src/shared/managers/IDManager';
 import { GroupComparisonValue, Operation } from './Operation';
 
 /**
@@ -11,26 +10,10 @@ export abstract class BaseAliasOperation extends Operation {
     onesignalId?: string,
     label?: string,
   ) {
-    super(operationName);
-    if (appId && onesignalId && label) {
-      this.appId = appId;
-      this.onesignalId = onesignalId;
+    super(operationName, appId, onesignalId);
+    if (label) {
       this.label = label;
     }
-  }
-
-  get appId(): string {
-    return this.getProperty<string>('appId');
-  }
-  protected set appId(value: string) {
-    this.setProperty<string>('appId', value);
-  }
-
-  get onesignalId(): string {
-    return this.getProperty<string>('onesignalId');
-  }
-  protected set onesignalId(value: string) {
-    this.setProperty<string>('onesignalId', value);
   }
 
   get label(): string {
@@ -40,25 +23,7 @@ export abstract class BaseAliasOperation extends Operation {
     this.setProperty<string>('label', value);
   }
 
-  override get createComparisonKey(): string {
-    return '';
-  }
-
   abstract override get modifyComparisonKey(): string;
 
   abstract override get groupComparisonType(): GroupComparisonValue;
-
-  override get canStartExecute(): boolean {
-    return !IDManager.isLocalId(this.onesignalId);
-  }
-
-  override get applyToRecordId(): string {
-    return this.onesignalId;
-  }
-
-  override translateIds(map: Record<string, string>): void {
-    if (map[this.onesignalId]) {
-      this.onesignalId = map[this.onesignalId];
-    }
-  }
 }

--- a/src/core/operations/BaseAliasOperation.ts
+++ b/src/core/operations/BaseAliasOperation.ts
@@ -1,0 +1,64 @@
+import { IDManager } from 'src/shared/managers/IDManager';
+import { GroupComparisonValue, Operation } from './Operation';
+
+/**
+ * Base class for alias-related operations
+ */
+export abstract class BaseAliasOperation extends Operation {
+  constructor(
+    operationName: string,
+    appId?: string,
+    onesignalId?: string,
+    label?: string,
+  ) {
+    super(operationName);
+    if (appId && onesignalId && label) {
+      this.appId = appId;
+      this.onesignalId = onesignalId;
+      this.label = label;
+    }
+  }
+
+  get appId(): string {
+    return this.getProperty<string>('appId');
+  }
+  protected set appId(value: string) {
+    this.setProperty<string>('appId', value);
+  }
+
+  get onesignalId(): string {
+    return this.getProperty<string>('onesignalId');
+  }
+  protected set onesignalId(value: string) {
+    this.setProperty<string>('onesignalId', value);
+  }
+
+  get label(): string {
+    return this.getProperty<string>('label');
+  }
+  protected set label(value: string) {
+    this.setProperty<string>('label', value);
+  }
+
+  override get createComparisonKey(): string {
+    return '';
+  }
+
+  abstract override get modifyComparisonKey(): string;
+
+  abstract override get groupComparisonType(): GroupComparisonValue;
+
+  override get canStartExecute(): boolean {
+    return !IDManager.isLocalId(this.onesignalId);
+  }
+
+  override get applyToRecordId(): string {
+    return this.onesignalId;
+  }
+
+  override translateIds(map: Record<string, string>): void {
+    if (map[this.onesignalId]) {
+      this.onesignalId = map[this.onesignalId];
+    }
+  }
+}

--- a/src/core/operations/BaseTagOperation.ts
+++ b/src/core/operations/BaseTagOperation.ts
@@ -1,0 +1,78 @@
+import { IDManager } from 'src/shared/managers/IDManager';
+import {
+  GroupComparisonType,
+  GroupComparisonValue,
+  Operation,
+} from './Operation';
+
+/**
+ * Base class for tag-related operations
+ */
+export abstract class BaseTagOperation extends Operation {
+  constructor(
+    operationName: string,
+    appId?: string,
+    onesignalId?: string,
+    key?: string,
+  ) {
+    super(operationName);
+    if (appId && onesignalId && key) {
+      this.appId = appId;
+      this.onesignalId = onesignalId;
+      this.key = key;
+    }
+  }
+
+  /**
+   * The application ID this subscription will be created under.
+   */
+  get appId(): string {
+    return this.getProperty<string>('appId');
+  }
+  protected set appId(value: string) {
+    this.setProperty<string>('appId', value);
+  }
+
+  get onesignalId(): string {
+    return this.getProperty<string>('onesignalId');
+  }
+  protected set onesignalId(value: string) {
+    this.setProperty<string>('onesignalId', value);
+  }
+
+  /**
+   * The tag key.
+   */
+  get key(): string {
+    return this.getProperty<string>('key');
+  }
+  protected set key(value: string) {
+    this.setProperty<string>('key', value);
+  }
+
+  override get createComparisonKey(): string {
+    return '';
+  }
+
+  override get modifyComparisonKey(): string {
+    return `${this.appId}.User.${this.onesignalId}`;
+  }
+
+  override get groupComparisonType(): GroupComparisonValue {
+    return GroupComparisonType.ALTER;
+  }
+
+  override get canStartExecute(): boolean {
+    return !IDManager.isLocalId(this.onesignalId);
+  }
+
+  override get applyToRecordId(): string {
+    return this.onesignalId;
+  }
+
+  override translateIds(map: Record<string, string>): void {
+    if (map[this.onesignalId]) {
+      this.onesignalId = map[this.onesignalId];
+    }
+  }
+}

--- a/src/core/operations/BaseTagOperation.ts
+++ b/src/core/operations/BaseTagOperation.ts
@@ -1,4 +1,3 @@
-import { IDManager } from 'src/shared/managers/IDManager';
 import {
   GroupComparisonType,
   GroupComparisonValue,
@@ -15,29 +14,10 @@ export abstract class BaseTagOperation extends Operation {
     onesignalId?: string,
     key?: string,
   ) {
-    super(operationName);
-    if (appId && onesignalId && key) {
-      this.appId = appId;
-      this.onesignalId = onesignalId;
+    super(operationName, appId, onesignalId);
+    if (key) {
       this.key = key;
     }
-  }
-
-  /**
-   * The application ID this subscription will be created under.
-   */
-  get appId(): string {
-    return this.getProperty<string>('appId');
-  }
-  protected set appId(value: string) {
-    this.setProperty<string>('appId', value);
-  }
-
-  get onesignalId(): string {
-    return this.getProperty<string>('onesignalId');
-  }
-  protected set onesignalId(value: string) {
-    this.setProperty<string>('onesignalId', value);
   }
 
   /**
@@ -50,29 +30,11 @@ export abstract class BaseTagOperation extends Operation {
     this.setProperty<string>('key', value);
   }
 
-  override get createComparisonKey(): string {
-    return '';
-  }
-
   override get modifyComparisonKey(): string {
     return `${this.appId}.User.${this.onesignalId}`;
   }
 
   override get groupComparisonType(): GroupComparisonValue {
     return GroupComparisonType.ALTER;
-  }
-
-  override get canStartExecute(): boolean {
-    return !IDManager.isLocalId(this.onesignalId);
-  }
-
-  override get applyToRecordId(): string {
-    return this.onesignalId;
-  }
-
-  override translateIds(map: Record<string, string>): void {
-    if (map[this.onesignalId]) {
-      this.onesignalId = map[this.onesignalId];
-    }
   }
 }

--- a/src/core/operations/BaseTagOperation.ts
+++ b/src/core/operations/BaseTagOperation.ts
@@ -1,8 +1,4 @@
-import {
-  GroupComparisonType,
-  GroupComparisonValue,
-  Operation,
-} from './Operation';
+import { Operation } from './Operation';
 
 /**
  * Base class for tag-related operations
@@ -32,9 +28,5 @@ export abstract class BaseTagOperation extends Operation {
 
   override get modifyComparisonKey(): string {
     return `${this.appId}.User.${this.onesignalId}`;
-  }
-
-  override get groupComparisonType(): GroupComparisonValue {
-    return GroupComparisonType.ALTER;
   }
 }

--- a/src/core/operations/CreateSubscriptionOperation.ts
+++ b/src/core/operations/CreateSubscriptionOperation.ts
@@ -1,0 +1,116 @@
+import { IDManager } from 'src/shared/managers/IDManager';
+import { SubscriptionStateKind } from 'src/shared/models/SubscriptionStateKind';
+import { OPERATION_NAME } from '../executors/constants';
+import { SubscriptionType } from '../models/SubscriptionModels';
+import {
+  GroupComparisonType,
+  GroupComparisonValue,
+  Operation,
+} from './Operation';
+import { Subscription } from './types';
+
+/**
+ * An Operation to create a new subscription in the OneSignal backend. The subscription will
+ * be associated to the user with the appId and onesignalId provided.
+ */
+export class CreateSubscriptionOperation extends Operation {
+  constructor(subscription?: Subscription) {
+    super(OPERATION_NAME.CREATE_SUBSCRIPTION);
+    if (subscription) {
+      this.appId = subscription.appId;
+      this.onesignalId = subscription.onesignalId;
+      this.subscriptionId = subscription.subscriptionId;
+      this.type = subscription.type;
+      this.enabled = subscription.enabled;
+      this.notification_types = subscription.notification_types;
+    }
+  }
+
+  /**
+   * The application ID this subscription will be created under.
+   */
+  get appId(): string {
+    return this.getProperty<string>('appId');
+  }
+  private set appId(value: string) {
+    this.setProperty<string>('appId', value);
+  }
+
+  /**
+   * The user ID this subscription will be associated with. This ID *may* be locally generated
+   * and can be checked via IDManager.isLocalId to ensure correct processing.
+   */
+  get onesignalId(): string {
+    return this.getProperty<string>('onesignalId');
+  }
+  private set onesignalId(value: string) {
+    this.setProperty<string>('onesignalId', value);
+  }
+
+  /**
+   * The local ID of the subscription being created. The subscription model with this ID will have its
+   * ID updated with the backend-generated ID post-create.
+   */
+  get subscriptionId(): string {
+    return this.getProperty<string>('subscriptionId');
+  }
+  private set subscriptionId(value: string) {
+    this.setProperty<string>('subscriptionId', value);
+  }
+
+  /**
+   * The type of subscription.
+   */
+  get type(): SubscriptionType {
+    return this.getProperty<SubscriptionType>('type');
+  }
+  private set type(value: SubscriptionType) {
+    this.setProperty<SubscriptionType>('type', value);
+  }
+
+  /**
+   * Whether this subscription is currently enabled.
+   */
+  get enabled(): boolean {
+    return this.getProperty<boolean>('enabled');
+  }
+  private set enabled(value: boolean) {
+    this.setProperty<boolean>('enabled', value);
+  }
+
+  /**
+   * The notification types this subscription is subscribed to.
+   */
+  get notification_types(): SubscriptionStateKind {
+    return this.getProperty<SubscriptionStateKind>('notification_types');
+  }
+  private set notification_types(value: SubscriptionStateKind) {
+    this.setProperty<SubscriptionStateKind>('notification_types', value);
+  }
+
+  override get createComparisonKey(): string {
+    return `${this.appId}.User.${this.onesignalId}`;
+  }
+
+  override get modifyComparisonKey(): string {
+    return `${this.appId}.User.${this.onesignalId}.Subscription.${this.subscriptionId}`;
+  }
+
+  override get groupComparisonType(): GroupComparisonValue {
+    return GroupComparisonType.ALTER;
+  }
+
+  override get canStartExecute(): boolean {
+    return !IDManager.isLocalId(this.onesignalId);
+  }
+
+  override get applyToRecordId(): string {
+    return this.onesignalId;
+  }
+
+  override translateIds(map: Record<string, string>): void {
+    if (map[this.onesignalId]) {
+      this.onesignalId = map[this.onesignalId];
+    }
+  }
+}

--- a/src/core/operations/CreateSubscriptionOperation.ts
+++ b/src/core/operations/CreateSubscriptionOperation.ts
@@ -20,6 +20,11 @@ export class CreateSubscriptionOperation extends Operation {
       this.type = subscription.type;
       this.enabled = subscription.enabled;
       this.notification_types = subscription.notification_types;
+      this.sdk = subscription.sdk;
+      this.device_model = subscription.device_model;
+      this.device_os = subscription.device_os;
+      this.web_auth = subscription.web_auth;
+      this.web_p256 = subscription.web_p256;
     }
   }
 
@@ -62,6 +67,41 @@ export class CreateSubscriptionOperation extends Operation {
   }
   private set notification_types(value: SubscriptionStateKind) {
     this.setProperty<SubscriptionStateKind>('notification_types', value);
+  }
+
+  get sdk(): string | undefined {
+    return this.getProperty<string | undefined>('sdk');
+  }
+  private set sdk(value: string | undefined) {
+    this.setProperty<string | undefined>('sdk', value);
+  }
+
+  get device_model(): string | undefined {
+    return this.getProperty<string | undefined>('device_model');
+  }
+  private set device_model(value: string | undefined) {
+    this.setProperty<string | undefined>('device_model', value);
+  }
+
+  get device_os(): number | undefined {
+    return this.getProperty<number | undefined>('device_os');
+  }
+  private set device_os(value: number | undefined) {
+    this.setProperty<number | undefined>('device_os', value);
+  }
+
+  get web_auth(): string | undefined {
+    return this.getProperty<string | undefined>('web_auth');
+  }
+  private set web_auth(value: string | undefined) {
+    this.setProperty<string | undefined>('web_auth', value);
+  }
+
+  get web_p256(): string | undefined {
+    return this.getProperty<string | undefined>('web_p256');
+  }
+  private set web_p256(value: string | undefined) {
+    this.setProperty<string | undefined>('web_p256', value);
   }
 
   override get createComparisonKey(): string {

--- a/src/core/operations/CreateSubscriptionOperation.ts
+++ b/src/core/operations/CreateSubscriptionOperation.ts
@@ -1,12 +1,7 @@
-import { IDManager } from 'src/shared/managers/IDManager';
 import { SubscriptionStateKind } from 'src/shared/models/SubscriptionStateKind';
 import { OPERATION_NAME } from '../executors/constants';
 import { SubscriptionType } from '../models/SubscriptionModels';
-import {
-  GroupComparisonType,
-  GroupComparisonValue,
-  Operation,
-} from './Operation';
+import { Operation } from './Operation';
 import { Subscription } from './types';
 
 /**
@@ -15,36 +10,17 @@ import { Subscription } from './types';
  */
 export class CreateSubscriptionOperation extends Operation {
   constructor(subscription?: Subscription) {
-    super(OPERATION_NAME.CREATE_SUBSCRIPTION);
+    super(
+      OPERATION_NAME.CREATE_SUBSCRIPTION,
+      subscription?.appId,
+      subscription?.onesignalId,
+    );
     if (subscription) {
-      this.appId = subscription.appId;
-      this.onesignalId = subscription.onesignalId;
       this.subscriptionId = subscription.subscriptionId;
       this.type = subscription.type;
       this.enabled = subscription.enabled;
       this.notification_types = subscription.notification_types;
     }
-  }
-
-  /**
-   * The application ID this subscription will be created under.
-   */
-  get appId(): string {
-    return this.getProperty<string>('appId');
-  }
-  private set appId(value: string) {
-    this.setProperty<string>('appId', value);
-  }
-
-  /**
-   * The user ID this subscription will be associated with. This ID *may* be locally generated
-   * and can be checked via IDManager.isLocalId to ensure correct processing.
-   */
-  get onesignalId(): string {
-    return this.getProperty<string>('onesignalId');
-  }
-  private set onesignalId(value: string) {
-    this.setProperty<string>('onesignalId', value);
   }
 
   /**
@@ -94,23 +70,5 @@ export class CreateSubscriptionOperation extends Operation {
 
   override get modifyComparisonKey(): string {
     return `${this.appId}.User.${this.onesignalId}.Subscription.${this.subscriptionId}`;
-  }
-
-  override get groupComparisonType(): GroupComparisonValue {
-    return GroupComparisonType.ALTER;
-  }
-
-  override get canStartExecute(): boolean {
-    return !IDManager.isLocalId(this.onesignalId);
-  }
-
-  override get applyToRecordId(): string {
-    return this.onesignalId;
-  }
-
-  override translateIds(map: Record<string, string>): void {
-    if (map[this.onesignalId]) {
-      this.onesignalId = map[this.onesignalId];
-    }
   }
 }

--- a/src/core/operations/DeleteAliasOperation.ts
+++ b/src/core/operations/DeleteAliasOperation.ts
@@ -1,48 +1,14 @@
-import { IDManager } from 'src/shared/managers/IDManager';
 import { OPERATION_NAME } from '../executors/constants';
-import {
-  GroupComparisonType,
-  GroupComparisonValue,
-  Operation,
-} from './Operation';
+import { BaseAliasOperation } from './BaseAliasOperation';
+import { GroupComparisonType, GroupComparisonValue } from './Operation';
 
 // Implements logic similar to Android SDK's DeleteAliasOperation
 // Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/DeleteAliasOperation.kt
-export class DeleteAliasOperation extends Operation {
+export class DeleteAliasOperation extends BaseAliasOperation {
   constructor();
   constructor(appId: string, onesignalId: string, label: string);
   constructor(appId?: string, onesignalId?: string, label?: string) {
-    super(OPERATION_NAME.DELETE_ALIAS);
-    if (appId && onesignalId && label) {
-      this.appId = appId;
-      this.onesignalId = onesignalId;
-      this.label = label;
-    }
-  }
-
-  get appId(): string {
-    return this.getProperty<string>('appId');
-  }
-  private set appId(value: string) {
-    this.setProperty<string>('appId', value);
-  }
-
-  get onesignalId(): string {
-    return this.getProperty<string>('onesignalId');
-  }
-  private set onesignalId(value: string) {
-    this.setProperty<string>('onesignalId', value);
-  }
-
-  get label(): string {
-    return this.getProperty<string>('label');
-  }
-  private set label(value: string) {
-    this.setProperty<string>('label', value);
-  }
-
-  override get createComparisonKey(): string {
-    return '';
+    super(OPERATION_NAME.DELETE_ALIAS, appId, onesignalId, label);
   }
 
   override get modifyComparisonKey(): string {
@@ -51,19 +17,5 @@ export class DeleteAliasOperation extends Operation {
 
   override get groupComparisonType(): GroupComparisonValue {
     return GroupComparisonType.NONE;
-  }
-
-  override get canStartExecute(): boolean {
-    return !IDManager.isLocalId(this.onesignalId);
-  }
-
-  override get applyToRecordId(): string {
-    return this.onesignalId;
-  }
-
-  override translateIds(map: Record<string, string>): void {
-    if (map[this.onesignalId]) {
-      this.onesignalId = map[this.onesignalId];
-    }
   }
 }

--- a/src/core/operations/DeleteTagOperation.ts
+++ b/src/core/operations/DeleteTagOperation.ts
@@ -1,77 +1,14 @@
-import { IDManager } from 'src/shared/managers/IDManager';
 import { OPERATION_NAME } from '../executors/constants';
-import {
-  GroupComparisonType,
-  GroupComparisonValue,
-  Operation,
-} from './Operation';
+import { BaseTagOperation } from './BaseTagOperation';
 
 /**
  * An Operation to delete a tag from the OneSignal backend. The tag will
  * be associated to the user with the appId and onesignalId provided.
  */
-export class DeleteTagOperation extends Operation {
+export class DeleteTagOperation extends BaseTagOperation {
   constructor();
   constructor(appId: string, onesignalId: string, key: string);
   constructor(appId?: string, onesignalId?: string, key?: string) {
-    super(OPERATION_NAME.DELETE_TAG);
-    if (appId && onesignalId && key) {
-      this.appId = appId;
-      this.onesignalId = onesignalId;
-      this.key = key;
-    }
-  }
-
-  /**
-   * The application ID this subscription will be created under.
-   */
-  get appId(): string {
-    return this.getProperty<string>('appId');
-  }
-  private set appId(value: string) {
-    this.setProperty<string>('appId', value);
-  }
-
-  get onesignalId(): string {
-    return this.getProperty<string>('onesignalId');
-  }
-  private set onesignalId(value: string) {
-    this.setProperty<string>('onesignalId', value);
-  }
-
-  /**
-   * The tag key to delete.
-   */
-  get key(): string {
-    return this.getProperty<string>('key');
-  }
-  private set key(value: string) {
-    this.setProperty<string>('key', value);
-  }
-
-  override get createComparisonKey(): string {
-    return '';
-  }
-
-  override get modifyComparisonKey(): string {
-    return `${this.appId}.User.${this.onesignalId}`;
-  }
-
-  override get groupComparisonType(): GroupComparisonValue {
-    return GroupComparisonType.ALTER;
-  }
-
-  override get canStartExecute(): boolean {
-    return !IDManager.isLocalId(this.onesignalId);
-  }
-
-  override get applyToRecordId(): string {
-    return this.onesignalId;
-  }
-
-  override translateIds(map: Record<string, string>): void {
-    if (map[this.onesignalId]) {
-      this.onesignalId = map[this.onesignalId];
-    }
+    super(OPERATION_NAME.DELETE_TAG, appId, onesignalId, key);
   }
 }

--- a/src/core/operations/Operation.ts
+++ b/src/core/operations/Operation.ts
@@ -1,3 +1,4 @@
+import { IDManager } from 'src/shared/managers/IDManager';
 import { Model } from '../models/Model';
 
 export const GroupComparisonType = {
@@ -10,30 +11,54 @@ export type GroupComparisonValue =
   (typeof GroupComparisonType)[keyof typeof GroupComparisonType];
 
 export abstract class Operation extends Model {
-  constructor(name: string) {
+  constructor(name: string, appId?: string, onesignalId?: string) {
     super();
     this.name = name;
+    if (appId && onesignalId) {
+      this.appId = appId;
+      this.onesignalId = onesignalId;
+    }
   }
 
   get name(): string {
     return this.getProperty<string>('name');
   }
-
   private set name(value: string) {
     this.setProperty<string>('name', value);
+  }
+
+  /**
+   * The application ID this subscription will be created under.
+   */
+  get appId(): string {
+    return this.getProperty<string>('appId');
+  }
+  protected set appId(value: string) {
+    this.setProperty<string>('appId', value);
+  }
+
+  get onesignalId(): string {
+    return this.getProperty<string>('onesignalId');
+  }
+  protected set onesignalId(value: string) {
+    this.setProperty<string>('onesignalId', value);
   }
 
   /**
    * This is a unique id that points to a record this operation will affect.
    * Example: If the operation is updating tags on a User this will be the onesignalId.
    */
-  abstract get applyToRecordId(): string;
+  get applyToRecordId(): string {
+    return this.onesignalId;
+  }
 
   /**
    * The key of this operation for when the starting operation has a `groupComparisonType`
    * of `GroupComparisonType.CREATE`
    */
-  abstract get createComparisonKey(): string;
+  get createComparisonKey(): string {
+    return '';
+  }
 
   /**
    * The key of this operation for when the starting operation has a `groupComparisonType`
@@ -50,14 +75,18 @@ export abstract class Operation extends Model {
   /**
    * Whether the operation can currently execute given its current state.
    */
-  abstract get canStartExecute(): boolean;
+  get canStartExecute(): boolean {
+    return !IDManager.isLocalId(this.onesignalId);
+  }
 
   /**
    * Called when an operation has resolved a local ID to a backend ID.
    * Any IDs within the operation that could be local should be translated at this time.
    */
   translateIds(map: Record<string, string>): void {
-    // Optional override
+    if (map[this.onesignalId]) {
+      this.onesignalId = map[this.onesignalId];
+    }
   }
 
   toString(): string {

--- a/src/core/operations/Operation.ts
+++ b/src/core/operations/Operation.ts
@@ -70,7 +70,9 @@ export abstract class Operation extends Model {
    * The comparison type to use when this operation is the starting operation, in terms of
    * which operations can be grouped with it.
    */
-  abstract get groupComparisonType(): GroupComparisonValue;
+  get groupComparisonType(): GroupComparisonValue {
+    return GroupComparisonType.ALTER;
+  }
 
   /**
    * Whether the operation can currently execute given its current state.

--- a/src/core/operations/RefreshUserOperation.ts
+++ b/src/core/operations/RefreshUserOperation.ts
@@ -1,4 +1,3 @@
-import { IDManager } from 'src/shared/managers/IDManager';
 import { OPERATION_NAME } from '../executors/constants';
 
 import {
@@ -15,32 +14,7 @@ export class RefreshUserOperation extends Operation {
   constructor();
   constructor(appId: string, onesignalId: string);
   constructor(appId?: string, onesignalId?: string) {
-    super(OPERATION_NAME.REFRESH_USER);
-    if (appId && onesignalId) {
-      this.appId = appId;
-      this.onesignalId = onesignalId;
-    }
-  }
-
-  /**
-   * The application ID this subscription will be created under.
-   */
-  get appId(): string {
-    return this.getProperty<string>('appId');
-  }
-  private set appId(value: string) {
-    this.setProperty<string>('appId', value);
-  }
-
-  /**
-   * The user ID this subscription will be associated with. This ID *may* be locally generated
-   * and can be checked via IDManager.isLocalId to ensure correct processing.
-   */
-  get onesignalId(): string {
-    return this.getProperty<string>('onesignalId');
-  }
-  private set onesignalId(value: string) {
-    this.setProperty<string>('onesignalId', value);
+    super(OPERATION_NAME.REFRESH_USER, appId, onesignalId);
   }
 
   override get createComparisonKey(): string {
@@ -53,19 +27,5 @@ export class RefreshUserOperation extends Operation {
 
   override get groupComparisonType(): GroupComparisonValue {
     return GroupComparisonType.CREATE;
-  }
-
-  override get canStartExecute(): boolean {
-    return !IDManager.isLocalId(this.onesignalId);
-  }
-
-  override get applyToRecordId(): string {
-    return this.onesignalId;
-  }
-
-  override translateIds(map: Record<string, string>): void {
-    if (map[this.onesignalId]) {
-      this.onesignalId = map[this.onesignalId];
-    }
   }
 }

--- a/src/core/operations/SetAliasOperation.ts
+++ b/src/core/operations/SetAliasOperation.ts
@@ -1,6 +1,5 @@
 import { OPERATION_NAME } from '../executors/constants';
 import { BaseAliasOperation } from './BaseAliasOperation';
-import { GroupComparisonType, GroupComparisonValue } from './Operation';
 
 // Implements logic similar to Android SDK's SetAliasOperation
 // Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetAliasOperation.kt
@@ -26,9 +25,5 @@ export class SetAliasOperation extends BaseAliasOperation {
 
   override get modifyComparisonKey(): string {
     return `${this.appId}.User.${this.onesignalId}.Identity.${this.label}`;
-  }
-
-  override get groupComparisonType(): GroupComparisonValue {
-    return GroupComparisonType.ALTER;
   }
 }

--- a/src/core/operations/SetAliasOperation.ts
+++ b/src/core/operations/SetAliasOperation.ts
@@ -1,15 +1,10 @@
-import { IDManager } from 'src/shared/managers/IDManager';
 import { OPERATION_NAME } from '../executors/constants';
-
-import {
-  GroupComparisonType,
-  GroupComparisonValue,
-  Operation,
-} from './Operation';
+import { BaseAliasOperation } from './BaseAliasOperation';
+import { GroupComparisonType, GroupComparisonValue } from './Operation';
 
 // Implements logic similar to Android SDK's SetAliasOperation
 // Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetAliasOperation.kt
-export class SetAliasOperation extends Operation {
+export class SetAliasOperation extends BaseAliasOperation {
   constructor();
   constructor(appId: string, onesignalId: string, label: string, value: string);
   constructor(
@@ -18,34 +13,8 @@ export class SetAliasOperation extends Operation {
     label?: string,
     value?: string,
   ) {
-    super(OPERATION_NAME.SET_ALIAS);
-    if (appId && onesignalId && label && value) {
-      this.appId = appId;
-      this.onesignalId = onesignalId;
-      this.label = label;
-      this.value = value;
-    }
-  }
-
-  get appId(): string {
-    return this.getProperty<string>('appId');
-  }
-  private set appId(value: string) {
-    this.setProperty<string>('appId', value);
-  }
-
-  get onesignalId(): string {
-    return this.getProperty<string>('onesignalId');
-  }
-  private set onesignalId(value: string) {
-    this.setProperty<string>('onesignalId', value);
-  }
-
-  get label(): string {
-    return this.getProperty<string>('label');
-  }
-  private set label(value: string) {
-    this.setProperty<string>('label', value);
+    super(OPERATION_NAME.SET_ALIAS, appId, onesignalId, label);
+    if (value) this.value = value;
   }
 
   get value(): string {
@@ -55,29 +24,11 @@ export class SetAliasOperation extends Operation {
     this.setProperty<string>('value', value);
   }
 
-  override get createComparisonKey(): string {
-    return '';
-  }
-
   override get modifyComparisonKey(): string {
     return `${this.appId}.User.${this.onesignalId}.Identity.${this.label}`;
   }
 
   override get groupComparisonType(): GroupComparisonValue {
     return GroupComparisonType.ALTER;
-  }
-
-  override get canStartExecute(): boolean {
-    return !IDManager.isLocalId(this.onesignalId);
-  }
-
-  override get applyToRecordId(): string {
-    return this.onesignalId;
-  }
-
-  override translateIds(map: Record<string, string>): void {
-    if (map[this.onesignalId]) {
-      this.onesignalId = map[this.onesignalId];
-    }
   }
 }

--- a/src/core/operations/SetPropertyOperation.ts
+++ b/src/core/operations/SetPropertyOperation.ts
@@ -1,11 +1,6 @@
-import { IDManager } from 'src/shared/managers/IDManager';
 import { OPERATION_NAME } from '../executors/constants';
 
-import {
-  GroupComparisonType,
-  GroupComparisonValue,
-  Operation,
-} from './Operation';
+import { Operation } from './Operation';
 
 /**
  * An Operation to update a property related to a specific user.
@@ -24,30 +19,11 @@ export class SetPropertyOperation extends Operation {
     property?: string,
     value?: unknown,
   ) {
-    super(OPERATION_NAME.SET_PROPERTY);
-    if (appId && onesignalId && property) {
-      this.appId = appId;
-      this.onesignalId = onesignalId;
+    super(OPERATION_NAME.SET_PROPERTY, appId, onesignalId);
+    if (property) {
       this.property = property;
       this.value = value;
     }
-  }
-
-  /**
-   * The OneSignal appId the purchase was captured under.
-   */
-  get appId(): string {
-    return this.getProperty<string>('appId');
-  }
-  private set appId(value: string) {
-    this.setProperty<string>('appId', value);
-  }
-
-  get onesignalId(): string {
-    return this.getProperty<string>('onesignalId');
-  }
-  private set onesignalId(value: string) {
-    this.setProperty<string>('onesignalId', value);
   }
 
   /**
@@ -70,29 +46,7 @@ export class SetPropertyOperation extends Operation {
     this.setProperty<unknown>('value', value);
   }
 
-  override get createComparisonKey(): string {
-    return '';
-  }
-
   override get modifyComparisonKey(): string {
     return `${this.appId}.User.${this.onesignalId}`;
-  }
-
-  override get groupComparisonType(): GroupComparisonValue {
-    return GroupComparisonType.ALTER;
-  }
-
-  override get canStartExecute(): boolean {
-    return !IDManager.isLocalId(this.onesignalId);
-  }
-
-  override get applyToRecordId(): string {
-    return this.onesignalId;
-  }
-
-  override translateIds(map: Record<string, string>): void {
-    if (map[this.onesignalId]) {
-      this.onesignalId = map[this.onesignalId];
-    }
   }
 }

--- a/src/core/operations/SetTagOperation.ts
+++ b/src/core/operations/SetTagOperation.ts
@@ -1,17 +1,11 @@
-import { IDManager } from 'src/shared/managers/IDManager';
 import { OPERATION_NAME } from '../executors/constants';
-
-import {
-  GroupComparisonType,
-  GroupComparisonValue,
-  Operation,
-} from './Operation';
+import { BaseTagOperation } from './BaseTagOperation';
 
 /**
  * An Operation to create/update a tag in the OneSignal backend. The tag will
  * be associated to the user with the appId and onesignalId provided.
  */
-export class SetTagOperation extends Operation {
+export class SetTagOperation extends BaseTagOperation {
   constructor();
   constructor(appId: string, onesignalId: string, key: string, value: string);
   constructor(
@@ -20,40 +14,8 @@ export class SetTagOperation extends Operation {
     key?: string,
     value?: string,
   ) {
-    super(OPERATION_NAME.SET_TAG);
-    if (appId && onesignalId && key && value) {
-      this.appId = appId;
-      this.onesignalId = onesignalId;
-      this.key = key;
-      this.value = value;
-    }
-  }
-
-  /**
-   * The application ID this subscription will be created under.
-   */
-  get appId(): string {
-    return this.getProperty<string>('appId');
-  }
-  private set appId(value: string) {
-    this.setProperty<string>('appId', value);
-  }
-
-  get onesignalId(): string {
-    return this.getProperty<string>('onesignalId');
-  }
-  private set onesignalId(value: string) {
-    this.setProperty<string>('onesignalId', value);
-  }
-
-  /**
-   * The tag key.
-   */
-  get key(): string {
-    return this.getProperty<string>('key');
-  }
-  private set key(value: string) {
-    this.setProperty<string>('key', value);
+    super(OPERATION_NAME.SET_TAG, appId, onesignalId, key);
+    if (value) this.value = value;
   }
 
   /**
@@ -64,31 +26,5 @@ export class SetTagOperation extends Operation {
   }
   private set value(value: string) {
     this.setProperty<string>('value', value);
-  }
-
-  override get createComparisonKey(): string {
-    return '';
-  }
-
-  override get modifyComparisonKey(): string {
-    return `${this.appId}.User.${this.onesignalId}`;
-  }
-
-  override get groupComparisonType(): GroupComparisonValue {
-    return GroupComparisonType.ALTER;
-  }
-
-  override get canStartExecute(): boolean {
-    return !IDManager.isLocalId(this.onesignalId);
-  }
-
-  override get applyToRecordId(): string {
-    return this.onesignalId;
-  }
-
-  override translateIds(map: Record<string, string>): void {
-    if (map[this.onesignalId]) {
-      this.onesignalId = map[this.onesignalId];
-    }
   }
 }

--- a/src/core/operations/TrackSessionEndOperation.ts
+++ b/src/core/operations/TrackSessionEndOperation.ts
@@ -1,11 +1,6 @@
-import { IDManager } from 'src/shared/managers/IDManager';
 import { OPERATION_NAME } from '../executors/constants';
 
-import {
-  GroupComparisonType,
-  GroupComparisonValue,
-  Operation,
-} from './Operation';
+import { Operation } from './Operation';
 
 /**
  * An Operation to track the ending of a session, related to a specific user.
@@ -14,33 +9,10 @@ export class TrackSessionEndOperation extends Operation {
   constructor();
   constructor(appId: string, onesignalId: string, sessionTime: number);
   constructor(appId?: string, onesignalId?: string, sessionTime?: number) {
-    super(OPERATION_NAME.TRACK_SESSION_END);
+    super(OPERATION_NAME.TRACK_SESSION_END, appId, onesignalId);
     if (appId && onesignalId && sessionTime) {
-      this.appId = appId;
-      this.onesignalId = onesignalId;
       this.sessionTime = sessionTime;
     }
-  }
-
-  /**
-   * The OneSignal appId the session was captured under.
-   */
-  get appId(): string {
-    return this.getProperty<string>('appId');
-  }
-  private set appId(value: string) {
-    this.setProperty<string>('appId', value);
-  }
-
-  /**
-   * The OneSignal ID driving the session. This ID *may* be locally generated
-   * and can be checked via IDManager.isLocalId to ensure correct processing.
-   */
-  get onesignalId(): string {
-    return this.getProperty<string>('onesignalId');
-  }
-  private set onesignalId(value: string) {
-    this.setProperty<string>('onesignalId', value);
   }
 
   /**
@@ -53,29 +25,7 @@ export class TrackSessionEndOperation extends Operation {
     this.setProperty<number>('sessionTime', value);
   }
 
-  override get createComparisonKey(): string {
-    return '';
-  }
-
   override get modifyComparisonKey(): string {
     return `${this.appId}.User.${this.onesignalId}`;
-  }
-
-  override get groupComparisonType(): GroupComparisonValue {
-    return GroupComparisonType.ALTER;
-  }
-
-  override get canStartExecute(): boolean {
-    return !IDManager.isLocalId(this.onesignalId);
-  }
-
-  override get applyToRecordId(): string {
-    return this.onesignalId;
-  }
-
-  override translateIds(map: Record<string, string>): void {
-    if (map[this.onesignalId]) {
-      this.onesignalId = map[this.onesignalId];
-    }
   }
 }

--- a/src/core/operations/TrackSessionStartOperation.ts
+++ b/src/core/operations/TrackSessionStartOperation.ts
@@ -1,10 +1,5 @@
-import { IDManager } from 'src/shared/managers/IDManager';
 import { OPERATION_NAME } from '../executors/constants';
-import {
-  GroupComparisonType,
-  GroupComparisonValue,
-  Operation,
-} from './Operation';
+import { Operation } from './Operation';
 
 /**
  * An Operation to track the starting of a session, related to a specific user.
@@ -13,57 +8,10 @@ export class TrackSessionStartOperation extends Operation {
   constructor();
   constructor(appId: string, onesignalId: string);
   constructor(appId?: string, onesignalId?: string) {
-    super(OPERATION_NAME.TRACK_SESSION_START);
-    if (appId && onesignalId) {
-      this.appId = appId;
-      this.onesignalId = onesignalId;
-    }
-  }
-
-  /**
-   * The OneSignal appId the session was captured under.
-   */
-  get appId(): string {
-    return this.getProperty<string>('appId');
-  }
-  private set appId(value: string) {
-    this.setProperty<string>('appId', value);
-  }
-
-  /**
-   * The OneSignal ID driving the session. This ID *may* be locally generated
-   * and can be checked via IDManager.isLocalId to ensure correct processing.
-   */
-  get onesignalId(): string {
-    return this.getProperty<string>('onesignalId');
-  }
-  private set onesignalId(value: string) {
-    this.setProperty<string>('onesignalId', value);
-  }
-
-  override get createComparisonKey(): string {
-    return '';
+    super(OPERATION_NAME.TRACK_SESSION_START, appId, onesignalId);
   }
 
   override get modifyComparisonKey(): string {
     return `${this.appId}.User.${this.onesignalId}`;
-  }
-
-  override get groupComparisonType(): GroupComparisonValue {
-    return GroupComparisonType.ALTER;
-  }
-
-  override get canStartExecute(): boolean {
-    return !IDManager.isLocalId(this.onesignalId);
-  }
-
-  override get applyToRecordId(): string {
-    return this.onesignalId;
-  }
-
-  override translateIds(map: Record<string, string>): void {
-    if (map[this.onesignalId]) {
-      this.onesignalId = map[this.onesignalId];
-    }
   }
 }

--- a/src/core/operations/types.ts
+++ b/src/core/operations/types.ts
@@ -8,4 +8,9 @@ export interface Subscription {
   onesignalId: string;
   subscriptionId: string;
   type: SubscriptionType;
+  sdk?: string;
+  device_model?: string;
+  device_os?: number;
+  web_auth?: string;
+  web_p256?: string;
 }

--- a/src/core/operations/types.ts
+++ b/src/core/operations/types.ts
@@ -1,0 +1,11 @@
+import { SubscriptionStateKind } from 'src/shared/models/SubscriptionStateKind';
+import { SubscriptionType } from '../models/SubscriptionModels';
+
+export interface Subscription {
+  appId: string;
+  enabled: boolean;
+  notification_types: SubscriptionStateKind;
+  onesignalId: string;
+  subscriptionId: string;
+  type: SubscriptionType;
+}


### PR DESCRIPTION
# Description
Continuation of the [Web SDK Refactor project](https://docs.google.com/document/d/1JsbmxVM_n6K9nRXwbJf6mQr5h88qy_vIEiBGY0Ub_lE/edit?tab=t.0#heading=h.ojv84gskof17). This pr is focuses on adding tests for the IdentityOperationExecutor tests.

## Details
- Implements the [CreateSubscriptionOperation](https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/CreateSubscriptionOperation.kt) class 
- Updates `Operation` class to have get and set app id, get and set onesignalid, applyToRecordId which returns onesignalid (unless overridden), createComparisonKey which returns '' (unless overridden), groupComparisonType to return Alter, translateIds to set map value
- Removes duplicate logic in derived classes
- Adds base classes like BaseTagOperation and BaseAliasOperation which share some properties to avoid duplicate logic
- For `CreateSubscriptionOperation` class, did **not** implement `address`, `status`. But added `notification_types`, `sdk`,`device_model`,`device_os`,`web_auth`,`web_p256`

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1273)
<!-- Reviewable:end -->
