### PR TITLE
Web SDK Refactor: Add Model Store Listeners

### DIFF
--- a/src/core/CoreModule.ts
+++ b/src/core/CoreModule.ts
@@ -6,8 +6,11 @@ import { LoginUserOperationExecutor } from './executors/LoginUserOperationExecut
 import { RefreshUserOperationExecutor } from './executors/RefreshUserOperationExecutor';
 import { SubscriptionOperationExecutor } from './executors/SubscriptionOperationExecutor';
 import { UpdateUserOperationExecutor } from './executors/UpdateUserOperationExecutor';
+import { IdentityModelStoreListener } from './listeners/IdentityModelStoreListener';
+import { type SingletonModelStoreListener } from './listeners/SingletonModelStoreListener';
 import { OperationModelStore } from './modelRepo/OperationModelStore';
 import { RebuildUserService } from './modelRepo/RebuildUserService';
+import { type Model } from './models/Model';
 import { ConfigModelStore } from './modelStores/ConfigModelStore';
 import { IdentityModelStore } from './modelStores/IdentityModelStore';
 import { PropertiesModelStore } from './modelStores/PropertiesModelStore';
@@ -29,6 +32,7 @@ export default class CoreModule {
   private configModelStore: ConfigModelStore;
   private rebuildUserService: RebuildUserService;
   private executors?: IOperationExecutor[];
+  private listeners?: SingletonModelStoreListener<Model>[];
 
   constructor() {
     this.initPromise = new Promise<void>((resolve) => {
@@ -57,11 +61,22 @@ export default class CoreModule {
           this.operationModelStore,
           this.newRecordsState,
         );
+        this.listeners = this.initializeListeners();
         this.initResolver();
       })
       .catch((e) => {
         Log.error(e);
       });
+  }
+
+  private initializeListeners() {
+    if (!this.operationRepo) return [];
+    return [
+      new IdentityModelStoreListener(
+        this.identityModelStore,
+        this.operationRepo,
+      ),
+    ];
   }
 
   private initializeExecutors() {

--- a/src/core/CoreModule.ts
+++ b/src/core/CoreModule.ts
@@ -7,6 +7,7 @@ import { RefreshUserOperationExecutor } from './executors/RefreshUserOperationEx
 import { SubscriptionOperationExecutor } from './executors/SubscriptionOperationExecutor';
 import { UpdateUserOperationExecutor } from './executors/UpdateUserOperationExecutor';
 import { IdentityModelStoreListener } from './listeners/IdentityModelStoreListener';
+import { PropertiesModelStoreListener } from './listeners/PropertiesModelStoreListener';
 import { type SingletonModelStoreListener } from './listeners/SingletonModelStoreListener';
 import { OperationModelStore } from './modelRepo/OperationModelStore';
 import { RebuildUserService } from './modelRepo/RebuildUserService';
@@ -74,6 +75,10 @@ export default class CoreModule {
     return [
       new IdentityModelStoreListener(
         this.identityModelStore,
+        this.operationRepo,
+      ),
+      new PropertiesModelStoreListener(
+        this.propertiesModelStore,
         this.operationRepo,
       ),
     ];

--- a/src/core/CoreModule.ts
+++ b/src/core/CoreModule.ts
@@ -7,8 +7,10 @@ import { RefreshUserOperationExecutor } from './executors/RefreshUserOperationEx
 import { SubscriptionOperationExecutor } from './executors/SubscriptionOperationExecutor';
 import { UpdateUserOperationExecutor } from './executors/UpdateUserOperationExecutor';
 import { IdentityModelStoreListener } from './listeners/IdentityModelStoreListener';
+import { ModelStoreListener } from './listeners/ModelStoreListener';
 import { PropertiesModelStoreListener } from './listeners/PropertiesModelStoreListener';
 import { type SingletonModelStoreListener } from './listeners/SingletonModelStoreListener';
+import { SubscriptionModelStoreListener } from './listeners/SubscriptionModelStoreListener';
 import { OperationModelStore } from './modelRepo/OperationModelStore';
 import { RebuildUserService } from './modelRepo/RebuildUserService';
 import { type Model } from './models/Model';
@@ -18,7 +20,7 @@ import { PropertiesModelStore } from './modelStores/PropertiesModelStore';
 import { SubscriptionModelStore } from './modelStores/SubscriptionModelStore';
 import { NewRecordsState } from './operationRepo/NewRecordsState';
 import { OperationRepo } from './operationRepo/OperationRepo';
-import { IOperationExecutor } from './types/operation';
+import type { IOperationExecutor } from './types/operation';
 
 export default class CoreModule {
   public operationModelStore: OperationModelStore;
@@ -33,7 +35,10 @@ export default class CoreModule {
   private configModelStore: ConfigModelStore;
   private rebuildUserService: RebuildUserService;
   private executors?: IOperationExecutor[];
-  private listeners?: SingletonModelStoreListener<Model>[];
+  private listeners?: (
+    | SingletonModelStoreListener<Model>
+    | ModelStoreListener<Model>
+  )[];
 
   constructor() {
     this.initPromise = new Promise<void>((resolve) => {
@@ -80,6 +85,11 @@ export default class CoreModule {
       new PropertiesModelStoreListener(
         this.propertiesModelStore,
         this.operationRepo,
+      ),
+      new SubscriptionModelStoreListener(
+        this.subscriptionModelStore,
+        this.operationRepo,
+        this.identityModelStore,
       ),
     ];
   }

--- a/src/core/listeners/IdentityModelStoreListener.ts
+++ b/src/core/listeners/IdentityModelStoreListener.ts
@@ -1,0 +1,42 @@
+import MainHelper from 'src/shared/helpers/MainHelper';
+import { type IdentityModel } from '../models/IdentityModel';
+import { type IdentityModelStore } from '../modelStores/IdentityModelStore';
+import { DeleteAliasOperation } from '../operations/DeleteAliasOperation';
+import { type Operation } from '../operations/Operation';
+import { SetAliasOperation } from '../operations/SetAliasOperation';
+import { type IOperationRepo } from '../types/operation';
+import { SingletonModelStoreListener } from './SingletonModelStoreListener';
+
+// Implements logic similar to Android SDK's IdentityModelStoreListener
+// Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/listeners/IdentityModelStoreListener.kt
+export class IdentityModelStoreListener extends SingletonModelStoreListener<IdentityModel> {
+  constructor(store: IdentityModelStore, opRepo: IOperationRepo) {
+    super(store, opRepo);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getReplaceOperation(_model: IdentityModel): Operation | null {
+    // when the identity model is replaced, nothing to do on the backend. Already handled via login process.
+    return null;
+  }
+
+  async getUpdateOperation(
+    model: IdentityModel,
+    _path: string,
+    property: string,
+    _oldValue: unknown,
+    newValue: unknown,
+  ): Promise<Operation> {
+    const appId = await MainHelper.getAppId();
+    if (newValue != null && typeof newValue === 'string') {
+      return new SetAliasOperation(
+        appId,
+        model.onesignalId,
+        property,
+        newValue,
+      );
+    } else {
+      return new DeleteAliasOperation(appId, model.onesignalId, property);
+    }
+  }
+}

--- a/src/core/listeners/ModelStoreListener.ts
+++ b/src/core/listeners/ModelStoreListener.ts
@@ -1,0 +1,93 @@
+import { ModelChangedArgs, type Model } from '../models/Model';
+import { Operation } from '../operations/Operation';
+import { ModelChangeTags, type IModelStore } from '../types/models';
+import { type IOperationRepo } from '../types/operation';
+
+// Implements logic similar to Android SDK's ModelStoreListener
+// Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/listeners/ModelStoreListener.kt
+/**
+ * A model store listener that translates changes in a model or model store
+ * into operations that are enqueued onto the operation repository.
+ * This is an abstract class; a concrete implementation must provide
+ * the specific Operation that should be enqueued.
+ */
+export abstract class ModelStoreListener<TModel extends Model> {
+  protected store: IModelStore<TModel>;
+  protected opRepo: IOperationRepo;
+
+  constructor(store: IModelStore<TModel>, opRepo: IOperationRepo) {
+    this.store = store;
+    this.opRepo = opRepo;
+  }
+
+  bootstrap(): void {
+    this.store.subscribe(this);
+  }
+
+  close(): void {
+    this.store.unsubscribe(this);
+  }
+
+  onModelAdded(model: TModel, tag: string): void {
+    if (tag !== ModelChangeTags.NORMAL) {
+      return;
+    }
+
+    const operation = this.getAddOperation(model);
+    if (operation != null) {
+      this.opRepo.enqueue(operation);
+    }
+  }
+
+  onModelUpdated(args: ModelChangedArgs, tag: string): void {
+    if (tag !== ModelChangeTags.NORMAL) {
+      return;
+    }
+
+    const operation = this.getUpdateOperation(
+      args.model as TModel,
+      args.path,
+      args.property,
+      args.oldValue,
+      args.newValue,
+    );
+    if (operation != null) {
+      this.opRepo.enqueue(operation);
+    }
+  }
+
+  onModelRemoved(model: TModel, tag: string): void {
+    if (tag !== ModelChangeTags.NORMAL) {
+      return;
+    }
+
+    const operation = this.getRemoveOperation(model);
+    if (operation != null) {
+      this.opRepo.enqueue(operation);
+    }
+  }
+
+  /**
+   * Called when a model has been added to the model store.
+   * @return The operation to enqueue when a model has been added, or null if no operation should be enqueued.
+   */
+  abstract getAddOperation(model: TModel): Promise<Operation | null>;
+
+  /**
+   * Called when a model has been removed from the model store.
+   * @return The operation to enqueue when a model has been removed, or null if no operation should be enqueued.
+   */
+  abstract getRemoveOperation(model: TModel): Promise<Operation | null>;
+
+  /**
+   * Called when a model has been updated.
+   * @return The operation to enqueue when the model has been updated, or null if no operation should be enqueued.
+   */
+  abstract getUpdateOperation(
+    model: TModel,
+    path: string,
+    property: string,
+    oldValue: unknown,
+    newValue: unknown,
+  ): Promise<Operation | null>;
+}

--- a/src/core/listeners/PropertiesModelStoreListener.ts
+++ b/src/core/listeners/PropertiesModelStoreListener.ts
@@ -1,0 +1,51 @@
+import MainHelper from 'src/shared/helpers/MainHelper';
+import { PropertiesModel } from '../models/PropertiesModel';
+import { type PropertiesModelStore } from '../modelStores/PropertiesModelStore';
+import { DeleteTagOperation } from '../operations/DeleteTagOperation';
+import { type Operation } from '../operations/Operation';
+import { SetPropertyOperation } from '../operations/SetPropertyOperation';
+import { SetTagOperation } from '../operations/SetTagOperation';
+import { type IOperationRepo } from '../types/operation';
+import { SingletonModelStoreListener } from './SingletonModelStoreListener';
+
+// Implements logic similar to Android SDK's PropertiesModelStoreListener
+// Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/listeners/PropertiesModelStoreListener.kt
+export class PropertiesModelStoreListener extends SingletonModelStoreListener<PropertiesModel> {
+  constructor(store: PropertiesModelStore, opRepo: IOperationRepo) {
+    super(store, opRepo);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getReplaceOperation(_model: PropertiesModel): Operation | null {
+    // when the property model is replaced, nothing to do on the backend. Already handled via login process.
+    return null;
+  }
+
+  async getUpdateOperation(
+    model: PropertiesModel,
+    path: string,
+    property: string,
+    _oldValue: unknown,
+    newValue: unknown,
+  ): Promise<Operation | null> {
+    const appId = await MainHelper.getAppId();
+    if (path.startsWith('tags')) {
+      if (newValue != null && typeof newValue === 'string') {
+        return new SetTagOperation(
+          appId,
+          model.onesignalId,
+          property,
+          newValue,
+        );
+      }
+      return new DeleteTagOperation(appId, model.onesignalId, property);
+    }
+
+    return new SetPropertyOperation(
+      appId,
+      model.onesignalId,
+      property,
+      newValue,
+    );
+  }
+}

--- a/src/core/listeners/SingletonModelStoreListener.ts
+++ b/src/core/listeners/SingletonModelStoreListener.ts
@@ -16,7 +16,7 @@ import { ISingletonModelStore } from './types';
  * the actual Operation to be enqueued.
  */
 export abstract class SingletonModelStoreListener<TModel extends Model>
-  implements ISingletonModelStoreChangeHandler<TModel>, Closeable
+  implements ISingletonModelStoreChangeHandler<TModel>
 {
   protected store: ISingletonModelStore<TModel>;
   protected opRepo: IOperationRepo;
@@ -79,9 +79,4 @@ export abstract class SingletonModelStoreListener<TModel extends Model>
     oldValue: unknown,
     newValue: unknown,
   ): Promise<Operation | null>;
-}
-
-// Interface Closeable (manually written since JS/TS has no built-in Closeable)
-export interface Closeable {
-  close(): void;
 }

--- a/src/core/listeners/SingletonModelStoreListener.ts
+++ b/src/core/listeners/SingletonModelStoreListener.ts
@@ -1,0 +1,87 @@
+import { type Model, ModelChangedArgs } from '../models/Model';
+import { type Operation } from '../operations/Operation';
+import {
+  ISingletonModelStoreChangeHandler,
+  ModelChangeTags,
+} from '../types/models';
+import { IOperationRepo } from '../types/operation';
+import { ISingletonModelStore } from './types';
+
+// Implements logic similar to Android SDK's SingletonModelStore
+// Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/listeners/SingletonModelStoreListener.kt
+/**
+ * A SingletonModelStore listener that translates a change in the
+ * singleton store to an operation enqueued onto the IOperationRepo.
+ * This is an abstract class; a concrete implementation must provide
+ * the actual Operation to be enqueued.
+ */
+export abstract class SingletonModelStoreListener<TModel extends Model>
+  implements ISingletonModelStoreChangeHandler<TModel>, Closeable
+{
+  protected store: ISingletonModelStore<TModel>;
+  protected opRepo: IOperationRepo;
+
+  constructor(store: ISingletonModelStore<TModel>, opRepo: IOperationRepo) {
+    this.store = store;
+    this.opRepo = opRepo;
+  }
+
+  bootstrap(): void {
+    this.store.subscribe(this);
+  }
+
+  close(): void {
+    this.store.unsubscribe(this);
+  }
+
+  onModelReplaced(model: TModel, tag: string): void {
+    if (tag !== ModelChangeTags.NORMAL) {
+      return;
+    }
+
+    const operation = this.getReplaceOperation(model);
+    if (operation != null) {
+      this.opRepo.enqueue(operation);
+    }
+  }
+
+  async onModelUpdated(args: ModelChangedArgs, tag: string): Promise<void> {
+    if (tag !== ModelChangeTags.NORMAL) {
+      return;
+    }
+
+    const operation = await this.getUpdateOperation(
+      args.model as TModel,
+      args.path,
+      args.property,
+      args.oldValue,
+      args.newValue,
+    );
+    if (operation != null) {
+      this.opRepo.enqueue(operation);
+    }
+  }
+
+  /**
+   * Called when the model has been replaced.
+   * @return The operation to enqueue when the model has been replaced, or null if no operation should be enqueued.
+   */
+  abstract getReplaceOperation(model: TModel): Operation | null;
+
+  /**
+   * Called when the model has been updated.
+   * @return The operation to enqueue when the model has been updated, or null if no operation should be enqueued.
+   */
+  abstract getUpdateOperation(
+    model: TModel,
+    path: string,
+    property: string,
+    oldValue: unknown,
+    newValue: unknown,
+  ): Promise<Operation | null>;
+}
+
+// Interface Closeable (manually written since JS/TS has no built-in Closeable)
+export interface Closeable {
+  close(): void;
+}

--- a/src/core/listeners/SubscriptionModelStoreListener.ts
+++ b/src/core/listeners/SubscriptionModelStoreListener.ts
@@ -1,0 +1,91 @@
+import MainHelper from 'src/shared/helpers/MainHelper';
+import { SubscriptionModel } from '../models/SubscriptionModel';
+import { IdentityModelStore } from '../modelStores/IdentityModelStore';
+import { SubscriptionModelStore } from '../modelStores/SubscriptionModelStore';
+import { CreateSubscriptionOperation } from '../operations/CreateSubscriptionOperation';
+import { DeleteSubscriptionOperation } from '../operations/DeleteSubscriptionOperation';
+import { type Operation } from '../operations/Operation';
+import { UpdateSubscriptionOperation } from '../operations/UpdateSubscriptionOperation';
+import { IOperationRepo } from '../types/operation';
+import { NotificationType, NotificationTypeValue } from '../types/subscription';
+import { ModelStoreListener } from './ModelStoreListener';
+
+// Implements logic similar to Android SDK's SubscriptionModelStoreListener
+// Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/listeners/SubscriptionModelStoreListener.kt
+export class SubscriptionModelStoreListener extends ModelStoreListener<SubscriptionModel> {
+  private _identityModelStore: IdentityModelStore;
+
+  constructor(
+    store: SubscriptionModelStore,
+    opRepo: IOperationRepo,
+    identityModelStore: IdentityModelStore,
+  ) {
+    super(store, opRepo);
+    this._identityModelStore = identityModelStore;
+  }
+
+  async getAddOperation(model: SubscriptionModel): Promise<Operation> {
+    const { enabled, notification_types } =
+      SubscriptionModelStoreListener.getSubscriptionEnabledAndStatus(model);
+
+    const appId = await MainHelper.getAppId();
+    return new CreateSubscriptionOperation({
+      appId,
+      onesignalId: this._identityModelStore.model.onesignalId,
+      subscriptionId: model.id,
+      type: model.type,
+      enabled,
+      token: model.token,
+      notification_types,
+    });
+  }
+
+  async getRemoveOperation(model: SubscriptionModel): Promise<Operation> {
+    const appId = await MainHelper.getAppId();
+    return new DeleteSubscriptionOperation(
+      appId,
+      this._identityModelStore.model.onesignalId,
+      model.id,
+    );
+  }
+
+  async getUpdateOperation(model: SubscriptionModel): Promise<Operation> {
+    const { enabled, notification_types } =
+      SubscriptionModelStoreListener.getSubscriptionEnabledAndStatus(model);
+    const appId = await MainHelper.getAppId();
+
+    return new UpdateSubscriptionOperation({
+      appId,
+      onesignalId: this._identityModelStore.model.onesignalId,
+      subscriptionId: model.id,
+      type: model.type,
+      enabled,
+      token: model.token,
+      notification_types,
+    });
+  }
+
+  private static getSubscriptionEnabledAndStatus(model: SubscriptionModel): {
+    enabled: boolean;
+    notification_types: NotificationTypeValue | undefined;
+  } {
+    let enabled: boolean;
+    let notification_types: NotificationTypeValue | undefined;
+
+    if (
+      model.enabled &&
+      model.notification_types === NotificationType.Subscribed &&
+      model.token
+    ) {
+      enabled = true;
+      notification_types = NotificationType.Subscribed;
+    } else {
+      enabled = false;
+      notification_types = !model.enabled
+        ? NotificationType.UserOptedOut
+        : model.notification_types;
+    }
+
+    return { enabled, notification_types };
+  }
+}

--- a/src/core/listeners/types.ts
+++ b/src/core/listeners/types.ts
@@ -1,0 +1,19 @@
+import type { Model } from '../models/Model';
+import type { IEventNotifier } from '../types/events';
+import type { ISingletonModelStoreChangeHandler } from '../types/models';
+
+export interface ISingletonModelStore<TModel extends Model>
+  extends IEventNotifier<ISingletonModelStoreChangeHandler<TModel>> {
+  /**
+   * The model managed by this singleton model store.
+   */
+  readonly model: TModel;
+
+  /**
+   * Replace the existing model with the new model provided.
+   *
+   * @param model A model that contains all the data for the new effective model.
+   * @param tag The tag which identifies how/why the model is being replaced.
+   */
+  replace(model: TModel, tag?: string): void;
+}

--- a/src/core/types/operation.ts
+++ b/src/core/types/operation.ts
@@ -53,7 +53,7 @@ export interface IOperationExecutor {
 }
 
 export interface IOperationRepo {
-  enqueue(operation: Operation, flush: boolean): void;
+  enqueue(operation: Operation, flush?: boolean): void;
   containsInstanceOf<T extends Operation>(
     type: new (...args: any[]) => T,
   ): boolean;

--- a/src/sw/helpers/ModelCacheDirectAccess.ts
+++ b/src/sw/helpers/ModelCacheDirectAccess.ts
@@ -1,5 +1,5 @@
-import EncodedModel from '../../core/caching/EncodedModel';
-import { ModelName } from '../../core/models/SupportedModels';
+import { SubscriptionModel } from 'src/core/models/SubscriptionModel';
+import { ModelName } from 'src/core/types/models';
 import Database from '../../shared/services/Database';
 
 /**
@@ -11,7 +11,7 @@ export class ModelCacheDirectAccess {
   static async getPushSubscriptionIdByToken(
     token: string,
   ): Promise<string | undefined> {
-    const pushSubscriptions = await Database.getAll<EncodedModel>(
+    const pushSubscriptions = await Database.getAll<SubscriptionModel>(
       ModelName.Subscriptions,
     );
     for (const pushSubscription of pushSubscriptions) {


### PR DESCRIPTION
# Description
## 1 Line Summary
Continuation of the [Web SDK Refactor project](https://docs.google.com/document/d/1JsbmxVM_n6K9nRXwbJf6mQr5h88qy_vIEiBGY0Ub_lE/edit?tab=t.0#heading=h.ojv84gskof17).

## Details
- Adds new [ModelStoreListener](https://github.com/OneSignal/OneSignal-Android-SDK/blob/ad5123a3fc32cc9dbff75f258773c5b80de9313f/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/listeners/ModelStoreListener.kt#L17) base class.
- Adds new [SingletonModelStoreListener](https://github.com/OneSignal/OneSignal-Android-SDK/blob/ad5123a3fc32cc9dbff75f258773c5b80de9313f/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/operations/listeners/SingletonModelStoreListener.kt#L42) base class.
- Adds new [PropertyModelStoreListener](https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/listeners/PropertiesModelStoreListener.kt). **Does not** add _configModelStore since we can grab APP_ID from MainHelper.
- Adds new [SubscriptionModelStoreListener](https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/listeners/SubscriptionModelStoreListener.kt) . **Does not** add _configModelStore since we can grab APP_ID from MainHelper.
- Adds new [IdentityModelStoreListener](https://github.com/OneSignal/OneSignal-Android-SDK/blob/ad5123a3fc32cc9dbff75f258773c5b80de9313f/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/operations/impl/listeners/IdentityModelStoreListener.kt#L4). **Does not** add _configModelStore since we can grab APP_ID from MainHelper.
- Updates CoreModule to have new listeners array that consists of `PropertyModelStoreListener`, `SubscriptionModelStoreListener` and `IdentityModelStoreListener` 

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1288)
<!-- Reviewable:end -->
