### PR TITLE
Web SDK Refactor: Login Operation Executor Tests

### DIFF
--- a/__test__/setupTests.ts
+++ b/__test__/setupTests.ts
@@ -3,6 +3,9 @@ beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
+// set timezone
+process.env.TZ = 'America/Los_Angeles';
+
 global.isSecureContext = true;
 
 Object.defineProperty(global, 'location', {

--- a/__test__/support/constants.ts
+++ b/__test__/support/constants.ts
@@ -21,11 +21,15 @@ export const APP_ID = '34fcbe85-278d-4fd2-a4ec-0f80e95072c5';
 
 export const DUMMY_PUSH_TOKEN =
   'https://fcm.googleapis.com/fcm/send/01010101010101';
+export const DUMMY_PUSH_TOKEN_2 =
+  'https://fcm.googleapis.com/fcm/send/01010101010102';
+
 export const DUMMY_ONESIGNAL_ID = '1111111111-2222222222-3333333333';
 export const DUMMY_ONESIGNAL_ID_2 = '2222222222-3333333333-4444444444';
 export const DUMMY_EXTERNAL_ID = 'rodrigo';
 export const DUMMY_EXTERNAL_ID_2 = 'iryna';
 export const DUMMY_SUBSCRIPTION_ID = '4444444444-5555555555-6666666666';
+export const DUMMY_SUBSCRIPTION_ID_2 = '7777777777-8888888888-9999999999';
 export const DUMMY_MODEL_ID = '0000000000';
 
 /* REQUEST CONSTANTS */

--- a/__test__/support/helpers/executors.ts
+++ b/__test__/support/helpers/executors.ts
@@ -1,0 +1,48 @@
+import { GroupComparisonType, Operation } from 'src/core/operations/Operation';
+import { IPreferencesService } from 'src/core/types/preferences';
+import { IRebuildUserService } from 'src/core/types/user';
+
+export class SomeOperation extends Operation {
+  constructor() {
+    super('some-operation');
+  }
+
+  get applyToRecordId() {
+    return '';
+  }
+
+  get createComparisonKey() {
+    return '';
+  }
+
+  get modifyComparisonKey() {
+    return '';
+  }
+
+  get groupComparisonType() {
+    return GroupComparisonType.CREATE;
+  }
+
+  get canStartExecute() {
+    return true;
+  }
+}
+
+// TODO: Revisit after implementing BuildUserService
+export const getRebuildOpsFn = vi.fn();
+export class BuildUserService implements IRebuildUserService {
+  getRebuildOperationsIfCurrentUser(...args: any[]) {
+    return getRebuildOpsFn(...args);
+  }
+}
+
+export const getValueFn = vi.fn().mockReturnValue('{}');
+export const setValueFn = vi.fn();
+export class MockPreferencesService implements IPreferencesService {
+  getValue(...args: any[]) {
+    return getValueFn(...args);
+  }
+  setValue(...args: any[]) {
+    return setValueFn(...args);
+  }
+}

--- a/src/core/executors/IdentityOperationExecutor.test.ts
+++ b/src/core/executors/IdentityOperationExecutor.test.ts
@@ -1,14 +1,18 @@
 import { APP_ID, DUMMY_ONESIGNAL_ID } from '__test__/support/constants';
+import {
+  BuildUserService,
+  getRebuildOpsFn,
+  getValueFn,
+  MockPreferencesService,
+  SomeOperation,
+} from '__test__/support/helpers/executors';
 import { server } from '__test__/support/mocks/server';
 import { http, HttpResponse } from 'msw';
 import { ExecutionResult } from 'src/core/types/operation';
-import { IPreferencesService } from 'src/core/types/preferences';
-import { IRebuildUserService } from 'src/core/types/user';
 import { IdentityConstants, OPERATION_NAME } from '../constants';
 import { IdentityModelStore } from '../modelStores/IdentityModelStore';
 import { NewRecordsState } from '../operationRepo/NewRecordsState';
 import { DeleteAliasOperation } from '../operations/DeleteAliasOperation';
-import { GroupComparisonType, Operation } from '../operations/Operation';
 import { SetAliasOperation } from '../operations/SetAliasOperation';
 import { IdentityOperationExecutor } from './IdentityOperationExecutor';
 
@@ -234,48 +238,3 @@ describe('IdentityOperationExecutor', () => {
     });
   });
 });
-
-// TODO: Revisit after implementing IdentityBackendService
-const getValueFn = vi.fn().mockReturnValue('{}');
-const setValueFn = vi.fn();
-class MockPreferencesService implements IPreferencesService {
-  getValue(...args: any[]) {
-    return getValueFn(...args);
-  }
-  setValue(...args: any[]) {
-    return setValueFn(...args);
-  }
-}
-// TODO: Revisit after implementing BuildUserService
-const getRebuildOpsFn = vi.fn();
-class BuildUserService implements IRebuildUserService {
-  getRebuildOperationsIfCurrentUser(...args: any[]) {
-    return getRebuildOpsFn(...args);
-  }
-}
-
-class SomeOperation extends Operation {
-  constructor() {
-    super('some-operation');
-  }
-
-  get applyToRecordId() {
-    return '';
-  }
-
-  get createComparisonKey() {
-    return '';
-  }
-
-  get modifyComparisonKey() {
-    return '';
-  }
-
-  get groupComparisonType() {
-    return GroupComparisonType.CREATE;
-  }
-
-  get canStartExecute() {
-    return true;
-  }
-}

--- a/src/core/executors/LoginUserOperationExecutor.test.ts
+++ b/src/core/executors/LoginUserOperationExecutor.test.ts
@@ -22,7 +22,7 @@ import { IdentityModelStore } from '../modelStores/IdentityModelStore';
 import { PropertiesModelStore } from '../modelStores/PropertiesModelStore';
 import { SubscriptionModelStore } from '../modelStores/SubscriptionModelStore';
 import { NewRecordsState } from '../operationRepo/NewRecordsState';
-import { SubscriptionWithAppId } from '../operations/BaseSubscriptionOperation';
+import { SubscriptionWithAppId } from '../operations/BaseFullSubscriptionOperation';
 import { CreateSubscriptionOperation } from '../operations/CreateSubscriptionOperation';
 import { DeleteSubscriptionOperation } from '../operations/DeleteSubscriptionOperation';
 import { LoginUserOperation } from '../operations/LoginUserOperation';

