### PR TITLE
Web SDK Refactor: LoginOeprationExecutor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,13 +6,13 @@ build/releases
 ngrok_last_url
 ngrok.log
 
-
 .DS_STORE
 *.pem
 *.key
 *.crt
 .vscode/**
 !.vscode/launch.json
+.cursor/
 
 coverage
 

--- a/src/core/executors/LoginUserOperationExecutor.ts
+++ b/src/core/executors/LoginUserOperationExecutor.ts
@@ -1,0 +1,305 @@
+import Environment from 'src/shared/helpers/Environment';
+import {
+  getResponseStatusType,
+  ResponseStatusType,
+} from 'src/shared/helpers/NetworkUtils';
+import Log from 'src/shared/libraries/Log';
+import { getTimeZoneId } from 'src/shared/utils/utils';
+import { IdentityConstants } from 'src/types/backend';
+import { ModelChangeTags } from 'src/types/models';
+import { ExecutionResult, IOperationExecutor } from 'src/types/operation';
+import { ConfigModelStore } from '../models/ConfigModelStore';
+import { IdentityModelStore } from '../models/IdentityModelStore';
+import { SupportedSubscription } from '../models/SubscriptionModels';
+import { Identity } from '../models/UserData';
+import { CreateSubscriptionOperation } from '../operations/CreateSubscriptionOperation';
+import { DeleteSubscriptionOperation } from '../operations/DeleteSubscriptionOperation';
+import { ExecutionResponse } from '../operations/ExecutionResponse';
+import { LoginUserOperation } from '../operations/LoginUserOperation';
+import { type Operation } from '../operations/Operation';
+import { RefreshUserOperation } from '../operations/RefreshUserOperation';
+import { SetAliasOperation } from '../operations/SetAliasOperation';
+import { TransferSubscriptionOperation } from '../operations/TransferSubscriptionOperation';
+import { UpdateSubscriptionOperation } from '../operations/UpdateSubscriptionOperation';
+import { RequestService } from '../requestService/RequestService';
+import { type IdentityOperationExecutor } from './IdentityOperationExecutor';
+import { OPERATION_NAME } from './constants';
+
+// Implements logic similar to Android's SDK's LoginUserOperationExecutor
+// Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
+export class LoginUserOperationExecutor implements IOperationExecutor {
+  constructor(
+    private identityOperationExecutor: IdentityOperationExecutor,
+    private identityModelStore: IdentityModelStore, // private identityModelStore: IdentityModelStore,
+    private propertiesModelStore: any, // TODO: implement PropertiesModelStore
+    private subscriptionsModelStore: any, // TODO: implement SubscriptionModelStore
+    private configModelStore: ConfigModelStore,
+  ) {}
+
+  get operations(): string[] {
+    return [OPERATION_NAME.LOGIN_USER];
+  }
+
+  async execute(operations: Operation[]): Promise<ExecutionResponse> {
+    Log.debug(
+      `LoginUserOperationExecutor(operation: ${JSON.stringify(operations)})`,
+    );
+    const startingOp = operations[0];
+
+    if (startingOp instanceof LoginUserOperation)
+      return this.loginUser(startingOp, operations.slice(1));
+
+    throw new Error(`Unrecognized operation: ${startingOp}`);
+  }
+
+  private async loginUser(
+    loginUserOp: LoginUserOperation,
+    operations: Operation[],
+  ): Promise<ExecutionResponse> {
+    const containsSubOp = operations.some(
+      (op) =>
+        op instanceof CreateSubscriptionOperation ||
+        op instanceof TransferSubscriptionOperation,
+    );
+
+    if (!containsSubOp && !loginUserOp.externalId)
+      return new ExecutionResponse(ExecutionResult.FAIL_NORETRY);
+
+    if (!loginUserOp.existingOnesignalId || !loginUserOp.externalId)
+      return this.createUser(loginUserOp, operations);
+
+    const result = await this.identityOperationExecutor.execute([
+      new SetAliasOperation(
+        loginUserOp.appId,
+        loginUserOp.existingOnesignalId,
+        IdentityConstants.EXTERNAL_ID,
+        loginUserOp.externalId,
+      ),
+    ]);
+
+    switch (result.result) {
+      case ExecutionResult.SUCCESS: {
+        const backendOneSignalId = loginUserOp.existingOnesignalId;
+        const opOneSignalId = loginUserOp.onesignalId;
+
+        if (this.identityModelStore.model.onesignalId === opOneSignalId) {
+          this.identityModelStore.model.setProperty(
+            IdentityConstants.ONESIGNAL_ID,
+            backendOneSignalId,
+            ModelChangeTags.HYDRATE,
+          );
+        }
+
+        if (this.propertiesModelStore.model.onesignalId === opOneSignalId) {
+          this.propertiesModelStore.model.setProperty(
+            'onesignalId',
+            backendOneSignalId,
+            ModelChangeTags.HYDRATE,
+          );
+        }
+        return new ExecutionResponse(
+          ExecutionResult.SUCCESS_STARTING_ONLY,
+          undefined,
+          undefined,
+          {
+            [loginUserOp.onesignalId]: backendOneSignalId,
+          },
+        );
+      }
+
+      case ExecutionResult.FAIL_CONFLICT:
+        Log.debug(`Handling 409 for externalId: ${loginUserOp.externalId}`);
+        return this.createUser(loginUserOp, operations);
+
+      case ExecutionResult.FAIL_NORETRY:
+        Log.error(
+          `Recovering from SetAlias failure for externalId: ${loginUserOp.externalId}`,
+        );
+        return this.createUser(loginUserOp, operations);
+
+      default:
+        return new ExecutionResponse(result.result);
+    }
+  }
+
+  private async createUser(
+    createUserOperation: LoginUserOperation,
+    operations: Operation[],
+  ): Promise<ExecutionResponse> {
+    const identity: Identity = {};
+    const subscriptions: Record<string, SupportedSubscription> = {};
+    const properties: Record<string, string> = {
+      timezone_id: getTimeZoneId(),
+      language: Environment.getLanguage(),
+    };
+
+    if (createUserOperation.externalId) {
+      identity[IdentityConstants.EXTERNAL_ID] = createUserOperation.externalId;
+    }
+
+    for (const operation of operations) {
+      if (
+        operation instanceof CreateSubscriptionOperation ||
+        operation instanceof TransferSubscriptionOperation ||
+        operation instanceof UpdateSubscriptionOperation ||
+        operation instanceof DeleteSubscriptionOperation
+      ) {
+        Object.assign(
+          subscriptions,
+          this.createSubscriptionsFromOperation(operation, subscriptions),
+        );
+      } else {
+        throw new Error(`Unrecognized operation: ${operation}`);
+      }
+    }
+
+    const subscriptionList = Object.entries(subscriptions);
+    const response = await RequestService.createUser(
+      { appId: createUserOperation.appId },
+      {
+        identity,
+        subscriptions: subscriptionList.map(([, sub]) => sub),
+        properties,
+      },
+    );
+
+    if (response.ok) {
+      const backendOneSignalId = response.result.identity.onesignal_id;
+      const opOneSignalId = createUserOperation.onesignalId;
+      if (!backendOneSignalId) throw new Error('No onesignal_id returned');
+
+      const idTranslations: Record<string, string> = {
+        [createUserOperation.onesignalId]: backendOneSignalId,
+      };
+
+      if (this.identityModelStore.model.onesignalId === opOneSignalId) {
+        this.identityModelStore.model.setProperty(
+          IdentityConstants.ONESIGNAL_ID,
+          backendOneSignalId,
+          ModelChangeTags.HYDRATE,
+        );
+      }
+
+      if (this.propertiesModelStore.model.onesignalId === opOneSignalId) {
+        this.propertiesModelStore.model.setProperty(
+          'onesignalId',
+          backendOneSignalId,
+          ModelChangeTags.HYDRATE,
+        );
+      }
+
+      for (let i = 0; i < subscriptionList.length; i++) {
+        const [localId] = subscriptionList[i];
+        const backendSub = response.result.subscriptions?.[i];
+
+        if (!backendSub || !('id' in backendSub)) continue;
+        idTranslations[localId] = backendSub.id;
+
+        if (this.configModelStore.model.pushSubscriptionId === localId) {
+          this.configModelStore.model.pushSubscriptionId = backendSub.id;
+        }
+
+        const model = this.subscriptionsModelStore.get(localId);
+        model?.setStringProperty('id', backendSub.id, ModelChangeTags.HYDRATE);
+      }
+
+      const followUp =
+        Object.keys(identity).length > 0
+          ? [
+              new RefreshUserOperation(
+                createUserOperation.appId,
+                backendOneSignalId,
+              ),
+            ]
+          : undefined;
+
+      return new ExecutionResponse(
+        ExecutionResult.SUCCESS,
+        undefined,
+        followUp,
+        idTranslations,
+      );
+    }
+
+    const { status, retryAfterSeconds } = response;
+    const responseType = getResponseStatusType(status);
+
+    switch (responseType) {
+      case ResponseStatusType.RETRYABLE:
+        return new ExecutionResponse(
+          ExecutionResult.FAIL_RETRY,
+          retryAfterSeconds,
+        );
+      case ResponseStatusType.UNAUTHORIZED:
+        return new ExecutionResponse(
+          ExecutionResult.FAIL_UNAUTHORIZED,
+          retryAfterSeconds,
+        );
+      default:
+        return new ExecutionResponse(ExecutionResult.FAIL_PAUSE_OPREPO);
+    }
+  }
+
+  private createSubscriptionsFromOperation(
+    operation:
+      | CreateSubscriptionOperation
+      | DeleteSubscriptionOperation
+      | TransferSubscriptionOperation
+      | UpdateSubscriptionOperation,
+    currentSubs: Record<string, SupportedSubscription>,
+  ): Record<string, SupportedSubscription> {
+    switch (true) {
+      case operation instanceof CreateSubscriptionOperation: {
+        const { subscriptionId, ...rest } = operation.toJSON();
+        return {
+          ...currentSubs,
+          [subscriptionId]: {
+            ...rest,
+          },
+        };
+      }
+
+      case operation instanceof UpdateSubscriptionOperation: {
+        const subscriptionId = operation.subscriptionId;
+
+        if (currentSubs[subscriptionId]) {
+          return {
+            ...currentSubs,
+            [subscriptionId]: {
+              ...currentSubs[subscriptionId],
+              enabled: operation.enabled,
+            },
+          };
+        }
+        return currentSubs;
+      }
+
+      case operation instanceof TransferSubscriptionOperation: {
+        const subscriptionId = operation.subscriptionId;
+        const subs = { ...currentSubs };
+
+        if (subs[subscriptionId]) {
+          subs[subscriptionId] = {
+            ...subs[subscriptionId],
+            id: subscriptionId,
+          };
+        } else {
+          subs[subscriptionId] = {
+            id: subscriptionId,
+            type: operation.type,
+          };
+        }
+        return subs;
+      }
+
+      case operation instanceof DeleteSubscriptionOperation: {
+        const subs = { ...currentSubs };
+        delete subs[operation.subscriptionId];
+        return subs;
+      }
+
+      default:
+        return currentSubs;
+    }
+  }
+}

--- a/src/core/models/ConfigModel.ts
+++ b/src/core/models/ConfigModel.ts
@@ -1,0 +1,10 @@
+import { Model } from './Model';
+
+export class ConfigModel extends Model {
+  get pushSubscriptionId(): string | undefined {
+    return this.getProperty<string | undefined>('pushSubscriptionId');
+  }
+  set pushSubscriptionId(value: string | undefined) {
+    this.setProperty('pushSubscriptionId', value);
+  }
+}

--- a/src/core/models/ConfigModelStore.ts
+++ b/src/core/models/ConfigModelStore.ts
@@ -1,0 +1,16 @@
+import { SimpleModelStore } from 'src/shared/models/SimpleModelStore';
+import { SingletonModelStore } from 'src/shared/models/SingletonModelStore';
+import { IPreferencesService } from 'src/types/preferences';
+import { ConfigModel } from './ConfigModel';
+
+export class ConfigModelStore extends SingletonModelStore<ConfigModel> {
+  constructor(prefs: IPreferencesService) {
+    super(
+      new SimpleModelStore<ConfigModel>(
+        () => new ConfigModel(),
+        'config',
+        prefs,
+      ),
+    );
+  }
+}

--- a/src/core/models/IdentityModel.ts
+++ b/src/core/models/IdentityModel.ts
@@ -1,33 +1,38 @@
 import { IdentityConstants } from 'src/types/backend';
 import { Model } from './Model';
 
+type IIdentityModel = {
+  [IdentityConstants.ONESIGNAL_ID]: string;
+  [IdentityConstants.EXTERNAL_ID]: string | null;
+};
+
 /**
  * The identity model as a MapModel: a simple key-value pair where the key represents
  * the alias label and the value represents the alias ID for that alias label.
  * This model provides simple access to more well-defined aliases.
  */
