### PR TITLE
Web SDK Refactor: RefreshUserOperationExecutor

### DIFF
--- a/src/core/executors/ExecutorBase.ts
+++ b/src/core/executors/ExecutorBase.ts
@@ -13,6 +13,7 @@ import { ExecutorResult } from './ExecutorResult';
 
 const RETRY_AFTER = 5_000;
 
+// TODO: Remove this with later Web SDK Prs
 export default abstract class ExecutorBase {
   protected _deltaQueue: CoreDelta<SupportedModel>[] = [];
   protected _operationQueue: Operation<SupportedModel>[] = [];

--- a/src/core/executors/ExecutorConfigMap.ts
+++ b/src/core/executors/ExecutorConfigMap.ts
@@ -1,9 +1,10 @@
-import { ExecutorConfigMap as ExecutorConfigMap } from '../models/ExecutorConfig';
+import { ExecutorConfigMap } from '../models/ExecutorConfig';
 import { ModelName } from '../models/SupportedModels';
 import IdentityRequests from '../requestService/IdentityRequests';
 import SubscriptionRequests from '../requestService/SubscriptionRequests';
 import UserPropertyRequests from '../requestService/UserPropertyRequests';
 
+// TODO: Remove this with later Web SDK Prs
 const subscriptionConfig = {
   add: SubscriptionRequests.addSubscription,
   remove: SubscriptionRequests.removeSubscription,

--- a/src/core/executors/ExecutorFactory.ts
+++ b/src/core/executors/ExecutorFactory.ts
@@ -6,6 +6,7 @@ import { IdentityExecutor } from './IdentityExecutor';
 import { PropertiesExecutor } from './PropertiesExecutor';
 import { SubscriptionExecutor } from './SubscriptionExecutor';
 
+// TODO: Remove this with later Web SDK Prs
 export class ExecutorFactory {
   static build(
     executorConfig: ExecutorConfig<SupportedModel>,

--- a/src/core/executors/ExecutorResult.ts
+++ b/src/core/executors/ExecutorResult.ts
@@ -4,6 +4,7 @@ export interface ExecutorResult<Model> {
   readonly result?: Model;
 }
 
+// TODO: Remove this with later Web SDK Prs
 export class ExecutorResultSuccess<Model> implements ExecutorResult<Model> {
   readonly success = true;
   readonly retriable = false;

--- a/src/core/executors/ExecutorStore.ts
+++ b/src/core/executors/ExecutorStore.ts
@@ -8,6 +8,7 @@ type ExecutorStoreInterface = {
   [key in ModelName]?: OSExecutor;
 };
 
+// TODO: Remove this with later Web SDK Prs
 export class ExecutorStore {
   store: ExecutorStoreInterface = {};
 

--- a/src/core/executors/LoginUserFromSubscriptionOperationExecutor.ts
+++ b/src/core/executors/LoginUserFromSubscriptionOperationExecutor.ts
@@ -20,8 +20,8 @@ export class LoginUserFromSubscriptionOperationExecutor
   implements IOperationExecutor
 {
   constructor(
-    private identityModelStore: IdentityModelStore,
-    private propertiesModelStore: PropertiesModelStore,
+    private _identityModelStore: IdentityModelStore,
+    private _propertiesModelStore: PropertiesModelStore,
   ) {}
 
   get operations(): string[] {
@@ -74,8 +74,8 @@ export class LoginUserFromSubscriptionOperationExecutor
       // Update the current identity, property, and subscription models from a local ID to the backend ID
       idTranslations[loginUserOp.onesignalId] = backendOneSignalId;
 
-      const identityModel = this.identityModelStore.model;
-      const propertiesModel = this.propertiesModelStore.model;
+      const identityModel = this._identityModelStore.model;
+      const propertiesModel = this._propertiesModelStore.model;
       if (identityModel.onesignalId === loginUserOp.onesignalId) {
         identityModel.setProperty(
           IdentityConstants.ONESIGNAL_ID,

--- a/src/core/executors/LoginUserOperationExecutor.ts
+++ b/src/core/executors/LoginUserOperationExecutor.ts
@@ -38,11 +38,11 @@ type SubscriptionMap = Record<
 // Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/LoginUserOperationExecutor.kt
 export class LoginUserOperationExecutor implements IOperationExecutor {
   constructor(
-    private identityOperationExecutor: IdentityOperationExecutor,
-    private identityModelStore: IdentityModelStore,
-    private propertiesModelStore: PropertiesModelStore,
-    private subscriptionsModelStore: SubscriptionModelStore,
-    private configModelStore: ConfigModelStore,
+    private _identityOperationExecutor: IdentityOperationExecutor,
+    private _identityModelStore: IdentityModelStore,
+    private _propertiesModelStore: PropertiesModelStore,
+    private _subscriptionsModelStore: SubscriptionModelStore,
+    private _configModelStore: ConfigModelStore,
   ) {}
 
   get operations(): string[] {
@@ -77,7 +77,7 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
     if (!loginUserOp.existingOnesignalId || !loginUserOp.externalId)
       return this.createUser(loginUserOp, operations);
 
-    const result = await this.identityOperationExecutor.execute([
+    const result = await this._identityOperationExecutor.execute([
       new SetAliasOperation(
         loginUserOp.appId,
         loginUserOp.existingOnesignalId,
@@ -91,16 +91,16 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
         const backendOneSignalId = loginUserOp.existingOnesignalId;
         const opOneSignalId = loginUserOp.onesignalId;
 
-        if (this.identityModelStore.model.onesignalId === opOneSignalId) {
-          this.identityModelStore.model.setProperty(
+        if (this._identityModelStore.model.onesignalId === opOneSignalId) {
+          this._identityModelStore.model.setProperty(
             IdentityConstants.ONESIGNAL_ID,
             backendOneSignalId,
             ModelChangeTags.HYDRATE,
           );
         }
 
-        if (this.propertiesModelStore.model.onesignalId === opOneSignalId) {
-          this.propertiesModelStore.model.setProperty(
+        if (this._propertiesModelStore.model.onesignalId === opOneSignalId) {
+          this._propertiesModelStore.model.setProperty(
             'onesignalId',
             backendOneSignalId,
             ModelChangeTags.HYDRATE,
@@ -180,16 +180,16 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
         [createUserOperation.onesignalId]: backendOneSignalId,
       };
 
-      if (this.identityModelStore.model.onesignalId === opOneSignalId) {
-        this.identityModelStore.model.setProperty(
+      if (this._identityModelStore.model.onesignalId === opOneSignalId) {
+        this._identityModelStore.model.setProperty(
           IdentityConstants.ONESIGNAL_ID,
           backendOneSignalId,
           ModelChangeTags.HYDRATE,
         );
       }
 
-      if (this.propertiesModelStore.model.onesignalId === opOneSignalId) {
-        this.propertiesModelStore.model.setProperty(
+      if (this._propertiesModelStore.model.onesignalId === opOneSignalId) {
+        this._propertiesModelStore.model.setProperty(
           'onesignalId',
           backendOneSignalId,
           ModelChangeTags.HYDRATE,
@@ -203,11 +203,11 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
         if (!backendSub || !('id' in backendSub)) continue;
         idTranslations[localId] = backendSub.id;
 
-        if (this.configModelStore.model.pushSubscriptionId === localId) {
-          this.configModelStore.model.pushSubscriptionId = backendSub.id;
+        if (this._configModelStore.model.pushSubscriptionId === localId) {
+          this._configModelStore.model.pushSubscriptionId = backendSub.id;
         }
 
-        const model = this.subscriptionsModelStore.get(localId);
+        const model = this._subscriptionsModelStore.get(localId);
         model?.setProperty('id', backendSub.id, ModelChangeTags.HYDRATE);
       }
 

--- a/src/core/executors/PropertiesExecutor.ts
+++ b/src/core/executors/PropertiesExecutor.ts
@@ -6,6 +6,7 @@ import { ModelName, SupportedModel } from '../models/SupportedModels';
 import { LegacyOperation } from '../operationRepo/LegacyOperation';
 import ExecutorBase from './ExecutorBase';
 
+// TODO: Remove this with later Web SDK Prs
 export class PropertiesExecutor extends ExecutorBase {
   constructor(
     executorConfig: ExecutorConfig<SupportedModel>,

--- a/src/core/executors/RefreshUserOperationExecutor.test.ts
+++ b/src/core/executors/RefreshUserOperationExecutor.test.ts
@@ -1,0 +1,293 @@
+import {
+  APP_ID,
+  DUMMY_ONESIGNAL_ID,
+  DUMMY_ONESIGNAL_ID_2,
+  DUMMY_PUSH_TOKEN,
+  DUMMY_SUBSCRIPTION_ID,
+} from '__test__/support/constants';
+import {
+  BuildUserService,
+  getRebuildOpsFn,
+  MockPreferencesService,
+  SomeOperation,
+} from '__test__/support/helpers/executors';
+import { server } from '__test__/support/mocks/server';
+import { http, HttpResponse } from 'msw';
+import { IdentityConstants, OPERATION_NAME } from '../constants';
+import { SubscriptionModel } from '../models/SubscriptionModel';
+import { ConfigModelStore } from '../modelStores/ConfigModelStore';
+import { IdentityModelStore } from '../modelStores/IdentityModelStore';
+import { PropertiesModelStore } from '../modelStores/PropertiesModelStore';
+import { SubscriptionModelStore } from '../modelStores/SubscriptionModelStore';
+import { NewRecordsState } from '../operationRepo/NewRecordsState';
+import { RefreshUserOperation } from '../operations/RefreshUserOperation';
+import {
+  ISubscription,
+  NotificationType,
+  SubscriptionType,
+  UserData,
+} from '../types/api';
+import { ModelChangeTags } from '../types/models';
+import { ExecutionResult } from '../types/operation';
+import { RefreshUserOperationExecutor } from './RefreshUserOperationExecutor';
+
+let identityPrefs: MockPreferencesService;
+let identityModelStore: IdentityModelStore;
+let propertiesModelStore: PropertiesModelStore;
+let configModelStore: ConfigModelStore;
+let subscriptionModelStore: SubscriptionModelStore;
+let newRecordsState: NewRecordsState;
+let buildUserService: BuildUserService;
+
+vi.mock('src/shared/libraries/Log');
+
+describe('RefreshUserOperationExecutor', () => {
+  beforeEach(() => {
+    identityPrefs = new MockPreferencesService();
+    identityModelStore = new IdentityModelStore(identityPrefs);
+    propertiesModelStore = new PropertiesModelStore(identityPrefs);
+    configModelStore = new ConfigModelStore(identityPrefs);
+    subscriptionModelStore = new SubscriptionModelStore(identityPrefs);
+    newRecordsState = new NewRecordsState();
+    buildUserService = new BuildUserService();
+  });
+
+  const getExecutor = () => {
+    return new RefreshUserOperationExecutor(
+      identityModelStore,
+      propertiesModelStore,
+      subscriptionModelStore,
+      configModelStore,
+      buildUserService,
+      newRecordsState,
+    );
+  };
+
+  test('should return correct operations (names)', async () => {
+    const executor = getExecutor();
+    expect(executor.operations).toEqual([OPERATION_NAME.REFRESH_USER]);
+  });
+
+  test('should validate operations', async () => {
+    const executor = getExecutor();
+    const someOp = new SomeOperation();
+    const ops = [someOp];
+
+    const result = executor.execute(ops);
+    await expect(() => result).rejects.toThrow(
+      `Unrecognized operation(s)! Attempted operations:\n${JSON.stringify(
+        ops,
+      )}`,
+    );
+  });
+
+  describe('getUser', () => {
+    beforeEach(() => {
+      // Set up initial model state
+      identityModelStore.model.setProperty(
+        IdentityConstants.ONESIGNAL_ID,
+        DUMMY_ONESIGNAL_ID,
+      );
+      // propertiesModelStore.model.setProperty('onesignalId', DUMMY_ONESIGNAL_ID);
+    });
+
+    test('should ignore refresh if id is different in identity model store', async () => {
+      setGetUserResponse(DUMMY_ONESIGNAL_ID_2, {}, { language: 'fr' });
+      const executor = getExecutor();
+      const refreshOp = new RefreshUserOperation(APP_ID, DUMMY_ONESIGNAL_ID_2);
+
+      const result = await executor.execute([refreshOp]);
+      expect(result.result).toBe(ExecutionResult.SUCCESS);
+      expect(propertiesModelStore.model.language).not.toBe('fr');
+    });
+
+    test('should handle successful user retrieval and update models', async () => {
+      setGetUserResponse();
+      propertiesModelStore.model.setProperty('onesignalId', DUMMY_ONESIGNAL_ID);
+
+      const executor = getExecutor();
+      const refreshOp = new RefreshUserOperation(APP_ID, DUMMY_ONESIGNAL_ID);
+
+      const result = await executor.execute([refreshOp]);
+      expect(result.result).toBe(ExecutionResult.SUCCESS);
+
+      // Check identity model updates
+      expect(identityModelStore.model.getProperty('onesignal_id')).toBe(
+        DUMMY_ONESIGNAL_ID,
+      );
+      expect(identityModelStore.model.getProperty('external_id')).toBe(
+        'test_user',
+      );
+
+      // Check properties model updates
+      expect(propertiesModelStore.model.country).toBe('US');
+      expect(propertiesModelStore.model.language).toBe('en');
+      expect(propertiesModelStore.model.tags).toEqual({
+        test_tag: 'test_value',
+        test_tag_2: 'test_value_2',
+      });
+      expect(propertiesModelStore.model.timezone).toBe('America/New_York');
+
+      // Check subscription model updates
+      const subscriptions = subscriptionModelStore.list();
+      expect(subscriptions.length).toBe(1);
+      expect(subscriptions[0]).toMatchObject({
+        id: DUMMY_SUBSCRIPTION_ID,
+        notification_types: NotificationType.UserOptedOut,
+        optedIn: false,
+        token: 'test@example.com',
+        type: SubscriptionType.Email,
+        device_os: '',
+        device_model: '',
+        sdk: '',
+      });
+    });
+
+    test('should preserve cached push subscription when updating models', async () => {
+      // Set up a push subscription in the store
+      const pushSubModel = new SubscriptionModel();
+      pushSubModel.id = DUMMY_SUBSCRIPTION_ID;
+      pushSubModel.type = SubscriptionType.ChromePush;
+      pushSubModel.token = DUMMY_PUSH_TOKEN;
+      pushSubModel.notification_types = NotificationType.Subscribed;
+
+      subscriptionModelStore.add(pushSubModel, ModelChangeTags.HYDRATE);
+      configModelStore.model.pushSubscriptionId = DUMMY_SUBSCRIPTION_ID;
+
+      const executor = getExecutor();
+      const refreshOp = new RefreshUserOperation(APP_ID, DUMMY_ONESIGNAL_ID);
+
+      // Mock response without push subscription
+      setGetUserResponse(DUMMY_ONESIGNAL_ID, {}, {}, [
+        {
+          id: 'email-sub-id',
+          type: SubscriptionType.Email,
+          token: 'test@example.com',
+        },
+      ]);
+
+      await executor.execute([refreshOp]);
+
+      // Check that both subscriptions exist (push is preserved)
+      const subscriptions = subscriptionModelStore.list();
+      expect(subscriptions.length).toBe(2);
+
+      // Find the push subscription
+      const pushSub = subscriptions.find(
+        (sub: SubscriptionModel) => sub.type === SubscriptionType.ChromePush,
+      );
+      expect(pushSub).toBeDefined();
+      expect(pushSub?.id).toBe(DUMMY_SUBSCRIPTION_ID);
+      expect(pushSub?.token).toBe(DUMMY_PUSH_TOKEN);
+    });
+
+    test('should handle network errors', async () => {
+      const executor = getExecutor();
+      const refreshOp = new RefreshUserOperation(APP_ID, DUMMY_ONESIGNAL_ID);
+
+      // retryable error
+      setGetUserError(429, 10);
+      const res1 = await executor.execute([refreshOp]);
+      expect(res1).toMatchObject({
+        result: ExecutionResult.FAIL_RETRY,
+        retryAfterSeconds: 10,
+      });
+
+      // unauthorized error
+      setGetUserError(401, 15);
+      const res2 = await executor.execute([refreshOp]);
+      expect(res2).toMatchObject({
+        result: ExecutionResult.FAIL_UNAUTHORIZED,
+        retryAfterSeconds: 15,
+      });
+
+      // missing error
+      // -- no rebuild ops
+      setGetUserError(404, 5);
+      const res3 = await executor.execute([refreshOp]);
+      expect(res3).toMatchObject({
+        result: ExecutionResult.FAIL_NORETRY,
+        retryAfterSeconds: undefined,
+      });
+
+      // -- with rebuild ops
+      const op = new SomeOperation();
+      getRebuildOpsFn.mockReturnValue([op]);
+      const res4 = await executor.execute([refreshOp]);
+      expect(res4).toMatchObject({
+        result: ExecutionResult.FAIL_RETRY,
+        retryAfterSeconds: 5,
+        operations: [op],
+      });
+
+      // -- in missing retry window
+      newRecordsState.add(DUMMY_ONESIGNAL_ID);
+      setGetUserError(404, 20);
+      const res6 = await executor.execute([refreshOp]);
+      expect(res6).toMatchObject({
+        result: ExecutionResult.FAIL_RETRY,
+        retryAfterSeconds: 20,
+      });
+
+      // other errors
+      setGetUserError(400);
+      const res7 = await executor.execute([refreshOp]);
+      expect(res7).toMatchObject({
+        result: ExecutionResult.FAIL_NORETRY,
+        retryAfterSeconds: undefined,
+      });
+    });
+  });
+});
+
+const getUserUri = (onesignalId = DUMMY_ONESIGNAL_ID) =>
+  `**/api/v1/apps/${APP_ID}/users/by/onesignal_id/${onesignalId}`;
+
+const setGetUserResponse = (
+  onesignalId = DUMMY_ONESIGNAL_ID,
+  identity: Omit<UserData['identity'], 'onesignal_id'> = {
+    external_id: 'test_user',
+  },
+  properties: UserData['properties'] = {
+    country: 'US',
+    language: 'en',
+    tags: { test_tag: 'test_value', test_tag_2: 'test_value_2' },
+    timezone_id: 'America/New_York',
+  },
+  subscriptions: Partial<ISubscription>[] = [
+    {
+      app_id: APP_ID,
+      id: DUMMY_SUBSCRIPTION_ID,
+      type: SubscriptionType.Email,
+      token: 'test@example.com',
+      notification_types: NotificationType.UserOptedOut,
+    },
+  ],
+) => {
+  server.use(
+    http.get(getUserUri(onesignalId), () =>
+      HttpResponse.json({
+        identity: {
+          onesignal_id: onesignalId,
+          ...identity,
+        },
+        properties,
+        subscriptions,
+      }),
+    ),
+  );
+};
+const setGetUserError = (status: number, retryAfter?: number) =>
+  server.use(
+    http.get(getUserUri(), () =>
+      HttpResponse.json(
+        {},
+        {
+          status,
+          headers: retryAfter
+            ? { 'Retry-After': retryAfter?.toString() }
+            : undefined,
+        },
+      ),
+    ),
+  );

--- a/src/core/executors/RefreshUserOperationExecutor.ts
+++ b/src/core/executors/RefreshUserOperationExecutor.ts
@@ -1,0 +1,167 @@
+import {
+  getResponseStatusType,
+  ResponseStatusType,
+} from 'src/shared/helpers/NetworkUtils';
+import SubscriptionHelper from 'src/shared/helpers/SubscriptionHelper';
+import Log from 'src/shared/libraries/Log';
+import { IdentityConstants, OPERATION_NAME } from '../constants';
+import { IdentityModel } from '../models/IdentityModel';
+import { PropertiesModel } from '../models/PropertiesModel';
+import { SubscriptionModel } from '../models/SubscriptionModel';
+import { ConfigModelStore } from '../modelStores/ConfigModelStore';
+import { type IdentityModelStore } from '../modelStores/IdentityModelStore';
+import { type PropertiesModelStore } from '../modelStores/PropertiesModelStore';
+import { type SubscriptionModelStore } from '../modelStores/SubscriptionModelStore';
+import { type NewRecordsState } from '../operationRepo/NewRecordsState';
+import { ExecutionResponse } from '../operations/ExecutionResponse';
+import { Operation } from '../operations/Operation';
+import { RefreshUserOperation } from '../operations/RefreshUserOperation';
+import AliasPair from '../requestService/AliasPair';
+import { RequestService } from '../requestService/RequestService';
+import { NotificationType } from '../types/api';
+import { ModelChangeTags } from '../types/models';
+import { ExecutionResult, type IOperationExecutor } from '../types/operation';
+import { type IRebuildUserService } from '../types/user';
+
+export class RefreshUserOperationExecutor implements IOperationExecutor {
+  constructor(
+    private _identityModelStore: IdentityModelStore,
+    private _propertiesModelStore: PropertiesModelStore,
+    private _subscriptionsModelStore: SubscriptionModelStore,
+    private _configModelStore: ConfigModelStore,
+    private _buildUserService: IRebuildUserService,
+    private _newRecordState: NewRecordsState,
+  ) {}
+
+  get operations(): string[] {
+    return [OPERATION_NAME.REFRESH_USER];
+  }
+
+  async execute(operations: Operation[]): Promise<ExecutionResponse> {
+    Log.debug(
+      `RefreshUserOperationExecutor(operation: ${JSON.stringify(operations)})`,
+    );
+
+    if (operations.some((op) => !(op instanceof RefreshUserOperation)))
+      throw new Error(
+        `Unrecognized operation(s)! Attempted operations:\n${JSON.stringify(
+          operations,
+        )}`,
+      );
+
+    const startingOp = operations[0];
+    return this.getUser(startingOp as RefreshUserOperation);
+  }
+
+  private async getUser(op: RefreshUserOperation): Promise<ExecutionResponse> {
+    const response = await RequestService.getUser(
+      { appId: op.appId },
+      new AliasPair(IdentityConstants.ONESIGNAL_ID, op.onesignalId),
+    );
+
+    const { ok, result, retryAfterSeconds, status } = response;
+    if (ok) {
+      if (op.onesignalId !== this._identityModelStore.model.onesignalId) {
+        return new ExecutionResponse(ExecutionResult.SUCCESS);
+      }
+
+      const identityModel = new IdentityModel();
+      for (const [key, value] of Object.entries(result.identity)) {
+        identityModel.setProperty(key, value);
+      }
+
+      const propertiesModel = new PropertiesModel();
+      propertiesModel.onesignalId = op.onesignalId;
+
+      const { properties = {}, subscriptions = [] } = result;
+      const { country, language, tags, timezone_id } = properties;
+
+      if (country) propertiesModel.country = country;
+      if (language) propertiesModel.language = language;
+      if (tags) propertiesModel.tags = tags;
+      if (timezone_id) propertiesModel.timezone = timezone_id;
+
+      const subscriptionModels: SubscriptionModel[] = [];
+      for (const sub of subscriptions) {
+        const model = new SubscriptionModel();
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        model.id = sub.id!;
+        model.token = sub.token ?? '';
+        model.notification_types =
+          sub.notification_types ?? NotificationType.Subscribed;
+
+        model.type = sub.type;
+        model.optedIn =
+          model.notification_types !== NotificationType.UserOptedOut;
+        model.sdk = sub.sdk ?? '';
+        model.device_os = sub.device_os ?? '';
+        model.device_model = sub.device_model ?? '';
+
+        // We only add a non-push subscriptions. For push, the device is the source of truth
+        // so we don't want to cache these subscriptions from the backend.
+        if (!SubscriptionHelper.isPushSubscriptionType(model.type)) {
+          subscriptionModels.push(model);
+        }
+      }
+
+      const pushSubscriptionId =
+        this._configModelStore.model.pushSubscriptionId;
+      if (pushSubscriptionId) {
+        const cachedPushModel =
+          this._subscriptionsModelStore.get(pushSubscriptionId);
+        if (cachedPushModel) subscriptionModels.push(cachedPushModel);
+      }
+
+      this._identityModelStore.replace(identityModel, ModelChangeTags.HYDRATE);
+      this._propertiesModelStore.replace(
+        propertiesModel,
+        ModelChangeTags.HYDRATE,
+      );
+      this._subscriptionsModelStore.replaceAll(
+        subscriptionModels,
+        ModelChangeTags.HYDRATE,
+      );
+
+      return new ExecutionResponse(ExecutionResult.SUCCESS);
+    }
+
+    const responseType = getResponseStatusType(status);
+    switch (responseType) {
+      case ResponseStatusType.RETRYABLE:
+        return new ExecutionResponse(
+          ExecutionResult.FAIL_RETRY,
+          retryAfterSeconds,
+        );
+      case ResponseStatusType.UNAUTHORIZED:
+        return new ExecutionResponse(
+          ExecutionResult.FAIL_UNAUTHORIZED,
+          retryAfterSeconds,
+        );
+      case ResponseStatusType.MISSING: {
+        if (
+          status === 404 &&
+          this._newRecordState.isInMissingRetryWindow(op.onesignalId)
+        )
+          return new ExecutionResponse(
+            ExecutionResult.FAIL_RETRY,
+            retryAfterSeconds,
+          );
+
+        const rebuildOps =
+          this._buildUserService.getRebuildOperationsIfCurrentUser(
+            op.appId,
+            op.onesignalId,
+          );
+        return rebuildOps
+          ? new ExecutionResponse(
+              ExecutionResult.FAIL_RETRY,
+              retryAfterSeconds,
+              rebuildOps,
+            )
+          : new ExecutionResponse(ExecutionResult.FAIL_NORETRY);
+      }
+      default:
+        return new ExecutionResponse(ExecutionResult.FAIL_NORETRY);
+    }
+  }
+}

--- a/src/core/executors/RefreshUserOperationExecutor.ts
+++ b/src/core/executors/RefreshUserOperationExecutor.ts
@@ -50,7 +50,7 @@ export class RefreshUserOperationExecutor implements IOperationExecutor {
       );
 
     const startingOp = operations[0];
-    return this.getUser(startingOp as RefreshUserOperation);
+    return this.getUser(startingOp);
   }
 
   private async getUser(op: RefreshUserOperation): Promise<ExecutionResponse> {

--- a/src/core/executors/RefreshUserOperationExecutor.ts
+++ b/src/core/executors/RefreshUserOperationExecutor.ts
@@ -23,6 +23,8 @@ import { ModelChangeTags } from '../types/models';
 import { ExecutionResult, type IOperationExecutor } from '../types/operation';
 import { type IRebuildUserService } from '../types/user';
 
+// Implements logic similar to Android SDK's RefreshUserOperationExecutor
+// Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt
 export class RefreshUserOperationExecutor implements IOperationExecutor {
   constructor(
     private _identityModelStore: IdentityModelStore,

--- a/src/core/executors/SubscriptionExecutor.ts
+++ b/src/core/executors/SubscriptionExecutor.ts
@@ -7,6 +7,7 @@ import { ModelName, SupportedModel } from '../models/SupportedModels';
 import { LegacyOperation } from '../operationRepo/LegacyOperation';
 import ExecutorBase from './ExecutorBase';
 
+// TODO: Remove this with later Web SDK Prs
 export class SubscriptionExecutor extends ExecutorBase {
   constructor(
     executorConfig: ExecutorConfig<SupportedModel>,

--- a/src/core/models/ConfigModel.ts
+++ b/src/core/models/ConfigModel.ts
@@ -1,8 +1,12 @@
 import { Model } from './Model';
 
-export class ConfigModel extends Model {
+type Config = {
+  pushSubscriptionId: string | undefined;
+};
+
+export class ConfigModel extends Model<Config> {
   get pushSubscriptionId(): string | undefined {
-    return this.getProperty<string | undefined>('pushSubscriptionId');
+    return this.getProperty('pushSubscriptionId');
   }
   set pushSubscriptionId(value: string | undefined) {
     this.setProperty('pushSubscriptionId', value);

--- a/src/core/models/Model.ts
+++ b/src/core/models/Model.ts
@@ -80,9 +80,7 @@ export interface ModelChangedArgs<T extends object = object> {
  *
  * Deserialization
  * ---------------
- * When deserializing a flat Model nothing specific is required. However if the Model
- * is nested the createModelForProperty and/or createListForProperty needs to be implemented
- * to aide in the deserialization process.
+ * When deserializing a flat Model nothing specific is required.
  */
 type BaseModel = { id?: string };
 
@@ -162,49 +160,9 @@ export class Model<
     this.data = newData;
   }
 
-  /**
-   * Called via initializeFromJson when the property being initialized is a JSON object,
-   * indicating the property value should be set to a nested Model. The specific concrete
-   * class of Model for this property is determined by the implementor and should depend on
-   * the property provided.
-   *
-   * @param property The property that is to contain the Model created by this method.
-   * @param jsonObject The JSON object that the Model will be created/initialized from.
-   *
-   * @return The created Model, or null if the property should not be set.
-   */
-  protected createModelForProperty(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _property: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _jsonObject: object,
-  ): Model<BaseModel> | null {
-    return null;
-  }
-
-  /**
-   * Called via initializeFromJson when the property being initialized is a JSON array,
-   * indicating the property value should be set to an Array. The specific concrete class
-   * inside the Array for this property is determined by the implementor and should depend
-   * on the property provided.
-   *
-   * @param property The property that is to contain the Array created by this method.
-   * @param jsonArray The JSON array that the Array will be created/initialized from.
-   *
-   * @return The created Array, or null if the property should not be set.
-   */
-  protected createListForProperty(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _property: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _jsonArray: unknown[],
-  ): unknown[] | null {
-    return null;
-  }
-
   setProperty<K extends keyof T>(
     name: string & K,
-    value: T[K] | null,
+    value: T[K] | undefined,
     tag: string = ModelChangeTags.NORMAL,
     forceChange = false,
   ): void {
@@ -214,7 +172,7 @@ export class Model<
       return;
     }
 
-    if (value !== null && value !== undefined) {
+    if (value !== undefined) {
       this.data.set(name, value);
     } else if (this.data.has(name)) {
       this.data.delete(name);
@@ -288,5 +246,10 @@ export class Model<
 
   get hasSubscribers(): boolean {
     return this.changeNotifier.hasSubscribers;
+  }
+
+  // Unique to web implementation
+  get isWebPush(): boolean {
+    return [];
   }
 }

--- a/src/core/models/Model.ts
+++ b/src/core/models/Model.ts
@@ -247,9 +247,4 @@ export class Model<
   get hasSubscribers(): boolean {
     return this.changeNotifier.hasSubscribers;
   }
-
-  // Unique to web implementation
-  get isWebPush(): boolean {
-    return [];
-  }
 }

--- a/src/core/models/PropertiesModel.ts
+++ b/src/core/models/PropertiesModel.ts
@@ -1,11 +1,12 @@
-import { IUserProperties } from 'src/core/types/user';
+import { IUserProperties } from '../types/api';
 import { Model } from './Model';
 
 type IPropertiesModel = {
-  onesignalId: string;
+  country: IUserProperties['country'];
   language: IUserProperties['language'];
-  timezone: IUserProperties['timezone_id'];
+  onesignalId: string;
   tags: IUserProperties['tags'];
+  timezone: IUserProperties['timezone_id'];
 };
 
 // Implements logic similar to Android's SDK's PropertiesModel
@@ -16,6 +17,13 @@ export class PropertiesModel extends Model<IPropertiesModel> {
   }
   set onesignalId(value: string) {
     this.setProperty('onesignalId', value);
+  }
+
+  get country(): string | undefined {
+    return this.getProperty('country');
+  }
+  set country(value: string | undefined) {
+    this.setProperty('country', value);
   }
 
   get language(): string | undefined {

--- a/src/core/models/SubscriptionModel.ts
+++ b/src/core/models/SubscriptionModel.ts
@@ -1,9 +1,10 @@
+import { SubscriptionStateKind } from 'src/shared/models/SubscriptionStateKind';
 import { ICreateUserSubscription, SubscriptionTypeValue } from '../types/api';
 import { Model } from './Model';
 
 type ISubscriptionModel = Pick<
   ICreateUserSubscription,
-  'device_model' | 'device_os' | 'sdk' | 'token' | 'type'
+  'device_model' | 'device_os' | 'sdk' | 'token' | 'type' | 'notification_types'
 > & {
   optedIn: boolean;
 };
@@ -25,11 +26,20 @@ export class SubscriptionModel extends Model<ISubscriptionModel> {
     this.setProperty('type', value);
   }
 
+  // Android SDK refers to this as address
   get token(): string {
     return this.getProperty('token');
   }
   set token(value: string) {
     this.setProperty('token', value);
+  }
+
+  // Android SDK refers to this as status
+  get notification_types(): SubscriptionStateKind | undefined {
+    return this.getProperty('notification_types');
+  }
+  set notification_types(value: SubscriptionStateKind | undefined) {
+    this.setProperty('notification_types', value);
   }
 
   get sdk(): string | undefined {

--- a/src/shared/helpers/SubscriptionHelper.ts
+++ b/src/shared/helpers/SubscriptionHelper.ts
@@ -1,7 +1,5 @@
-import {
-  SubscriptionChannel,
-  SubscriptionType,
-} from '../../core/models/SubscriptionModels';
+import { SubscriptionType, SubscriptionTypeValue } from 'src/core/types/api';
+import { SubscriptionChannel } from '../../core/models/SubscriptionModels';
 import {
   InvalidStateError,
   InvalidStateReason,
@@ -50,7 +48,7 @@ export default class SubscriptionHelper {
   /**
    * Helper that checks if a given SubscriptionType is a push subscription.
    */
-  public static isPushSubscriptionType(type: SubscriptionType): boolean {
+  public static isPushSubscriptionType(type: SubscriptionTypeValue): boolean {
     switch (type) {
       case SubscriptionType.ChromePush:
       case SubscriptionType.SafariPush:
@@ -63,7 +61,7 @@ export default class SubscriptionHelper {
   }
 
   public static toSubscriptionChannel(
-    type: SubscriptionType,
+    type: SubscriptionTypeValue,
   ): SubscriptionChannel | undefined {
     switch (type) {
       case SubscriptionType.Email:


### PR DESCRIPTION
# Description
## 1 Line Summary
Continuation of the [Web SDK Refactor project](https://docs.google.com/document/d/1JsbmxVM_n6K9nRXwbJf6mQr5h88qy_vIEiBGY0Ub_lE/edit?tab=t.0#heading=h.ojv84gskof17).

## Details
- Implements logic similar to [RefreshUserOperationExecutor](https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt)
- Adds tests for RefreshUserOperationExecutor
- Removes `createModelForProperty` and `createListForProperty` as it doesnt seem needed for now
- Did not add the check for SubscriptionStatus.DISABLED_FROM_REST_API_DEFAULT_REASON for [optedIn](https://github.com/OneSignal/OneSignal-Android-SDK/blob/5249d8d78bbec6fb783f3f377bea29a55fabb797/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/executors/RefreshUserOperationExecutor.kt#L114) as we didnt have this enum property present before

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1281)
<!-- Reviewable:end -->