--- a/src/core/executors/LoginUserOperationExecutor.test.ts
+++ b/src/core/executors/LoginUserOperationExecutor.test.ts
@@ -1,0 +1,532 @@
+import {
+  APP_ID,
+  DUMMY_EXTERNAL_ID,
+  DUMMY_ONESIGNAL_ID,
+  DUMMY_ONESIGNAL_ID_2,
+  DUMMY_PUSH_TOKEN,
+  DUMMY_PUSH_TOKEN_2,
+  DUMMY_SUBSCRIPTION_ID,
+  DUMMY_SUBSCRIPTION_ID_2,
+} from '__test__/support/constants';
+import {
+  BuildUserService,
+  MockPreferencesService,
+  SomeOperation,
+} from '__test__/support/helpers/executors';
+import { server } from '__test__/support/mocks/server';
+import { http, HttpResponse } from 'msw';
+import { IdentityConstants, OPERATION_NAME } from '../constants';
+import { SubscriptionModel } from '../models/SubscriptionModel';
+import { ConfigModelStore } from '../modelStores/ConfigModelStore';
+import { IdentityModelStore } from '../modelStores/IdentityModelStore';
+import { PropertiesModelStore } from '../modelStores/PropertiesModelStore';
+import { SubscriptionModelStore } from '../modelStores/SubscriptionModelStore';
+import { NewRecordsState } from '../operationRepo/NewRecordsState';
+import { SubscriptionWithAppId } from '../operations/BaseSubscriptionOperation';
+import { CreateSubscriptionOperation } from '../operations/CreateSubscriptionOperation';
+import { DeleteSubscriptionOperation } from '../operations/DeleteSubscriptionOperation';
+import { LoginUserOperation } from '../operations/LoginUserOperation';
+import { RefreshUserOperation } from '../operations/RefreshUserOperation';
+import { TransferSubscriptionOperation } from '../operations/TransferSubscriptionOperation';
+import { UpdateSubscriptionOperation } from '../operations/UpdateSubscriptionOperation';
+import {
+  ICreateUser,
+  ISubscription,
+  NotificationType,
+  SubscriptionType,
+} from '../types/api';
+import { ModelChangeTags } from '../types/models';
+import { ExecutionResult } from '../types/operation';
+import { IdentityOperationExecutor } from './IdentityOperationExecutor';
+import { LoginUserOperationExecutor } from './LoginUserOperationExecutor';
+
+let identityPrefs: MockPreferencesService;
+let identityModelStore: IdentityModelStore;
+let propertiesModelStore: PropertiesModelStore;
+let configModelStore: ConfigModelStore;
+let subscriptionModelStore: SubscriptionModelStore;
+
+vi.mock('src/shared/libraries/Log');
+
+describe('LoginUserOperationExecutor', () => {
+  beforeEach(() => {
+    identityPrefs = new MockPreferencesService();
+    identityModelStore = new IdentityModelStore(identityPrefs);
+    propertiesModelStore = new PropertiesModelStore(identityPrefs);
+    configModelStore = new ConfigModelStore(identityPrefs);
+    subscriptionModelStore = new SubscriptionModelStore(identityPrefs);
+  });
+
+  const getExecutor = () => {
+    return new LoginUserOperationExecutor(
+      new IdentityOperationExecutor(
+        identityModelStore,
+        new BuildUserService(),
+        new NewRecordsState(),
+      ),
+      identityModelStore,
+      propertiesModelStore,
+      subscriptionModelStore,
+      configModelStore,
+    );
+  };
+
+  test('should return correct operations (names)', async () => {
+    const executor = getExecutor();
+
+    expect(executor.operations).toEqual([OPERATION_NAME.LOGIN_USER]);
+  });
+
+  test('should validate operations', async () => {
+    const executor = getExecutor();
+
+    const someOp = new SomeOperation();
+
+    // with invalid ops
+    const ops = [someOp];
+    const result = executor.execute(ops);
+    await expect(() => result).rejects.toThrow(
+      `Unrecognized operation: {"name":"${someOp.name}"}`,
+    );
+  });
+
+  describe('create user', () => {
+    beforeEach(() => {
+      setCreateUser(DUMMY_ONESIGNAL_ID);
+    });
+
+    test('should fail if there are invalid operations', async () => {
+      const executor = getExecutor();
+
+      // login op with create subscription op and no externalId
+      const loginOp = new LoginUserOperation(APP_ID, DUMMY_ONESIGNAL_ID);
+
+      const ops = [loginOp];
+      const res = await executor.execute(ops);
+      expect(res.result).toBe(ExecutionResult.FAIL_NORETRY);
+
+      // login op with subscription op and random operation
+      const transferSubOp = new TransferSubscriptionOperation(
+        APP_ID,
+        DUMMY_ONESIGNAL_ID,
+        mockSubscriptionOpInfo.subscriptionId,
+      );
+      const someOp = new SomeOperation();
+      const ops2 = [loginOp, transferSubOp, someOp];
+      const res2 = executor.execute(ops2);
+      await expect(res2).rejects.toThrow(
+        `Unrecognized operation: {"name":"${someOp.name}"}`,
+      );
+    });
+
+    test('can create user if there is no onesignal id or externalId', async () => {
+      const executor = getExecutor();
+
+      const loginOp = new LoginUserOperation(APP_ID, DUMMY_ONESIGNAL_ID_2);
+      const createSubOp = new CreateSubscriptionOperation(
+        mockSubscriptionOpInfo,
+      );
+
+      const ops = [loginOp, createSubOp];
+      const res = await executor.execute(ops);
+
+      expect(res).toEqual({
+        result: ExecutionResult.SUCCESS,
+        retryAfterSeconds: undefined,
+        operations: undefined,
+        idTranslations: {
+          [DUMMY_ONESIGNAL_ID_2]: DUMMY_ONESIGNAL_ID,
+        },
+      });
+    });
+
+    test('can create user with existing subscription and follow up operations', async () => {
+      const someSubscription = {
+        app_id: APP_ID,
+        id: DUMMY_SUBSCRIPTION_ID_2,
+        type: SubscriptionType.ChromePush,
+        token: DUMMY_PUSH_TOKEN,
+      };
+      // @ts-expect-error - TODO: add more properties to subscription
+      setCreateUser(DUMMY_ONESIGNAL_ID_2, [someSubscription]);
+
+      // have identity model, config, properties model have the same onesignalId to check
+      // that their properties are updated
+      identityModelStore.model.setProperty(
+        IdentityConstants.ONESIGNAL_ID,
+        DUMMY_ONESIGNAL_ID,
+      );
+      propertiesModelStore.model.setProperty('onesignalId', DUMMY_ONESIGNAL_ID);
+      configModelStore.model.pushSubscriptionId = DUMMY_SUBSCRIPTION_ID;
+
+      const subscriptionModel = new SubscriptionModel();
+      subscriptionModel.setProperty('id', DUMMY_SUBSCRIPTION_ID);
+      subscriptionModelStore.add(subscriptionModel, ModelChangeTags.HYDRATE);
+
+      // perform operations with old onesignal id
+      const executor = getExecutor();
+
+      const loginOp = new LoginUserOperation(APP_ID, DUMMY_ONESIGNAL_ID);
+      loginOp.setProperty('externalId', DUMMY_EXTERNAL_ID);
+
+      const createSubOp = new CreateSubscriptionOperation(
+        mockSubscriptionOpInfo,
+      );
+
+      const ops = [loginOp, createSubOp];
+      const res = await executor.execute(ops);
+
+      // should update model properties
+      expect(
+        identityModelStore.model.getProperty(IdentityConstants.ONESIGNAL_ID),
+      ).toEqual(DUMMY_ONESIGNAL_ID_2);
+      expect(propertiesModelStore.model.getProperty('onesignalId')).toEqual(
+        DUMMY_ONESIGNAL_ID_2,
+      );
+      expect(configModelStore.model.pushSubscriptionId).toEqual(
+        DUMMY_SUBSCRIPTION_ID_2,
+      );
+      expect(subscriptionModel.getProperty('id')).toEqual(
+        DUMMY_SUBSCRIPTION_ID_2,
+      );
+
+      // should have a refresh user operation
+      expect(res).toEqual({
+        result: ExecutionResult.SUCCESS,
+        retryAfterSeconds: undefined,
+        operations: [new RefreshUserOperation(APP_ID, DUMMY_ONESIGNAL_ID_2)],
+        idTranslations: {
+          [DUMMY_ONESIGNAL_ID]: DUMMY_ONESIGNAL_ID_2,
+          [DUMMY_SUBSCRIPTION_ID]: DUMMY_SUBSCRIPTION_ID_2,
+        },
+      });
+    });
+
+    test('should handle network errors', async () => {
+      const executor = getExecutor();
+
+      const loginOp = new LoginUserOperation(APP_ID, DUMMY_ONESIGNAL_ID);
+      const createSubOp = new CreateSubscriptionOperation(
+        mockSubscriptionOpInfo,
+      );
+
+      const ops = [loginOp, createSubOp];
+
+      // retryable error
+      setCreateUserError(429, 10);
+      const res = await executor.execute(ops);
+      expect(res).toEqual({
+        result: ExecutionResult.FAIL_RETRY,
+        retryAfterSeconds: 10,
+      });
+
+      // unauthorized error
+      setCreateUserError(401, 15);
+      const res2 = await executor.execute(ops);
+      expect(res2).toEqual({
+        result: ExecutionResult.FAIL_UNAUTHORIZED,
+        retryAfterSeconds: 15,
+      });
+
+      // others errors - pause repo
+      setCreateUserError(400, 20);
+      const res3 = await executor.execute(ops);
+      expect(res3).toEqual({
+        result: ExecutionResult.FAIL_PAUSE_OPREPO,
+        retryAfterSeconds: undefined,
+      });
+    });
+  });
+
+  describe('login user', () => {
+    const setAddAlias = (onesignalId: string) => {
+      server.use(
+        http.patch(
+          `**/api/v1/apps/${APP_ID}/users/by/onesignal_id/${onesignalId}/identity`,
+          () =>
+            HttpResponse.json({
+              identity: {
+                onesignal_id: onesignalId,
+              },
+            }),
+        ),
+      );
+    };
+
+    const setAddAliasError = (status: number, retryAfter?: number) => {
+      server.use(
+        http.patch(
+          `**/api/v1/apps/${APP_ID}/users/by/onesignal_id/${DUMMY_ONESIGNAL_ID}/identity`,
+          () =>
+            HttpResponse.json(
+              {},
+              {
+                status,
+                headers: retryAfter
+                  ? { 'Retry-After': retryAfter?.toString() }
+                  : undefined,
+              },
+            ),
+        ),
+      );
+    };
+
+    test('can add/set alias when logging in a user with existing onesignal id', async () => {
+      identityModelStore.model.setProperty(
+        IdentityConstants.ONESIGNAL_ID,
+        DUMMY_ONESIGNAL_ID,
+      );
+      propertiesModelStore.model.setProperty('onesignalId', DUMMY_ONESIGNAL_ID);
+
+      const executor = getExecutor();
+
+      const loginOp = new LoginUserOperation(APP_ID, DUMMY_ONESIGNAL_ID);
+      loginOp.setProperty('externalId', DUMMY_EXTERNAL_ID);
+
+      // different id for testing id translations
+      loginOp.setProperty('existingOnesignalId', DUMMY_ONESIGNAL_ID_2);
+      setAddAlias(DUMMY_ONESIGNAL_ID_2);
+
+      const ops = [loginOp];
+      const res = await executor.execute(ops);
+
+      // should update model properties
+      expect(
+        identityModelStore.model.getProperty(IdentityConstants.ONESIGNAL_ID),
+      ).toEqual(DUMMY_ONESIGNAL_ID_2);
+      expect(propertiesModelStore.model.getProperty('onesignalId')).toEqual(
+        DUMMY_ONESIGNAL_ID_2,
+      );
+
+      expect(res).toEqual({
+        result: ExecutionResult.SUCCESS_STARTING_ONLY,
+        idTranslations: {
+          [DUMMY_ONESIGNAL_ID]: DUMMY_ONESIGNAL_ID_2,
+        },
+      });
+    });
+
+    test('can handle network errors', async () => {
+      const executor = getExecutor();
+
+      const loginOp = new LoginUserOperation(APP_ID, DUMMY_ONESIGNAL_ID);
+      loginOp.setProperty('externalId', DUMMY_EXTERNAL_ID);
+      loginOp.setProperty('existingOnesignalId', DUMMY_ONESIGNAL_ID);
+
+      // Conflict error - should create user
+      setAddAliasError(409);
+      setCreateUser('123');
+
+      const res = await executor.execute([loginOp]);
+      expect(res).toMatchObject({
+        result: ExecutionResult.SUCCESS,
+        idTranslations: {
+          [DUMMY_ONESIGNAL_ID]: '123',
+        },
+      });
+
+      // Fail no retry - should create user
+      setAddAliasError(400);
+      setCreateUser('456');
+
+      const res2 = await executor.execute([loginOp]);
+      expect(res2).toMatchObject({
+        result: ExecutionResult.SUCCESS,
+        idTranslations: {
+          [DUMMY_ONESIGNAL_ID]: '456',
+        },
+      });
+
+      // Some other error
+      setAddAliasError(401);
+
+      const res3 = await executor.execute([loginOp]);
+      expect(res3).toMatchObject({
+        result: ExecutionResult.FAIL_UNAUTHORIZED,
+      });
+    });
+  });
+
+  describe('create subscriptions', () => {
+    test('can create a subscriptions', async () => {
+      setCreateUser(DUMMY_ONESIGNAL_ID);
+      const executor = getExecutor();
+
+      const loginOp = new LoginUserOperation(APP_ID, DUMMY_ONESIGNAL_ID);
+      loginOp.setProperty('externalId', DUMMY_EXTERNAL_ID);
+
+      const createSubOp = new CreateSubscriptionOperation(
+        mockSubscriptionOpInfo,
+      );
+
+      const ops = [loginOp, createSubOp];
+      await executor.execute(ops);
+
+      expect(createUserFn).toHaveBeenCalledWith({
+        identity: {
+          external_id: DUMMY_EXTERNAL_ID,
+        },
+        properties: {
+          language: 'en',
+          timezone_id: 'America/Los_Angeles',
+        },
+        refresh_device_metadata: true,
+        subscriptions: [
+          {
+            token: mockSubscriptionOpInfo.token,
+            type: mockSubscriptionOpInfo.type,
+          },
+        ],
+      });
+    });
+
+    test('can update a subscription', async () => {
+      setCreateUser(DUMMY_ONESIGNAL_ID);
+      const executor = getExecutor();
+
+      const loginOp = new LoginUserOperation(APP_ID, DUMMY_ONESIGNAL_ID);
+      loginOp.setProperty('externalId', DUMMY_EXTERNAL_ID);
+
+      // needs to be created first for update to do anything
+      const createSubOp = new CreateSubscriptionOperation(
+        mockSubscriptionOpInfo,
+      );
+      const updates = {
+        enabled: false,
+        notification_types: NotificationType.NotSubscribed,
+        token: DUMMY_PUSH_TOKEN_2,
+      };
+      const updateSubOp = new UpdateSubscriptionOperation({
+        ...mockSubscriptionOpInfo,
+        ...updates,
+      });
+
+      // with create sub op
+      const ops = [loginOp, createSubOp, updateSubOp];
+      await executor.execute(ops);
+
+      expect(createUserFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subscriptions: [
+            {
+              type: mockSubscriptionOpInfo.type,
+              ...updates,
+            },
+          ],
+        }),
+      );
+
+      // with no create sub op
+      createUserFn.mockClear();
+      await executor.execute([loginOp, updateSubOp]);
+      expect(createUserFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subscriptions: [],
+        }),
+      );
+    });
+
+    test('can transfer a subscription', async () => {
+      setCreateUser(DUMMY_ONESIGNAL_ID);
+      const executor = getExecutor();
+
+      const loginOp = new LoginUserOperation(APP_ID, DUMMY_ONESIGNAL_ID);
+      loginOp.setProperty('externalId', DUMMY_EXTERNAL_ID);
+
+      // need to create subscription first to test transfer
+      const createSubOp = new CreateSubscriptionOperation(
+        mockSubscriptionOpInfo,
+      );
+      const transferSubOp = new TransferSubscriptionOperation(
+        APP_ID,
+        DUMMY_ONESIGNAL_ID,
+        createSubOp.subscriptionId,
+      );
+
+      const ops = [loginOp, createSubOp, transferSubOp];
+      await executor.execute(ops);
+
+      // should have id in the subscription
+      expect(createUserFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subscriptions: [
+            {
+              id: DUMMY_SUBSCRIPTION_ID,
+              type: mockSubscriptionOpInfo.type,
+              token: mockSubscriptionOpInfo.token,
+            },
+          ],
+        }),
+      );
+    });
+
+    test('can delete a subscription', async () => {
+      setCreateUser(DUMMY_ONESIGNAL_ID);
+      const executor = getExecutor();
+
+      const loginOp = new LoginUserOperation(APP_ID, DUMMY_ONESIGNAL_ID);
+      loginOp.setProperty('externalId', DUMMY_EXTERNAL_ID);
+
+      // need to create subscription first to test delete
+      const createSubOp = new CreateSubscriptionOperation(
+        mockSubscriptionOpInfo,
+      );
+      const deleteSubOp = new DeleteSubscriptionOperation(
+        APP_ID,
+        DUMMY_ONESIGNAL_ID,
+        createSubOp.subscriptionId,
+      );
+
+      const ops = [loginOp, createSubOp, deleteSubOp];
+      await executor.execute(ops);
+
+      expect(createUserFn).toHaveBeenCalledWith(
+        expect.objectContaining({ subscriptions: [] }),
+      );
+    });
+  });
+});
+
+const mockSubscriptionOpInfo = {
+  appId: APP_ID,
+  onesignalId: DUMMY_ONESIGNAL_ID,
+  subscriptionId: DUMMY_SUBSCRIPTION_ID,
+  token: DUMMY_PUSH_TOKEN,
+  type: SubscriptionType.ChromePush,
+} satisfies SubscriptionWithAppId;
+
+const createUserUri = `**/api/v1/apps/${APP_ID}/users`;
+
+const createUserFn = vi.fn();
+const setCreateUser = (
+  onesignalId: string,
+  subscriptions?: ISubscription[],
+) => {
+  server.use(
+    http.post(createUserUri, async ({ request }) => {
+      createUserFn(await request.json());
+      return HttpResponse.json({
+        identity: {
+          onesignal_id: onesignalId,
+        },
+        subscriptions,
+      } satisfies ICreateUser);
+    }),
+  );
+};
+
+const setCreateUserError = (status: number, retryAfter?: number) => {
+  server.use(
+    http.post(createUserUri, () =>
+      HttpResponse.json(
+        { error: 'error' },
+        {
+          status,
+          headers: retryAfter
+            ? { 'Retry-After': retryAfter?.toString() }
+            : undefined,
+        },
+      ),
+    ),
+  );
+};