-export class IdentityModel extends Model {
+export class IdentityModel extends Model<IIdentityModel> {
   /**
    * The OneSignal ID for this identity.
    * WARNING: This *might* be a local ID depending on whether the user has been
    * successfully created on the backend or not.
    */
   get onesignalId(): string {
-    return this.getProperty<string>(IdentityConstants.ONESIGNAL_ID);
+    return this.getProperty(IdentityConstants.ONESIGNAL_ID);
   }
 
   set onesignalId(value: string) {
-    this.setProperty<string>(IdentityConstants.ONESIGNAL_ID, value);
+    this.setProperty(IdentityConstants.ONESIGNAL_ID, value);
   }
 
   /**
    * The (developer-managed) identifier that uniquely identifies this user.
    */
   get externalId(): string | null {
-    return this.getProperty<string | null>(IdentityConstants.EXTERNAL_ID);
+    return this.getProperty(IdentityConstants.EXTERNAL_ID);
   }
 
   set externalId(value: string | null) {
-    this.setProperty<string | null>(IdentityConstants.EXTERNAL_ID, value);
+    this.setProperty(IdentityConstants.EXTERNAL_ID, value);
   }
 }

--- a/src/core/operations/BaseAliasOperation.ts
+++ b/src/core/operations/BaseAliasOperation.ts
@@ -1,9 +1,16 @@
 import { Operation } from './Operation';
 
+type AliasOperation = {
+  label: string;
+};
+
 /**
  * Base class for alias-related operations
  */
-export abstract class BaseAliasOperation extends Operation {
+export abstract class BaseAliasOperation<
+  U extends object = AliasOperation,
+  T extends U & AliasOperation = U & AliasOperation,
+> extends Operation<T> {
   constructor(
     operationName: string,
     appId?: string,
@@ -17,9 +24,9 @@ export abstract class BaseAliasOperation extends Operation {
   }
 
   get label(): string {
-    return this.getProperty<string>('label');
+    return this.getProperty('label');
   }
   protected set label(value: string) {
-    this.setProperty<string>('label', value);
+    this.setProperty('label', value);
   }
 }

--- a/src/core/operations/BaseSubscriptionOperation.ts
+++ b/src/core/operations/BaseSubscriptionOperation.ts
@@ -4,10 +4,22 @@ import { SubscriptionType } from '../models/SubscriptionModels';
 import { Operation } from './Operation';
 import { Subscription } from './types';
 
+type SubscriptionOperation = {
+  device_model: string | undefined;
+  device_os: number | undefined;
+  enabled: boolean;
+  notification_types: SubscriptionStateKind;
+  sdk: string | undefined;
+  subscriptionId: string;
+  type: SubscriptionType;
+  web_auth: string | undefined;
+  web_p256: string | undefined;
+};
+
 /**
  * Base class for subscription-related operations
  */
-export abstract class BaseSubscriptionOperation extends Operation {
+export abstract class BaseSubscriptionOperation extends Operation<SubscriptionOperation> {
   constructor(
     operationName: string,
     appId?: string,
@@ -34,90 +46,90 @@ export abstract class BaseSubscriptionOperation extends Operation {
    * and can be checked via IDManager.isLocalId to ensure correct processing.
    */
   get subscriptionId(): string {
-    return this.getProperty<string>('subscriptionId');
+    return this.getProperty('subscriptionId');
   }
   protected set subscriptionId(value: string) {
-    this.setProperty<string>('subscriptionId', value);
+    this.setProperty('subscriptionId', value);
   }
 
   /**
    * The type of subscription.
    */
-  get type(): SubscriptionType {
-    return this.getProperty<SubscriptionType>('type');
+  public get type(): SubscriptionType {
+    return this.getProperty('type');
   }
   protected set type(value: SubscriptionType) {
-    this.setProperty<SubscriptionType>('type', value);
+    this.setProperty('type', value);
   }
 
   /**
    * Whether this subscription is currently enabled.
    */
   get enabled(): boolean {
-    return this.getProperty<boolean>('enabled');
+    return this.getProperty('enabled');
   }
   protected set enabled(value: boolean) {
-    this.setProperty<boolean>('enabled', value);
+    this.setProperty('enabled', value);
   }
 
   /**
    * The notification types this subscription is subscribed to.
    */
   get notification_types(): SubscriptionStateKind {
-    return this.getProperty<SubscriptionStateKind>('notification_types');
+    return this.getProperty('notification_types');
   }
   protected set notification_types(value: SubscriptionStateKind) {
-    this.setProperty<SubscriptionStateKind>('notification_types', value);
+    this.setProperty('notification_types', value);
   }
 
   /**
    * The SDK identifier
    */
   get sdk(): string | undefined {
-    return this.getProperty<string | undefined>('sdk');
+    return this.getProperty('sdk');
   }
   protected set sdk(value: string | undefined) {
-    this.setProperty<string | undefined>('sdk', value);
+    this.setProperty('sdk', value);
   }
 
   /**
    * The device model
    */
   get device_model(): string | undefined {
-    return this.getProperty<string | undefined>('device_model');
+    return this.getProperty('device_model');
   }
   protected set device_model(value: string | undefined) {
-    this.setProperty<string | undefined>('device_model', value);
+    this.setProperty('device_model', value);
   }
 
   /**
    * The device OS version
    */
   get device_os(): number | undefined {
-    return this.getProperty<number | undefined>('device_os');
+    return this.getProperty('device_os');
   }
   protected set device_os(value: number | undefined) {
-    this.setProperty<number | undefined>('device_os', value);
+    this.setProperty('device_os', value);
   }
 
   /**
    * Web authentication value
    */
   get web_auth(): string | undefined {
-    return this.getProperty<string | undefined>('web_auth');
+    return this.getProperty('web_auth');
   }
   protected set web_auth(value: string | undefined) {
-    this.setProperty<string | undefined>('web_auth', value);
+    this.setProperty('web_auth', value);
   }
 
   /**
    * Web P256 value
    */
   get web_p256(): string | undefined {
-    return this.getProperty<string | undefined>('web_p256');
+    return this.getProperty('web_p256');
   }
   protected set web_p256(value: string | undefined) {
-    this.setProperty<string | undefined>('web_p256', value);
+    this.setProperty('web_p256', value);
   }
 
   override get createComparisonKey(): string {

--- a/src/core/operations/BaseTagOperation.ts
+++ b/src/core/operations/BaseTagOperation.ts
@@ -1,9 +1,16 @@
 import { Operation } from './Operation';
 
+type TagOperation = {
+  key: string;
+};
+
 /**
  * Base class for tag-related operations
  */
-export abstract class BaseTagOperation extends Operation {
+export abstract class BaseTagOperation<
+  U extends object = TagOperation,
+  T extends U & TagOperation = U & TagOperation,
+> extends Operation<T> {
   constructor(
     operationName: string,
     appId?: string,
@@ -20,10 +27,10 @@ export abstract class BaseTagOperation extends Operation {
    * The tag key.
    */
   get key(): string {
-    return this.getProperty<string>('key');
+    return this.getProperty('key');
   }
   protected set key(value: string) {
-    this.setProperty<string>('key', value);
+    this.setProperty('key', value);
   }
 
   override get modifyComparisonKey(): string {

--- a/src/core/operations/Operation.ts
+++ b/src/core/operations/Operation.ts
@@ -10,7 +10,16 @@ export const GroupComparisonType = {
 export type GroupComparisonValue =
   (typeof GroupComparisonType)[keyof typeof GroupComparisonType];
 
-export abstract class Operation extends Model {
+type BaseOperation = {
+  name: string;
+  appId: string;
+  onesignalId: string;
+};
+
+export abstract class Operation<
+  B extends object = BaseOperation,
+  T extends B & BaseOperation = B & BaseOperation,
+> extends Model<T> {
   constructor(name: string, appId?: string, onesignalId?: string) {
     super();
     this.name = name;
@@ -21,27 +30,27 @@ export abstract class Operation extends Model {
   }
 
   get name(): string {
-    return this.getProperty<string>('name');
+    return this.getProperty('name');
   }
   private set name(value: string) {
-    this.setProperty<string>('name', value);
+    this.setProperty('name', value);
   }
 
   /**
    * The application ID this subscription will be created under.
    */
   get appId(): string {
-    return this.getProperty<string>('appId');
+    return this.getProperty('appId');
   }
   protected set appId(value: string) {
-    this.setProperty<string>('appId', value);
+    this.setProperty('appId', value);
   }
 
   get onesignalId(): string {
-    return this.getProperty<string>('onesignalId');
+    return this.getProperty('onesignalId');
   }
   protected set onesignalId(value: string) {
-    this.setProperty<string>('onesignalId', value);
+    this.setProperty('onesignalId', value);
   }
 
   /**

--- a/src/core/operations/SetAliasOperation.ts
+++ b/src/core/operations/SetAliasOperation.ts
@@ -1,9 +1,13 @@
 import { OPERATION_NAME } from '../executors/constants';
 import { BaseAliasOperation } from './BaseAliasOperation';
 
+type AliasOp = {
+  value: string;
+};
+
 // Implements logic similar to Android SDK's SetAliasOperation
 // Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/SetAliasOperation.kt
-export class SetAliasOperation extends BaseAliasOperation {
+export class SetAliasOperation extends BaseAliasOperation<AliasOp> {
   constructor();
   constructor(appId: string, onesignalId: string, label: string, value: string);
   constructor(
@@ -17,10 +21,10 @@ export class SetAliasOperation extends BaseAliasOperation {
   }
 
   get value(): string {
-    return this.getProperty<string>('value');
+    return this.getProperty('value');
   }
   private set value(value: string) {
-    this.setProperty<string>('value', value);
+    this.setProperty('value', value);
   }
 
   override get modifyComparisonKey(): string {

--- a/src/core/operations/SetTagOperation.ts
+++ b/src/core/operations/SetTagOperation.ts
@@ -1,11 +1,15 @@
 import { OPERATION_NAME } from '../executors/constants';
 import { BaseTagOperation } from './BaseTagOperation';
 
+type TagOp = {
+  value: string;
+};
+
 /**
  * An Operation to create/update a tag in the OneSignal backend. The tag will
  * be associated to the user with the appId and onesignalId provided.
  */
-export class SetTagOperation extends BaseTagOperation {
+export class SetTagOperation extends BaseTagOperation<TagOp> {
   constructor();
   constructor(appId: string, onesignalId: string, key: string, value: string);
   constructor(
@@ -22,9 +26,9 @@ export class SetTagOperation extends BaseTagOperation {
    * The new/updated tag value.
    */
   get value(): string {
-    return this.getProperty<string>('value');
+    return this.getProperty('value');
   }
   private set value(value: string) {
-    this.setProperty<string>('value', value);
+    this.setProperty('value', value);
   }
 }

--- a/src/types/operation.ts
+++ b/src/types/operation.ts
@@ -52,17 +52,6 @@ export interface IOperationExecutor {
   execute(operations: Operation[]): Promise<ExecutionResponse>;
 }
 
-export interface ConfigModel {
-  opRepoExecutionInterval: number;
-  opRepoPostWakeDelay: number;
-  opRepoPostCreateDelay: number;
-  opRepoDefaultFailRetryBackoff: number;
-}
-
-export interface ConfigModelStore {
-  model: ConfigModel;
-}
-
 export interface OperationModelStore {
   add(operation: Operation): void;
   add(index: number, operation: Operation): void;


### PR DESCRIPTION
# Description
## 1 Line Summary
Continuation of the [Web SDK Refactor project](https://docs.google.com/document/d/1JsbmxVM_n6K9nRXwbJf6mQr5h88qy_vIEiBGY0Ub_lE/edit?tab=t.0#heading=h.ojv84gskof17).

## Details
- Implements [LoginUserOperationExecutor](https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt)
- Ill make separate pr to implement `PropertiesModel` and `SubscriptionsModel`
- Updated Model class to have generics , useful when using toJSON in the `createSubscriptionsFromOperation` method
- Did not implement properties for SubscriptionObject like `deviceOs`, `rooted`, `netType`, and `carrier`, and `appVersion`

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1277)
<!-- Reviewable:end -->
