### PR TITLE
Web SDK Refactor: LoginUserFromSubscriptionOperationExecutor

### DIFF
--- a/src/core/executors/LoginUserFromSubscriptionOperationExecutor.test.ts
+++ b/src/core/executors/LoginUserFromSubscriptionOperationExecutor.test.ts
@@ -150,34 +150,6 @@ describe('LoginUserFromSubscriptionOperationExecutor', () => {
       });
     });
 
-    test.skip('should not update models if onesignalId does not match', async () => {
-      setFetchAliasesResult(DUMMY_ONESIGNAL_ID_2);
-
-      // Set models with a different onesignalId than the one in the operation
-      identityModelStore.model.setProperty(
-        IdentityConstants.ONESIGNAL_ID,
-        'different-id',
-      );
-      propertiesModelStore.model.setProperty('onesignalId', 'different-id');
-
-      const executor = getExecutor();
-      const loginOp = new LoginUserFromSubscriptionOperation(
-        APP_ID,
-        DUMMY_ONESIGNAL_ID,
-        DUMMY_SUBSCRIPTION_ID,
-      );
-
-      await executor.execute([loginOp]);
-
-      // Should not update models because IDs don't match
-      expect(
-        identityModelStore.model.getProperty(IdentityConstants.ONESIGNAL_ID),
-      ).toEqual('different-id');
-      expect(propertiesModelStore.model.getProperty('onesignalId')).toEqual(
-        'different-id',
-      );
-    });
-
     test('should fail if subscription has no onesignalId', async () => {
       setFetchAliasesResult(); // No onesignalId in response
 

--- a/src/core/executors/LoginUserFromSubscriptionOperationExecutor.test.ts
+++ b/src/core/executors/LoginUserFromSubscriptionOperationExecutor.test.ts
@@ -1,0 +1,220 @@
+import {
+  APP_ID,
+  DUMMY_ONESIGNAL_ID,
+  DUMMY_ONESIGNAL_ID_2,
+  DUMMY_SUBSCRIPTION_ID,
+} from '__test__/support/constants';
+import {
+  MockPreferencesService,
+  SomeOperation,
+} from '__test__/support/helpers/executors';
+import { server } from '__test__/support/mocks/server';
+import { http, HttpResponse } from 'msw';
+import { IdentityConstants, OPERATION_NAME } from '../constants';
+import { IdentityModelStore } from '../modelStores/IdentityModelStore';
+import { PropertiesModelStore } from '../modelStores/PropertiesModelStore';
+import { LoginUserFromSubscriptionOperation } from '../operations/LoginUserFromSubscriptionOperation';
+import { RefreshUserOperation } from '../operations/RefreshUserOperation';
+import { ExecutionResult } from '../types/operation';
+import { LoginUserFromSubscriptionOperationExecutor } from './LoginUserFromSubscriptionOperationExecutor';
+
+let identityPrefs: MockPreferencesService;
+let identityModelStore: IdentityModelStore;
+let propertiesModelStore: PropertiesModelStore;
+
+vi.mock('src/shared/libraries/Log');
+
+describe('LoginUserFromSubscriptionOperationExecutor', () => {
+  beforeEach(() => {
+    identityPrefs = new MockPreferencesService();
+    identityModelStore = new IdentityModelStore(identityPrefs);
+    propertiesModelStore = new PropertiesModelStore(identityPrefs);
+  });
+
+  const getExecutor = () => {
+    return new LoginUserFromSubscriptionOperationExecutor(
+      identityModelStore,
+      propertiesModelStore,
+    );
+  };
+
+  test('should return correct operations (names)', () => {
+    const executor = getExecutor();
+    expect(executor.operations).toEqual([
+      OPERATION_NAME.LOGIN_USER_FROM_SUBSCRIPTION_USER,
+    ]);
+  });
+
+  test('should validate operations', async () => {
+    const executor = getExecutor();
+    const someOp = new SomeOperation();
+
+    // with invalid ops
+    const ops = [someOp];
+    const result = executor.execute(ops);
+    await expect(() => result).rejects.toThrow(
+      `Unrecognized operation: ${someOp}`,
+    );
+  });
+
+  test('should throw if more than one operation is provided', async () => {
+    const executor = getExecutor();
+    const loginOp1 = new LoginUserFromSubscriptionOperation(
+      APP_ID,
+      DUMMY_ONESIGNAL_ID,
+      DUMMY_SUBSCRIPTION_ID,
+    );
+    const loginOp2 = new LoginUserFromSubscriptionOperation(
+      APP_ID,
+      DUMMY_ONESIGNAL_ID,
+      DUMMY_SUBSCRIPTION_ID,
+    );
+
+    const ops = [loginOp1, loginOp2];
+    const result = executor.execute(ops);
+    await expect(() => result).rejects.toThrow(/Only supports one operation/);
+  });
+
+  describe('loginUser', () => {
+    const setFetchAliasesResult = (onesignalId?: string) => {
+      server.use(
+        http.get(
+          `**/api/v1/apps/${APP_ID}/subscriptions/${DUMMY_SUBSCRIPTION_ID}/identity`,
+          () =>
+            HttpResponse.json({
+              identity: onesignalId
+                ? {
+                    [IdentityConstants.ONESIGNAL_ID]: onesignalId,
+                  }
+                : {},
+            }),
+        ),
+      );
+    };
+
+    const setFetchAliasesError = (status: number, retryAfter?: number) => {
+      server.use(
+        http.get(
+          `**/api/v1/apps/${APP_ID}/subscriptions/${DUMMY_SUBSCRIPTION_ID}/identity`,
+          () =>
+            HttpResponse.json(
+              {},
+              {
+                status,
+                headers: retryAfter
+                  ? { 'Retry-After': retryAfter?.toString() }
+                  : undefined,
+              },
+            ),
+        ),
+      );
+    };
+
+    test('should successfully login from subscription and update models', async () => {
+      // Set up identity to be returned from the API
+      setFetchAliasesResult(DUMMY_ONESIGNAL_ID_2);
+
+      // Setup existing identity and properties
+      identityModelStore.model.setProperty(
+        IdentityConstants.ONESIGNAL_ID,
+        DUMMY_ONESIGNAL_ID,
+      );
+      propertiesModelStore.model.setProperty('onesignalId', DUMMY_ONESIGNAL_ID);
+
+      const executor = getExecutor();
+      const loginOp = new LoginUserFromSubscriptionOperation(
+        APP_ID,
+        DUMMY_ONESIGNAL_ID,
+        DUMMY_SUBSCRIPTION_ID,
+      );
+
+      const result = await executor.execute([loginOp]);
+
+      // Should update models with new onesignalId
+      expect(
+        identityModelStore.model.getProperty(IdentityConstants.ONESIGNAL_ID),
+      ).toEqual(DUMMY_ONESIGNAL_ID_2);
+
+      expect(propertiesModelStore.model.getProperty('onesignalId')).toEqual(
+        DUMMY_ONESIGNAL_ID_2,
+      );
+
+      // Should return success with id translations and refresh operation
+      expect(result).toEqual({
+        result: ExecutionResult.SUCCESS,
+        retryAfterSeconds: undefined,
+        operations: [new RefreshUserOperation(APP_ID, DUMMY_ONESIGNAL_ID_2)],
+        idTranslations: {
+          [DUMMY_ONESIGNAL_ID]: DUMMY_ONESIGNAL_ID_2,
+        },
+      });
+    });
+
+    test.skip('should not update models if onesignalId does not match', async () => {
+      setFetchAliasesResult(DUMMY_ONESIGNAL_ID_2);
+
+      // Set models with a different onesignalId than the one in the operation
+      identityModelStore.model.setProperty(
+        IdentityConstants.ONESIGNAL_ID,
+        'different-id',
+      );
+      propertiesModelStore.model.setProperty('onesignalId', 'different-id');
+
+      const executor = getExecutor();
+      const loginOp = new LoginUserFromSubscriptionOperation(
+        APP_ID,
+        DUMMY_ONESIGNAL_ID,
+        DUMMY_SUBSCRIPTION_ID,
+      );
+
+      await executor.execute([loginOp]);
+
+      // Should not update models because IDs don't match
+      expect(
+        identityModelStore.model.getProperty(IdentityConstants.ONESIGNAL_ID),
+      ).toEqual('different-id');
+      expect(propertiesModelStore.model.getProperty('onesignalId')).toEqual(
+        'different-id',
+      );
+    });
+
+    test('should fail if subscription has no onesignalId', async () => {
+      setFetchAliasesResult(); // No onesignalId in response
+
+      const executor = getExecutor();
+      const loginOp = new LoginUserFromSubscriptionOperation(
+        APP_ID,
+        DUMMY_ONESIGNAL_ID,
+        DUMMY_SUBSCRIPTION_ID,
+      );
+
+      const result = await executor.execute([loginOp]);
+
+      expect(result.result).toBe(ExecutionResult.FAIL_NORETRY);
+    });
+
+    test('should handle network errors', async () => {
+      const executor = getExecutor();
+      const loginOp = new LoginUserFromSubscriptionOperation(
+        APP_ID,
+        DUMMY_ONESIGNAL_ID,
+        DUMMY_SUBSCRIPTION_ID,
+      );
+
+      // Retryable error
+      setFetchAliasesError(429, 10);
+      const res = await executor.execute([loginOp]);
+      expect(res.result).toBe(ExecutionResult.FAIL_RETRY);
+
+      // Unauthorized error
+      setFetchAliasesError(401);
+      const res2 = await executor.execute([loginOp]);
+      expect(res2.result).toBe(ExecutionResult.FAIL_UNAUTHORIZED);
+
+      // Other errors - no retry
+      setFetchAliasesError(400);
+      const res3 = await executor.execute([loginOp]);
+      expect(res3.result).toBe(ExecutionResult.FAIL_NORETRY);
+    });
+  });
+});

--- a/src/core/executors/LoginUserFromSubscriptionOperationExecutor.test.ts
+++ b/src/core/executors/LoginUserFromSubscriptionOperationExecutor.test.ts
@@ -76,36 +76,35 @@ describe('LoginUserFromSubscriptionOperationExecutor', () => {
   });
 
   describe('loginUser', () => {
+    const getSubscriptionIdentityUrl = (subscriptionId: string) =>
+      `**/api/v1/apps/${APP_ID}/subscriptions/${subscriptionId}/user/identity`;
+
     const setFetchAliasesResult = (onesignalId?: string) => {
       server.use(
-        http.get(
-          `**/api/v1/apps/${APP_ID}/subscriptions/${DUMMY_SUBSCRIPTION_ID}/identity`,
-          () =>
-            HttpResponse.json({
-              identity: onesignalId
-                ? {
-                    [IdentityConstants.ONESIGNAL_ID]: onesignalId,
-                  }
-                : {},
-            }),
+        http.get(getSubscriptionIdentityUrl(DUMMY_SUBSCRIPTION_ID), () =>
+          HttpResponse.json({
+            identity: onesignalId
+              ? {
+                  [IdentityConstants.ONESIGNAL_ID]: onesignalId,
+                }
+              : {},
+          }),
         ),
       );
     };
 
     const setFetchAliasesError = (status: number, retryAfter?: number) => {
       server.use(
-        http.get(
-          `**/api/v1/apps/${APP_ID}/subscriptions/${DUMMY_SUBSCRIPTION_ID}/identity`,
-          () =>
-            HttpResponse.json(
-              {},
-              {
-                status,
-                headers: retryAfter
-                  ? { 'Retry-After': retryAfter?.toString() }
-                  : undefined,
-              },
-            ),
+        http.get(getSubscriptionIdentityUrl(DUMMY_SUBSCRIPTION_ID), () =>
+          HttpResponse.json(
+            {},
+            {
+              status,
+              headers: retryAfter
+                ? { 'Retry-After': retryAfter?.toString() }
+                : undefined,
+            },
+          ),
         ),
       );
     };

--- a/src/core/executors/LoginUserFromSubscriptionOperationExecutor.ts
+++ b/src/core/executors/LoginUserFromSubscriptionOperationExecutor.ts
@@ -20,7 +20,6 @@ export class LoginUserFromSubscriptionOperationExecutor
   implements IOperationExecutor
 {
   constructor(
-    // private subscriptionBackend: ISubscriptionBackendService,
     private identityModelStore: IdentityModelStore,
     private propertiesModelStore: PropertiesModelStore,
   ) {}

--- a/src/core/executors/LoginUserFromSubscriptionOperationExecutor.ts
+++ b/src/core/executors/LoginUserFromSubscriptionOperationExecutor.ts
@@ -1,0 +1,114 @@
+import {
+  getResponseStatusType,
+  ResponseStatusType,
+} from 'src/shared/helpers/NetworkUtils';
+import Log from 'src/shared/libraries/Log';
+import { IdentityConstants, OPERATION_NAME } from '../constants';
+import { type IdentityModelStore } from '../modelStores/IdentityModelStore';
+import { type PropertiesModelStore } from '../modelStores/PropertiesModelStore';
+import { ExecutionResponse } from '../operations/ExecutionResponse';
+import { LoginUserFromSubscriptionOperation } from '../operations/LoginUserFromSubscriptionOperation';
+import { Operation } from '../operations/Operation';
+import { RefreshUserOperation } from '../operations/RefreshUserOperation';
+import { RequestService } from '../requestService/RequestService';
+import { ModelChangeTags } from '../types/models';
+import { ExecutionResult, type IOperationExecutor } from '../types/operation';
+
+// Implements logic similar to Android SDK's LoginUserFromSubscriptionOperationExecutor
+// Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserFromSubscriptionOperationExecutor.kt
+export class LoginUserFromSubscriptionOperationExecutor
+  implements IOperationExecutor
+{
+  constructor(
+    // private subscriptionBackend: ISubscriptionBackendService,
+    private identityModelStore: IdentityModelStore,
+    private propertiesModelStore: PropertiesModelStore,
+  ) {}
+
+  get operations(): string[] {
+    return [OPERATION_NAME.LOGIN_USER_FROM_SUBSCRIPTION_USER];
+  }
+
+  async execute(operations: Operation[]): Promise<ExecutionResponse> {
+    Log.debug(
+      `LoginUserFromSubscriptionOperationExecutor(operation: ${operations})`,
+    );
+
+    if (operations.length > 1)
+      throw new Error(
+        `Only supports one operation! Attempted operations:\n${operations}`,
+      );
+
+    const startingOp = operations[0];
+    if (startingOp instanceof LoginUserFromSubscriptionOperation)
+      return this.loginUser(startingOp);
+
+    throw new Error(`Unrecognized operation: ${startingOp}`);
+  }
+
+  private async loginUser(
+    loginUserOp: LoginUserFromSubscriptionOperation,
+  ): Promise<ExecutionResponse> {
+    const response = await RequestService.fetchAliasesForSubscription(
+      { appId: loginUserOp.appId },
+      loginUserOp.subscriptionId,
+    );
+
+    const { status, ok } = response;
+
+    if (ok) {
+      const identity = response.result.identity;
+
+      const backendOneSignalId = identity[IdentityConstants.ONESIGNAL_ID];
+
+      if (!backendOneSignalId) {
+        Log.warn(
+          `Subscription ${loginUserOp.subscriptionId} has no ${IdentityConstants.ONESIGNAL_ID}!`,
+        );
+        return new ExecutionResponse(ExecutionResult.FAIL_NORETRY);
+      }
+
+      const idTranslations: Record<string, string> = {};
+
+      // Add the "local-to-backend" ID translation to the IdentifierTranslator for any operations that were
+      // *not* executed but still reference the locally-generated IDs.
+      // Update the current identity, property, and subscription models from a local ID to the backend ID
+      idTranslations[loginUserOp.onesignalId] = backendOneSignalId;
+
+      const identityModel = this.identityModelStore.model;
+      const propertiesModel = this.propertiesModelStore.model;
+      if (identityModel.onesignalId === loginUserOp.onesignalId) {
+        identityModel.setProperty(
+          IdentityConstants.ONESIGNAL_ID,
+          backendOneSignalId,
+          ModelChangeTags.HYDRATE,
+        );
+      }
+
+      if (propertiesModel.onesignalId === loginUserOp.onesignalId) {
+        propertiesModel.setProperty(
+          'onesignalId',
+          backendOneSignalId,
+          ModelChangeTags.HYDRATE,
+        );
+      }
+
+      return new ExecutionResponse(
+        ExecutionResult.SUCCESS,
+        undefined,
+        [new RefreshUserOperation(loginUserOp.appId, backendOneSignalId)],
+        idTranslations,
+      );
+    }
+
+    const responseType = getResponseStatusType(status);
+    switch (responseType) {
+      case ResponseStatusType.RETRYABLE:
+        return new ExecutionResponse(ExecutionResult.FAIL_RETRY);
+      case ResponseStatusType.UNAUTHORIZED:
+        return new ExecutionResponse(ExecutionResult.FAIL_UNAUTHORIZED);
+      default:
+        return new ExecutionResponse(ExecutionResult.FAIL_NORETRY);
+    }
+  }
+}

--- a/src/core/executors/LoginUserFromSubscriptionOperationExecutor.ts
+++ b/src/core/executors/LoginUserFromSubscriptionOperationExecutor.ts
@@ -48,7 +48,7 @@ export class LoginUserFromSubscriptionOperationExecutor
   private async loginUser(
     loginUserOp: LoginUserFromSubscriptionOperation,
   ): Promise<ExecutionResponse> {
-    const response = await RequestService.fetchAliasesForSubscription(
+    const response = await RequestService.getIdentityFromSubscription(
       { appId: loginUserOp.appId },
       loginUserOp.subscriptionId,
     );

--- a/src/core/operations/LoginUserFromSubscriptionOperation.ts
+++ b/src/core/operations/LoginUserFromSubscriptionOperation.ts
@@ -5,50 +5,51 @@ import {
   Operation,
 } from './Operation';
 
-/**
- * An Operation to login the user with the subscriptionId provided.
- */
-export class LoginUserFromSubscriptionOperation extends Operation {
+interface LoginUserOperation {
+  subscriptionId: string;
+}
+
+// Implements logic similar to Android SDK's LoginUserFromSubscriptionOperation
+// Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/LoginUserFromSubscriptionOperation.kt
+export class LoginUserFromSubscriptionOperation extends Operation<LoginUserOperation> {
   constructor();
   constructor(appId: string, onesignalId: string, subscriptionId: string);
   constructor(appId?: string, onesignalId?: string, subscriptionId?: string) {
-    super(OPERATION_NAME.LOGIN_USER_FROM_SUBSCRIPTION_USER, appId, onesignalId);
-    if (subscriptionId) {
+    super(OPERATION_NAME.LOGIN_USER_FROM_SUBSCRIPTION_USER);
+
+    if (appId && onesignalId && subscriptionId) {
+      this.appId = appId;
+      this.onesignalId = onesignalId;
       this.subscriptionId = subscriptionId;
     }
   }
 
-  /**
-   * The optional external ID of this newly logged-in user. Must be unique for the appId.
-   */
   get subscriptionId(): string {
-    return this.getProperty<string>('subscriptionId');
+    return this.getProperty('subscriptionId');
   }
   private set subscriptionId(value: string) {
-    this.setProperty<string>('subscriptionId', value);
+    this.setProperty('subscriptionId', value);
   }
 
-  private getKey(): string {
+  private get comparisonKey(): string {
     return `${this.appId}.Subscription.${this.subscriptionId}.Login`;
   }
-
-  override get createComparisonKey(): string {
-    return this.getKey();
+  get createComparisonKey(): string {
+    return this.comparisonKey;
+  }
+  get modifyComparisonKey(): string {
+    return this.comparisonKey;
   }
 
-  override get modifyComparisonKey(): string {
-    return this.getKey();
-  }
-
-  override get groupComparisonType(): GroupComparisonValue {
+  get groupComparisonType(): GroupComparisonValue {
     return GroupComparisonType.NONE;
   }
 
-  override get canStartExecute(): boolean {
+  get canStartExecute(): boolean {
     return true;
   }
 
-  override get applyToRecordId(): string {
+  get applyToRecordId(): string {
     return this.subscriptionId;
   }
 }

--- a/src/core/operations/LoginUserFromSubscriptionOperation.ts
+++ b/src/core/operations/LoginUserFromSubscriptionOperation.ts
@@ -15,11 +15,8 @@ export class LoginUserFromSubscriptionOperation extends Operation<LoginUserOpera
   constructor();
   constructor(appId: string, onesignalId: string, subscriptionId: string);
   constructor(appId?: string, onesignalId?: string, subscriptionId?: string) {
-    super(OPERATION_NAME.LOGIN_USER_FROM_SUBSCRIPTION_USER);
-
-    if (appId && onesignalId && subscriptionId) {
-      this.appId = appId;
-      this.onesignalId = onesignalId;
+    super(OPERATION_NAME.LOGIN_USER_FROM_SUBSCRIPTION_USER, appId, onesignalId);
+    if (subscriptionId) {
       this.subscriptionId = subscriptionId;
     }
   }

--- a/src/core/operations/TrackSessionEndOperation.ts
+++ b/src/core/operations/TrackSessionEndOperation.ts
@@ -2,15 +2,19 @@ import { OPERATION_NAME } from '../constants';
 
 import { Operation } from './Operation';
 
+type TrackEndOp = {
+  sessionTime: number;
+};
+
 /**
  * An Operation to track the ending of a session, related to a specific user.
  */
-export class TrackSessionEndOperation extends Operation {
+export class TrackSessionEndOperation extends Operation<TrackEndOp> {
   constructor();
   constructor(appId: string, onesignalId: string, sessionTime: number);
   constructor(appId?: string, onesignalId?: string, sessionTime?: number) {
     super(OPERATION_NAME.TRACK_SESSION_END, appId, onesignalId);
-    if (appId && onesignalId && sessionTime) {
+    if (sessionTime) {
       this.sessionTime = sessionTime;
     }
   }
@@ -19,10 +23,10 @@ export class TrackSessionEndOperation extends Operation {
    * The amount of active time for the session, in milliseconds.
    */
   get sessionTime(): number {
-    return this.getProperty<number>('sessionTime');
+    return this.getProperty('sessionTime');
   }
   private set sessionTime(value: number) {
-    this.setProperty<number>('sessionTime', value);
+    this.setProperty('sessionTime', value);
   }
 
   override get modifyComparisonKey(): string {

--- a/src/core/requestService/IdentityRequests.ts
+++ b/src/core/requestService/IdentityRequests.ts
@@ -13,6 +13,7 @@ import { isIdentityObject } from '../utils/typePredicates';
 import { processIdentityOperation } from './helpers';
 import { RequestService } from './RequestService';
 
+// TODO: Remove with web sdk refactor work
 /**
  * This class contains logic for all the Identity model related requests that can be made to the OneSignal API
  * These static functions are what are ultimately invoked by the operation processing logic in the Executor class

--- a/src/core/requestService/RequestService.ts
+++ b/src/core/requestService/RequestService.ts
@@ -249,13 +249,13 @@ export class RequestService {
    * @param requestMetadata - { appId }
    * @param subscriptionId - subscription id
    */
-  static async fetchAliasesForSubscription(
+  static async getIdentityFromSubscription(
     requestMetadata: RequestMetadata,
     subscriptionId: string,
   ) {
     const { appId } = requestMetadata;
     return OneSignalApiBase.get<{ identity: IUserIdentity }>(
-      `apps/${appId}/subscriptions/${subscriptionId}/identity`,
+      `apps/${appId}/subscriptions/${subscriptionId}/user/identity`,
     );
   }
 

--- a/src/core/requestService/RequestService.ts
+++ b/src/core/requestService/RequestService.ts
@@ -252,7 +252,7 @@ export class RequestService {
   static async fetchAliasesForSubscription(
     requestMetadata: RequestMetadata,
     subscriptionId: string,
-  ): Promise<OneSignalApiBaseResponse> {
+  ) {
     const { appId } = requestMetadata;
     return OneSignalApiBase.get<{ identity: IUserIdentity }>(
       `apps/${appId}/subscriptions/${subscriptionId}/identity`,

--- a/src/core/requestService/SubscriptionRequests.ts
+++ b/src/core/requestService/SubscriptionRequests.ts
@@ -17,6 +17,7 @@ import { isCompleteSubscriptionObject } from '../utils/typePredicates';
 import { processSubscriptionOperation } from './helpers';
 import { RequestService } from './RequestService';
 
+// TODO: Remove with web sdk refactor work
 /**
  * This class contains logic for all the Subscription model related requests that can be made to the OneSignal API
  * These static functions are what are ultimately invoked by the operation processing logic in the Executor class

--- a/src/core/requestService/UpdateUserPayload.ts
+++ b/src/core/requestService/UpdateUserPayload.ts
@@ -1,5 +1,6 @@
 import { UserPropertiesModel } from '../models/UserPropertiesModel';
 
+// TODO: Remove with web sdk refactor work
 export type UpdateUserPayload = {
   properties?: UserPropertiesModel;
   refresh_device_metadata?: boolean;

--- a/src/core/requestService/UserPropertyRequests.ts
+++ b/src/core/requestService/UserPropertyRequests.ts
@@ -15,6 +15,7 @@ import { isCompleteSubscriptionObject } from '../utils/typePredicates';
 import AliasPair from './AliasPair';
 import { RequestService } from './RequestService';
 
+// TODO: Remove with web sdk refactor work
 /**
  * This class contains logic for all the UserProperty model related requests that can be made to the OneSignal API
  * These static functions are what are ultimately invoked by the operation processing logic in the Executor class


### PR DESCRIPTION
# Description
## 1 Line Summary
Continuation of the [Web SDK Refactor project](https://docs.google.com/document/d/1JsbmxVM_n6K9nRXwbJf6mQr5h88qy_vIEiBGY0Ub_lE/edit?tab=t.0#heading=h.ojv84gskof17).

## Details
- Implements [LoginUserFromSubscriptionOperationExecutor](https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserFromSubscriptionOperationExecutor.kt)
- Also adds tests for the executor
- Uses request alias service instead of passing/use `_subscriptionBackend`
- Renamed request service `fetchAliasesForSubscription` to `getIdentityFromSubscription` and fix broken api uri as it should be `.../user/identity` and not `.../identity` (which 404s)

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1280)
<!-- Reviewable:end -->