--- a/src/core/models/Model.ts
+++ b/src/core/models/Model.ts
@@ -97,7 +97,6 @@ export class Model<
   get id(): string {
     return this.getProperty('id') as string;
   }
-
   set id(value: string) {
     this.setProperty('id', value);
   }

--- a/src/core/operations/BaseFullSubscriptionOperation.ts
+++ b/src/core/operations/BaseFullSubscriptionOperation.ts
@@ -1,0 +1,132 @@
+import {
+  ICreateUserSubscription,
+  NotificationTypeValue,
+  SubscriptionTypeValue,
+} from '../types/api';
+import { BaseSubscriptionOperation } from './BaseSubscriptionOperation';
+
+type SubscriptionOp = ICreateUserSubscription & {
+  subscriptionId: string;
+};
+
+export type SubscriptionWithAppId = SubscriptionOp & {
+  appId: string;
+  onesignalId: string;
+};
+
+/**
+ * Base class for subscription-related operations with full properties
+ */
+export abstract class BaseFullSubscriptionOperation extends BaseSubscriptionOperation<SubscriptionOp> {
+  constructor(
+    operationName: string,
+    appId?: string,
+    onesignalId?: string,
+    subscription?: SubscriptionOp,
+  ) {
+    super(operationName, appId, onesignalId);
+
+    if (subscription) {
+      this.device_model = subscription.device_model;
+      this.device_os = subscription.device_os;
+      this.enabled = subscription.enabled;
+      this.notification_types = subscription.notification_types;
+      this.sdk = subscription.sdk;
+      this.subscriptionId = subscription.subscriptionId;
+      this.token = subscription.token;
+      this.type = subscription.type;
+      this.web_auth = subscription.web_auth;
+      this.web_p256 = subscription.web_p256;
+    }
+  }
+
+  /**
+   * The type of subscription.
+   */
+  public get type(): SubscriptionTypeValue {
+    return this.getProperty('type');
+  }
+  protected set type(value: SubscriptionTypeValue) {
+    this.setProperty('type', value);
+  }
+
+  /**
+   * The token for the subscription.
+   */
+  public get token(): string {
+    return this.getProperty('token');
+  }
+  protected set token(value: string) {
+    this.setProperty('token', value);
+  }
+
+  /**
+   * Whether this subscription is currently enabled.
+   */
+  get enabled(): boolean | undefined {
+    return this.getProperty('enabled');
+  }
+  protected set enabled(value: boolean | undefined) {
+    this.setProperty('enabled', value);
+  }
+
+  /**
+   * The notification types this subscription is subscribed to.
+   */
+  get notification_types(): NotificationTypeValue | undefined {
+    return this.getProperty('notification_types');
+  }
+  protected set notification_types(value: NotificationTypeValue | undefined) {
+    this.setProperty('notification_types', value);
+  }
+
+  /**
+   * The SDK identifier
+   */
+  get sdk(): string | undefined {
+    return this.getProperty('sdk');
+  }
+  protected set sdk(value: string | undefined) {
+    this.setProperty('sdk', value);
+  }
+
+  /**
+   * The device model
+   */
+  get device_model(): string | undefined {
+    return this.getProperty('device_model');
+  }
+  protected set device_model(value: string | undefined) {
+    this.setProperty('device_model', value);
+  }
+
+  /**
+   * The device OS version
+   */
+  get device_os(): string | undefined {
+    return this.getProperty('device_os');
+  }
+  protected set device_os(value: string | undefined) {
+    this.setProperty('device_os', value);
+  }
+
+  /**
+   * Web authentication value
+   */
+  get web_auth(): string | undefined {
+    return this.getProperty('web_auth');
+  }
+  protected set web_auth(value: string | undefined) {
+    this.setProperty('web_auth', value);
+  }
+
+  /**
+   * Web P256 value
+   */
+  get web_p256(): string | undefined {
+    return this.getProperty('web_p256');
+  }
+  protected set web_p256(value: string | undefined) {
+    this.setProperty('web_p256', value);
+  }
+}

--- a/src/core/operations/BaseSubscriptionOperation.ts
+++ b/src/core/operations/BaseSubscriptionOperation.ts
@@ -1,44 +1,25 @@
 import { IDManager } from 'src/shared/managers/IDManager';
-import {
-  ICreateUserSubscription,
-  NotificationTypeValue,
-  SubscriptionTypeValue,
-} from '../types/api';
 import { Operation } from './Operation';
 
-type SubscriptionOp = ICreateUserSubscription & {
+export type BaseSubOp = {
   subscriptionId: string;
 };
 
-export type SubscriptionWithAppId = SubscriptionOp & {
-  appId: string;
-  onesignalId: string;
-};
-
 /**
- * Base class for subscription-related operations
+ * Base class for subscription-related operations that just need a subscriptionId
  */
-export abstract class BaseSubscriptionOperation extends Operation<SubscriptionOp> {
+export abstract class BaseSubscriptionOperation<
+  U extends object = BaseSubOp,
+  T extends U & BaseSubOp = U & BaseSubOp,
+> extends Operation<T> {
   constructor(
     operationName: string,
     appId?: string,
     onesignalId?: string,
-    subscription?: SubscriptionOp,
+    subscriptionId?: string,
   ) {
     super(operationName, appId, onesignalId);
-
-    if (subscription) {
-      this.device_model = subscription.device_model;
-      this.device_os = subscription.device_os;
-      this.enabled = subscription.enabled;
-      this.notification_types = subscription.notification_types;
-      this.sdk = subscription.sdk;
-      this.subscriptionId = subscription.subscriptionId;
-      this.token = subscription.token;
-      this.type = subscription.type;
-      this.web_auth = subscription.web_auth;
-      this.web_p256 = subscription.web_p256;
-    }
+    if (subscriptionId) this.subscriptionId = subscriptionId;
   }
 
   /**
@@ -50,96 +31,6 @@ export abstract class BaseSubscriptionOperation extends Operation<SubscriptionOp
   }
   protected set subscriptionId(value: string) {
     this.setProperty('subscriptionId', value);
-  }
-
-  /**
-   * The type of subscription.
-   */
-  public get type(): SubscriptionTypeValue {
-    return this.getProperty('type');
-  }
-  protected set type(value: SubscriptionTypeValue) {
-    this.setProperty('type', value);
-  }
-
-  /**
-   * The token for the subscription.
-   */
-  public get token(): string {
-    return this.getProperty('token');
-  }
-  protected set token(value: string) {
-    this.setProperty('token', value);
-  }
-
-  /**
-   * Whether this subscription is currently enabled.
-   */
-  get enabled(): boolean | undefined {
-    return this.getProperty('enabled');
-  }
-  protected set enabled(value: boolean | undefined) {
-    this.setProperty('enabled', value);
-  }
-
-  /**
-   * The notification types this subscription is subscribed to.
-   */
-  get notification_types(): NotificationTypeValue | undefined {
-    return this.getProperty('notification_types');
-  }
-  protected set notification_types(value: NotificationTypeValue | undefined) {
-    this.setProperty('notification_types', value);
-  }
-
-  /**
-   * The SDK identifier
-   */
-  get sdk(): string | undefined {
-    return this.getProperty('sdk');
-  }
-  protected set sdk(value: string | undefined) {
-    this.setProperty('sdk', value);
-  }
-
-  /**
-   * The device model
-   */
-  get device_model(): string | undefined {
-    return this.getProperty('device_model');
-  }
-  protected set device_model(value: string | undefined) {
-    this.setProperty('device_model', value);
-  }
-
-  /**
-   * The device OS version
-   */
-  get device_os(): string | undefined {
-    return this.getProperty('device_os');
-  }
-  protected set device_os(value: string | undefined) {
-    this.setProperty('device_os', value);
-  }
-
-  /**
-   * Web authentication value
-   */
-  get web_auth(): string | undefined {
-    return this.getProperty('web_auth');
-  }
-  protected set web_auth(value: string | undefined) {
-    this.setProperty('web_auth', value);
-  }
-
-  /**
-   * Web P256 value
-   */
-  get web_p256(): string | undefined {
-    return this.getProperty('web_p256');
-  }
-  protected set web_p256(value: string | undefined) {
-    this.setProperty('web_p256', value);
   }
 
   override get createComparisonKey(): string {

--- a/src/core/operations/CreateSubscriptionOperation.ts
+++ b/src/core/operations/CreateSubscriptionOperation.ts
@@ -1,15 +1,15 @@
 import { IDManager } from 'src/shared/managers/IDManager';
 import { OPERATION_NAME } from '../constants';
 import {
-  BaseSubscriptionOperation,
+  BaseFullSubscriptionOperation,
   SubscriptionWithAppId,
-} from './BaseSubscriptionOperation';
+} from './BaseFullSubscriptionOperation';
 
 /**
  * An Operation to create a new subscription in the OneSignal backend. The subscription will
  * be associated to the user with the appId and onesignalId provided.
  */
-export class CreateSubscriptionOperation extends BaseSubscriptionOperation {
+export class CreateSubscriptionOperation extends BaseFullSubscriptionOperation {
   constructor(subscription?: SubscriptionWithAppId) {
     super(
       OPERATION_NAME.CREATE_SUBSCRIPTION,

--- a/src/core/operations/DeleteSubscriptionOperation.ts
+++ b/src/core/operations/DeleteSubscriptionOperation.ts
@@ -1,11 +1,20 @@
+import { IDManager } from 'src/shared/managers/IDManager';
 import { OPERATION_NAME } from '../constants';
-import { BaseSubscriptionOperation } from './BaseSubscriptionOperation';
-import { GroupComparisonType, GroupComparisonValue } from './Operation';
+import {
+  GroupComparisonType,
+  GroupComparisonValue,
+  Operation,
+} from './Operation';
+
+type DeleteOp = {
+  subscriptionId: string;
+};
 
 /**
  * An Operation to delete a subscription from the OneSignal backend.
  */
-export class DeleteSubscriptionOperation extends BaseSubscriptionOperation {
+export class DeleteSubscriptionOperation extends Operation<DeleteOp> {
+  constructor(appId: string, onesignalId: string, subscriptionId: string);
   constructor(appId?: string, onesignalId?: string, subscriptionId?: string) {
     super(OPERATION_NAME.DELETE_SUBSCRIPTION, appId, onesignalId);
     if (subscriptionId) {
@@ -13,7 +22,43 @@ export class DeleteSubscriptionOperation extends BaseSubscriptionOperation {
     }
   }
 
+  /**
+   * The subscription ID for the operation. This ID *may* be locally generated
+   * and can be checked via IDManager.isLocalId to ensure correct processing.
+   */
+  get subscriptionId(): string {
+    return this.getProperty('subscriptionId');
+  }
+  protected set subscriptionId(value: string) {
+    this.setProperty('subscriptionId', value);
+  }
+
+  override get createComparisonKey(): string {
+    return `${this.appId}.User.${this.onesignalId}`;
+  }
+  override get modifyComparisonKey(): string {
+    return `${this.appId}.User.${this.onesignalId}.Subscription.${this.subscriptionId}`;
+  }
+
   override get groupComparisonType(): GroupComparisonValue {
     return GroupComparisonType.NONE;
+  }
+
+  override get canStartExecute(): boolean {
+    return (
+      !IDManager.isLocalId(this.onesignalId) &&
+      !IDManager.isLocalId(this.subscriptionId)
+    );
+  }
+
+  override get applyToRecordId(): string {
+    return this.subscriptionId;
+  }
+
+  override translateIds(map: Record<string, string>): void {
+    super.translateIds(map);
+    if (map[this.subscriptionId]) {
+      this.subscriptionId = map[this.subscriptionId];
+    }
   }
 }

--- a/src/core/operations/DeleteSubscriptionOperation.ts
+++ b/src/core/operations/DeleteSubscriptionOperation.ts
@@ -1,19 +1,11 @@
-import { IDManager } from 'src/shared/managers/IDManager';
 import { OPERATION_NAME } from '../constants';
-import {
-  GroupComparisonType,
-  GroupComparisonValue,
-  Operation,
-} from './Operation';
-
-type DeleteOp = {
-  subscriptionId: string;
-};
+import { BaseSubscriptionOperation } from './BaseSubscriptionOperation';
+import { GroupComparisonType, GroupComparisonValue } from './Operation';
 
 /**
  * An Operation to delete a subscription from the OneSignal backend.
  */
-export class DeleteSubscriptionOperation extends Operation<DeleteOp> {
+export class DeleteSubscriptionOperation extends BaseSubscriptionOperation {
   constructor(appId: string, onesignalId: string, subscriptionId: string);
   constructor(appId?: string, onesignalId?: string, subscriptionId?: string) {
     super(OPERATION_NAME.DELETE_SUBSCRIPTION, appId, onesignalId);
@@ -22,43 +14,7 @@ export class DeleteSubscriptionOperation extends Operation<DeleteOp> {
     }
   }
 
-  /**
-   * The subscription ID for the operation. This ID *may* be locally generated
-   * and can be checked via IDManager.isLocalId to ensure correct processing.
-   */
-  get subscriptionId(): string {
-    return this.getProperty('subscriptionId');
-  }
-  protected set subscriptionId(value: string) {
-    this.setProperty('subscriptionId', value);
-  }
-
-  override get createComparisonKey(): string {
-    return `${this.appId}.User.${this.onesignalId}`;
-  }
-  override get modifyComparisonKey(): string {
-    return `${this.appId}.User.${this.onesignalId}.Subscription.${this.subscriptionId}`;
-  }
-
   override get groupComparisonType(): GroupComparisonValue {
     return GroupComparisonType.NONE;
-  }
-
-  override get canStartExecute(): boolean {
-    return (
-      !IDManager.isLocalId(this.onesignalId) &&
-      !IDManager.isLocalId(this.subscriptionId)
-    );
-  }
-
-  override get applyToRecordId(): string {
-    return this.subscriptionId;
-  }
-
-  override translateIds(map: Record<string, string>): void {
-    super.translateIds(map);
-    if (map[this.subscriptionId]) {
-      this.subscriptionId = map[this.subscriptionId];
-    }
   }
 }

--- a/src/core/operations/LoginUserOperation.ts
+++ b/src/core/operations/LoginUserOperation.ts
@@ -6,6 +6,11 @@ import {
   Operation,
 } from './Operation';
 
+type ILoginOp = {
+  externalId?: string;
+  existingOnesignalId?: string;
+};
+
 /**
  * An Operation to login the user with the externalId provided. Logging in a user will do the
  * following:
@@ -13,33 +18,33 @@ import {
  * 1. Attempt to give the user identified by existingOnesignalId an alias of externalId. If
  *    this succeeds the existing user becomes
  */
-export class LoginUserOperation extends Operation {
+export class LoginUserOperation extends Operation<ILoginOp> {
   constructor();
   constructor(
     appId: string,
     onesignalId: string,
     externalId?: string,
-    existingOneSignalId?: string | null,
+    existingOneSignalId?: string,
   );
   constructor(
     appId?: string,
     onesignalId?: string,
     externalId?: string,
-    existingOneSignalId: string | null = null,
+    existingOneSignalId?: string,
   ) {
     super(OPERATION_NAME.LOGIN_USER, appId, onesignalId);
     if (externalId) this.externalId = externalId;
-    this.existingOnesignalId = existingOneSignalId;
+    if (existingOneSignalId) this.existingOnesignalId = existingOneSignalId;
   }
 
   /**
    * The optional external ID of this newly logged-in user. Must be unique for the appId.
    */
   get externalId(): string | undefined {
-    return this.getProperty<string | undefined>('externalId');
+    return this.getProperty('externalId');
   }
   private set externalId(value: string) {
-    this.setProperty<string>('externalId', value);
+    this.setProperty('externalId', value);
   }
 
   /**
@@ -47,11 +52,11 @@ export class LoginUserOperation extends Operation {
    * When null (or non-null but unsuccessful), a new user will be upserted. This ID *may* be locally generated
    * and can be checked via IDManager.isLocalId to ensure correct processing.
    */
-  get existingOnesignalId(): string | null {
-    return this.getProperty<string | null>('existingOnesignalId');
+  get existingOnesignalId(): string | undefined {
+    return this.getProperty('existingOnesignalId');
   }
-  private set existingOnesignalId(value: string | null) {
-    this.setProperty<string>('existingOnesignalId', value);
+  private set existingOnesignalId(value: string) {
+    this.setProperty('existingOnesignalId', value);
   }
 
   override get createComparisonKey(): string {
@@ -68,7 +73,7 @@ export class LoginUserOperation extends Operation {
 
   override get canStartExecute(): boolean {
     return (
-      this.existingOnesignalId === null ||
+      !this.existingOnesignalId ||
       !IDManager.isLocalId(this.existingOnesignalId)
     );
   }

--- a/src/core/operations/TransferSubscriptionOperation.ts
+++ b/src/core/operations/TransferSubscriptionOperation.ts
@@ -1,19 +1,11 @@
-import { IDManager } from 'src/shared/managers/IDManager';
 import { OPERATION_NAME } from '../constants';
-import {
-  GroupComparisonType,
-  GroupComparisonValue,
-  Operation,
-} from './Operation';
-
-type TransferOp = {
-  subscriptionId: string;
-};
+import { BaseSubscriptionOperation } from './BaseSubscriptionOperation';
+import { GroupComparisonType, GroupComparisonValue } from './Operation';
 
 /**
  * An Operation to transfer a subscription to a new owner on the OneSignal backend.
  */
-export class TransferSubscriptionOperation extends Operation<TransferOp> {
+export class TransferSubscriptionOperation extends BaseSubscriptionOperation {
   constructor(appId: string, onesignalId: string, subscriptionId: string);
   constructor(appId?: string, onesignalId?: string, subscriptionId?: string) {
     super(OPERATION_NAME.TRANSFER_SUBSCRIPTION, appId, onesignalId);
@@ -22,43 +14,11 @@ export class TransferSubscriptionOperation extends Operation<TransferOp> {
     }
   }
 
-  /**
-   * The subscription ID for the operation. This ID *may* be locally generated
-   * and can be checked via IDManager.isLocalId to ensure correct processing.
-   */
-  get subscriptionId(): string {
-    return this.getProperty('subscriptionId');
-  }
-  protected set subscriptionId(value: string) {
-    this.setProperty('subscriptionId', value);
-  }
-
-  override get createComparisonKey(): string {
-    return `${this.appId}.User.${this.onesignalId}`;
-  }
-  override get modifyComparisonKey(): string {
-    return `${this.appId}.Subscription.${this.subscriptionId}.Transfer`;
-  }
-
   override get groupComparisonType(): GroupComparisonValue {
     return GroupComparisonType.NONE;
   }
 
-  override get canStartExecute(): boolean {
-    return (
-      !IDManager.isLocalId(this.onesignalId) &&
-      !IDManager.isLocalId(this.subscriptionId)
-    );
-  }
-
-  override get applyToRecordId(): string {
-    return this.subscriptionId;
-  }
-
-  override translateIds(map: Record<string, string>): void {
-    super.translateIds(map);
-    if (map[this.subscriptionId]) {
-      this.subscriptionId = map[this.subscriptionId];
-    }
+  override get modifyComparisonKey(): string {
+    return `${this.appId}.Subscription.${this.subscriptionId}.Transfer`;
   }
 }

--- a/src/core/operations/TransferSubscriptionOperation.ts
+++ b/src/core/operations/TransferSubscriptionOperation.ts
@@ -1,11 +1,20 @@
+import { IDManager } from 'src/shared/managers/IDManager';
 import { OPERATION_NAME } from '../constants';
-import { BaseSubscriptionOperation } from './BaseSubscriptionOperation';
-import { GroupComparisonType, GroupComparisonValue } from './Operation';
+import {
+  GroupComparisonType,
+  GroupComparisonValue,
+  Operation,
+} from './Operation';
+
+type TransferOp = {
+  subscriptionId: string;
+};
 
 /**
  * An Operation to transfer a subscription to a new owner on the OneSignal backend.
  */
-export class TransferSubscriptionOperation extends BaseSubscriptionOperation {
+export class TransferSubscriptionOperation extends Operation<TransferOp> {
+  constructor(appId: string, onesignalId: string, subscriptionId: string);
   constructor(appId?: string, onesignalId?: string, subscriptionId?: string) {
     super(OPERATION_NAME.TRANSFER_SUBSCRIPTION, appId, onesignalId);
     if (subscriptionId) {
@@ -13,11 +22,43 @@ export class TransferSubscriptionOperation extends BaseSubscriptionOperation {
     }
   }
 
+  /**
+   * The subscription ID for the operation. This ID *may* be locally generated
+   * and can be checked via IDManager.isLocalId to ensure correct processing.
+   */
+  get subscriptionId(): string {
+    return this.getProperty('subscriptionId');
+  }
+  protected set subscriptionId(value: string) {
+    this.setProperty('subscriptionId', value);
+  }
+
+  override get createComparisonKey(): string {
+    return `${this.appId}.User.${this.onesignalId}`;
+  }
+  override get modifyComparisonKey(): string {
+    return `${this.appId}.Subscription.${this.subscriptionId}.Transfer`;
+  }
+
   override get groupComparisonType(): GroupComparisonValue {
     return GroupComparisonType.NONE;
   }
 
-  override get modifyComparisonKey(): string {
-    return `${this.appId}.Subscription.${this.subscriptionId}.Transfer`;
+  override get canStartExecute(): boolean {
+    return (
+      !IDManager.isLocalId(this.onesignalId) &&
+      !IDManager.isLocalId(this.subscriptionId)
+    );
+  }
+
+  override get applyToRecordId(): string {
+    return this.subscriptionId;
+  }
+
+  override translateIds(map: Record<string, string>): void {
+    super.translateIds(map);
+    if (map[this.subscriptionId]) {
+      this.subscriptionId = map[this.subscriptionId];
+    }
   }
 }

--- a/src/core/operations/UpdateSubscriptionOperation.ts
+++ b/src/core/operations/UpdateSubscriptionOperation.ts
@@ -1,13 +1,13 @@
 import { OPERATION_NAME } from '../constants';
 import {
-  BaseSubscriptionOperation,
+  BaseFullSubscriptionOperation,
   SubscriptionWithAppId,
-} from './BaseSubscriptionOperation';
+} from './BaseFullSubscriptionOperation';
 
 /**
  * An Operation to update an existing subscription in the OneSignal backend.
  */
-export class UpdateSubscriptionOperation extends BaseSubscriptionOperation {
+export class UpdateSubscriptionOperation extends BaseFullSubscriptionOperation {
   constructor(subscription?: SubscriptionWithAppId) {
     super(
       OPERATION_NAME.UPDATE_SUBSCRIPTION,

--- a/src/core/types/api.ts
+++ b/src/core/types/api.ts
@@ -79,8 +79,8 @@ export interface ICreateUserSubscription {
 export interface ICreateUser {
   refresh_device_metadata?: boolean;
   identity: ICreateUserIdentity;
-  properties: IUserProperties;
-  subscriptions: ICreateUserSubscription[];
+  properties?: IUserProperties;
+  subscriptions?: ICreateUserSubscription[];
 }
 
 export interface IUserIdentity {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       include: ['src/**'],
       reporter: ['text-summary', 'lcov'],
       reportsDirectory: 'coverage',
+      reportOnFailure: true,
     },
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
# Description
## 1 Line Summary
Continuation of the [Web SDK Refactor project](https://docs.google.com/document/d/1JsbmxVM_n6K9nRXwbJf6mQr5h88qy_vIEiBGY0Ub_lE/edit?tab=t.0#heading=h.ojv84gskof17).

## Details
- add tests for Login Operation Executor
- changed from Object.assign to variable assignment for `subscriptions` variable since delete subscription would need to remove properties and Object.assign will fail to do that
- for create subscription operation, made it more like the Android SDK implementation with passing just `enabled`, `notifications_types` (status), `type`, `token` (address)
- for update subscription operation, made it pass along `notification_types` & `token`
- added `BaseFullSubscriptionOperation` which has more subscription properties used for CreateSubscriptionOperation and UpdateSubscriptionOperation

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1279)
<!-- Reviewable:end -->
