### PR TITLE
Web SDK Refactor: Add Alias Tests

### DIFF
--- a/__test__/support/environment/TestEnvironment.ts
+++ b/__test__/support/environment/TestEnvironment.ts
@@ -7,10 +7,7 @@ import {
   ServerAppConfig,
 } from '../../../src/shared/models/AppConfig';
 import { DUMMY_ONESIGNAL_ID, DUMMY_PUSH_TOKEN } from '../constants';
-import {
-  getDummyIdentityOSModel,
-  getDummyPushSubscriptionOSModel,
-} from '../helpers/core';
+import { getDummyPushSubscriptionOSModel } from '../helpers/core';
 import BrowserUserAgent from '../models/BrowserUserAgent';
 import {
   initOSGlobals,
@@ -44,14 +41,8 @@ export class TestEnvironment {
     const oneSignal = await initOSGlobals(config);
 
     if (config.useMockIdentityModel) {
-      const dummyIdentityModel = getDummyIdentityOSModel();
-      // set on the model instance
-      dummyIdentityModel.onesignalId = DUMMY_ONESIGNAL_ID;
-      // set on the model data
-      dummyIdentityModel.setProperty('onesignal_id', DUMMY_ONESIGNAL_ID);
-
       const model = OneSignal.coreDirector.getIdentityModel();
-      model.initializeFromModel(null, dummyIdentityModel);
+      model.onesignalId = DUMMY_ONESIGNAL_ID;
     }
 
     if (config.useMockPushSubscriptionModel) {

--- a/__test__/support/helpers/configHelper.ts
+++ b/__test__/support/helpers/configHelper.ts
@@ -1,4 +1,3 @@
-import { http, HttpResponse } from 'msw';
 import { ConfigHelper } from '../../../src/shared/helpers/ConfigHelper';
 import {
   AppConfig,
@@ -6,10 +5,6 @@ import {
   ServerAppConfig,
 } from '../../../src/shared/models/AppConfig';
 import TestContext from '../environment/TestContext';
-
-const serverConfig = TestContext.getFakeServerAppConfig(
-  ConfigIntegrationKind.Custom,
-);
 
 /**
  * Test Helper Function.
@@ -32,18 +27,3 @@ export async function getFinalAppConfig(
 
   return await ConfigHelper.getAppConfig(fakeUserConfig, getFakeServerConfig);
 }
-
-export const mockServerConfig = () => {
-  return http.get('**/sync/*/web', ({ request }) => {
-    const url = new URL(request.url);
-    const callbackParam = url.searchParams.get('callback');
-    return new HttpResponse(
-      `${callbackParam}(${JSON.stringify(serverConfig)})`,
-      {
-        headers: {
-          'Content-Type': 'application/javascript',
-        },
-      },
-    );
-  });
-};

--- a/__test__/support/helpers/requests.ts
+++ b/__test__/support/helpers/requests.ts
@@ -1,0 +1,128 @@
+import { http, HttpResponse } from 'msw';
+import { ConfigIntegrationKind } from 'src/shared/models/AppConfig';
+import { APP_ID, DUMMY_ONESIGNAL_ID } from '../constants';
+import TestContext from '../environment/TestContext';
+import { server } from '../mocks/server';
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// configs
+const serverConfig = TestContext.getFakeServerAppConfig(
+  ConfigIntegrationKind.Custom,
+);
+
+export const mockServerConfig = () => {
+  return http.get('**/sync/*/web', ({ request }) => {
+    const url = new URL(request.url);
+    const callbackParam = url.searchParams.get('callback');
+    return new HttpResponse(
+      `${callbackParam}(${JSON.stringify(serverConfig)})`,
+      {
+        headers: {
+          'Content-Type': 'application/javascript',
+        },
+      },
+    );
+  });
+};
+export const mockPageStylesCss = () => {
+  return http.get(
+    'https://onesignal.com/sdks/web/v16/OneSignalSDK.page.styles.css',
+    () => {
+      return new HttpResponse('/* CSS */', {
+        headers: { 'Content-Type': 'text/css' },
+      });
+    },
+  );
+};
+
+const getHandler = ({
+  uri,
+  method,
+  status,
+  response = {},
+  retryAfter,
+  callback,
+}: {
+  uri: string;
+  method: 'patch' | 'delete';
+  status: number;
+  response?: object;
+  retryAfter?: number;
+  callback?: (object?: unknown) => void;
+}) => {
+  server.use(
+    http[method](uri, async ({ request }) => {
+      if (method !== 'delete') {
+        callback?.(await request.json());
+      } else {
+        callback?.();
+      }
+      return HttpResponse.json(response, {
+        status,
+        headers: retryAfter
+          ? { 'Retry-After': retryAfter?.toString() }
+          : undefined,
+      });
+    }),
+  );
+};
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// alias
+const getSetAliasUri = (onesignalId: string = DUMMY_ONESIGNAL_ID) =>
+  `**/api/v1/apps/${APP_ID}/users/by/onesignal_id/${onesignalId}/identity`;
+const getDeleteAliasUri = (onesignalId: string = DUMMY_ONESIGNAL_ID) =>
+  `**/api/v1/apps/${APP_ID}/users/by/onesignal_id/${onesignalId}/identity/*`;
+
+export const addAliasFn = vi.fn();
+export const setAddAliasResponse = ({
+  onesignalId,
+}: { onesignalId?: string } = {}) =>
+  getHandler({
+    uri: getSetAliasUri(onesignalId),
+    method: 'patch',
+    status: 200,
+    callback: addAliasFn,
+  });
+export const setAddAliasError = ({
+  onesignalId,
+  status,
+  retryAfter,
+}: {
+  onesignalId: string;
+  status: number;
+  retryAfter?: number;
+}) =>
+  getHandler({
+    uri: getSetAliasUri(onesignalId),
+    method: 'patch',
+    status,
+    retryAfter,
+  });
+
+export const deleteAliasFn = vi.fn();
+export const setDeleteAliasResponse = ({
+  onesignalId,
+}: { onesignalId?: string } = {}) =>
+  getHandler({
+    uri: getDeleteAliasUri(onesignalId),
+    method: 'delete',
+    status: 200,
+    callback: deleteAliasFn,
+  });
+
+export const setDeleteAliasError = ({
+  onesignalId,
+  status,
+  retryAfter,
+}: {
+  onesignalId: string;
+  status: number;
+  retryAfter?: number;
+}) =>
+  getHandler({
+    uri: getDeleteAliasUri(onesignalId),
+    method: 'delete',
+    status,
+    retryAfter,
+  });

--- a/__test__/support/helpers/requests.ts
+++ b/__test__/support/helpers/requests.ts
@@ -89,7 +89,7 @@ export const setAddAliasError = ({
   status,
   retryAfter,
 }: {
-  onesignalId: string;
+  onesignalId?: string;
   status: number;
   retryAfter?: number;
 }) =>
@@ -116,7 +116,7 @@ export const setDeleteAliasError = ({
   status,
   retryAfter,
 }: {
-  onesignalId: string;
+  onesignalId?: string;
   status: number;
   retryAfter?: number;
 }) =>

--- a/__test__/unit/user/login.test.ts
+++ b/__test__/unit/user/login.test.ts
@@ -65,7 +65,7 @@ describe('Login tests', () => {
   test('Login twice with different user -> logs in to second user', async () => {
     await TestEnvironment.initialize({ useMockIdentityModel: true });
     setupLoginStubs();
-
+    nock({});
     const identifyOrUpsertUserSpy = stub(LoginManager, 'identifyOrUpsertUser');
 
     await LoginManager.login(DUMMY_EXTERNAL_ID);
@@ -186,6 +186,7 @@ describe('Login tests', () => {
       useMockIdentityModel: true,
       useMockPushSubscriptionModel: true,
     });
+    nock({});
 
     stub(
       LoginManager,
@@ -210,7 +211,7 @@ describe('Login tests', () => {
     await TestEnvironment.initialize({
       useMockIdentityModel: true,
     });
-
+    nock({});
     stub(
       LoginManager,
       'identifyOrUpsertUser',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@size-limit/file": "^11.2.0",
-        "@types/body-parser": "*",
+        "@types/body-parser": "latest",
         "@types/express": "^4.17.17",
         "@types/intl-tel-input": "^18.1.4",
         "@types/jsdom": "^21.1.7",

--- a/src/core/CoreModule.ts
+++ b/src/core/CoreModule.ts
@@ -68,6 +68,7 @@ export default class CoreModule {
           this.newRecordsState,
         );
         this.listeners = this.initializeListeners();
+        this.operationRepo.start();
         this.initResolver();
       })
       .catch((e) => {

--- a/src/core/executors/IdentityOperationExecutor.test.ts
+++ b/src/core/executors/IdentityOperationExecutor.test.ts
@@ -4,8 +4,12 @@ import {
   getRebuildOpsFn,
   SomeOperation,
 } from '__test__/support/helpers/executors';
-import { server } from '__test__/support/mocks/server';
-import { http, HttpResponse } from 'msw';
+import {
+  setAddAliasError,
+  setAddAliasResponse,
+  setDeleteAliasError,
+  setDeleteAliasResponse,
+} from '__test__/support/helpers/requests';
 import { ExecutionResult } from 'src/core/types/operation';
 import { IdentityConstants, OPERATION_NAME } from '../constants';
 import { IdentityModelStore } from '../modelStores/IdentityModelStore';
@@ -31,9 +35,6 @@ const deleteAliasOp = new DeleteAliasOperation(
 let identityModelStore: IdentityModelStore;
 let newRecordsState: NewRecordsState;
 
-const identityUri = `**/api/v1/apps/*/users/by/onesignal_id/*/identity`;
-const deleteAliasUri = `${identityUri}/*`;
-
 describe('IdentityOperationExecutor', () => {
   const getExecutor = () => {
     return new IdentityOperationExecutor(
@@ -44,13 +45,8 @@ describe('IdentityOperationExecutor', () => {
   };
 
   beforeEach(() => {
-    server.use(
-      // set alias api
-      http.patch(identityUri, () => HttpResponse.json({})),
-      // delete alias api
-      http.delete(deleteAliasUri, () => HttpResponse.json({})),
-    );
-
+    setAddAliasResponse();
+    setDeleteAliasResponse();
     identityModelStore = new IdentityModelStore();
     newRecordsState = new NewRecordsState();
   });
@@ -116,62 +112,35 @@ describe('IdentityOperationExecutor', () => {
   });
 
   describe('Errors', () => {
-    const setAliasError = (
-      uri: string,
-      method: 'patch' | 'delete',
-      status: number,
-      retryAfter?: number,
-    ) => {
-      server.use(
-        http[method](uri, () =>
-          HttpResponse.json(
-            {},
-            {
-              status,
-              headers: retryAfter
-                ? { 'Retry-After': retryAfter?.toString() }
-                : undefined,
-            },
-          ),
-        ),
-      );
-    };
-
-    const setAddAliasError = (status: number, retryAfter?: number) =>
-      setAliasError(identityUri, 'patch', status, retryAfter);
-
-    const setDeleteAliasError = (status: number, retryAfter?: number) =>
-      setAliasError(deleteAliasUri, 'delete', status, retryAfter);
-
     test('should handle setAlias errors', async () => {
       const executor = getExecutor();
       const ops = [setAliasOp];
 
       // Retryable
-      setAddAliasError(429, 10);
+      setAddAliasError({ status: 429, retryAfter: 10 });
       const res = await executor.execute(ops);
       expect(res.result).toBe(ExecutionResult.FAIL_RETRY);
       expect(res.retryAfterSeconds).toBe(10);
 
       // Invalid
-      setAddAliasError(400);
+      setAddAliasError({ status: 400 });
       const res2 = await executor.execute(ops);
       expect(res2.result).toBe(ExecutionResult.FAIL_NORETRY);
 
       // Conflict
-      setAddAliasError(409, 5);
+      setAddAliasError({ status: 409, retryAfter: 5 });
       const res3 = await executor.execute(ops);
       expect(res3.result).toBe(ExecutionResult.FAIL_CONFLICT);
       expect(res3.retryAfterSeconds).toBe(5);
 
       // Unauthorized
-      setAddAliasError(401, 15);
+      setAddAliasError({ status: 401, retryAfter: 15 });
       const res4 = await executor.execute(ops);
       expect(res4.result).toBe(ExecutionResult.FAIL_UNAUTHORIZED);
       expect(res4.retryAfterSeconds).toBe(15);
 
       // Missing
-      setAddAliasError(410);
+      setAddAliasError({ status: 410 });
       const res5 = await executor.execute(ops);
 
       // no rebuild ops
@@ -188,7 +157,7 @@ describe('IdentityOperationExecutor', () => {
 
       // in missing retry window
       newRecordsState.add(DUMMY_ONESIGNAL_ID);
-      setAddAliasError(404, 20);
+      setAddAliasError({ status: 404, retryAfter: 20 });
       const res6 = await executor.execute(ops);
       expect(res6.result).toBe(ExecutionResult.FAIL_RETRY);
       expect(res6.retryAfterSeconds).toBe(20);
@@ -199,35 +168,35 @@ describe('IdentityOperationExecutor', () => {
       const ops = [deleteAliasOp];
 
       // Retryable
-      setDeleteAliasError(429, 10);
+      setDeleteAliasError({ status: 429, retryAfter: 10 });
       const res = await executor.execute(ops);
       expect(res.result).toBe(ExecutionResult.FAIL_RETRY);
       expect(res.retryAfterSeconds).toBe(10);
 
       // Invalid
-      setDeleteAliasError(400);
+      setDeleteAliasError({ status: 400 });
       const res2 = await executor.execute(ops);
       expect(res2.result).toBe(ExecutionResult.FAIL_NORETRY);
 
       // Conflict
-      setDeleteAliasError(409, 5);
+      setDeleteAliasError({ status: 409, retryAfter: 5 });
       const res3 = await executor.execute(ops);
       expect(res3.result).toBe(ExecutionResult.SUCCESS);
 
       // Unauthorized
-      setDeleteAliasError(401, 15);
+      setDeleteAliasError({ status: 401, retryAfter: 15 });
       const res4 = await executor.execute(ops);
       expect(res4.result).toBe(ExecutionResult.FAIL_UNAUTHORIZED);
       expect(res4.retryAfterSeconds).toBe(15);
 
       // Missing
-      setDeleteAliasError(410);
+      setDeleteAliasError({ status: 410 });
       const res5 = await executor.execute(ops);
       expect(res5.result).toBe(ExecutionResult.SUCCESS);
 
       // in missing retry window
       newRecordsState.add(DUMMY_ONESIGNAL_ID);
-      setDeleteAliasError(404, 20);
+      setDeleteAliasError({ status: 404, retryAfter: 20 });
       const res6 = await executor.execute(ops);
       expect(res6.result).toBe(ExecutionResult.FAIL_RETRY);
       expect(res6.retryAfterSeconds).toBe(20);

--- a/src/core/listeners/SingletonModelStoreListener.ts
+++ b/src/core/listeners/SingletonModelStoreListener.ts
@@ -24,14 +24,7 @@ export abstract class SingletonModelStoreListener<TModel extends Model>
   constructor(store: ISingletonModelStore<TModel>, opRepo: IOperationRepo) {
     this.store = store;
     this.opRepo = opRepo;
-  }
-
-  bootstrap(): void {
     this.store.subscribe(this);
-  }
-
-  close(): void {
-    this.store.unsubscribe(this);
   }
 
   onModelReplaced(model: TModel, tag: string): void {

--- a/src/core/modelStores/SingletonModelStore.ts
+++ b/src/core/modelStores/SingletonModelStore.ts
@@ -4,6 +4,7 @@ import {
   IModelStoreChangeHandler,
   ISingletonModelStore,
   ISingletonModelStoreChangeHandler,
+  type ModelChangeTagValue,
 } from 'src/core/types/models';
 import { EventProducer } from '../../shared/helpers/EventProducer';
 
@@ -34,7 +35,7 @@ export class SingletonModelStore<TModel extends Model>
     return createdModel;
   }
 
-  replace(model: TModel, tag: string): void {
+  replace(model: TModel, tag: ModelChangeTagValue): void {
     const existingModel = this.model;
     existingModel.initializeFromModel(existingModel.modelId, model);
     this.store.persist();
@@ -57,13 +58,13 @@ export class SingletonModelStore<TModel extends Model>
 
   /**
    * @param {TModel} model
-   * @param {string} tag
+   * @param {ModelChangeTagValue)} tag
    */
   onModelAdded(): void {
     // No-op: singleton is transparently added
   }
 
-  onModelUpdated(args: ModelChangedArgs, tag: string): void {
+  onModelUpdated(args: ModelChangedArgs, tag: ModelChangeTagValue): void {
     this.changeSubscription.fire((handler) =>
       handler.onModelUpdated(args, tag),
     );
@@ -71,7 +72,7 @@ export class SingletonModelStore<TModel extends Model>
 
   /**
    * @param {TModel} model
-   * @param {string} tag
+   * @param {ModelChangeTagValue} tag
    */
   onModelRemoved(): void {
     // No-op: singleton is never removed

--- a/src/core/modelStores/SingletonModelStore.ts
+++ b/src/core/modelStores/SingletonModelStore.ts
@@ -16,7 +16,6 @@ export class SingletonModelStore<TModel extends Model>
   private readonly changeSubscription = new EventProducer<
     ISingletonModelStoreChangeHandler<TModel>
   >();
-  private readonly singletonId = '-singleton-';
 
   constructor(store: ModelStore<TModel>) {
     this.store = store;
@@ -24,21 +23,20 @@ export class SingletonModelStore<TModel extends Model>
   }
 
   get model(): TModel {
-    const model = this.store.get(this.singletonId);
+    const model = this.store.list()[0];
     if (model) return model;
 
     const createdModel = this.store.create();
     if (!createdModel)
       throw new Error(`Unable to initialize model from store ${this.store}`);
 
-    createdModel.modelId = this.singletonId;
     this.store.add(createdModel);
     return createdModel;
   }
 
   replace(model: TModel, tag: string): void {
     const existingModel = this.model;
-    existingModel.initializeFromModel(this.singletonId, model);
+    existingModel.initializeFromModel(existingModel.modelId, model);
     this.store.persist();
     this.changeSubscription.fire((handler) =>
       handler.onModelReplaced(existingModel, tag),

--- a/src/core/models/Model.ts
+++ b/src/core/models/Model.ts
@@ -140,7 +140,7 @@ export class Model<
     name: string & K,
     value: T[K] | undefined,
     tag: string = ModelChangeTags.NORMAL,
-    forceChange = false,
+    forceChange = true,
   ): void {
     const oldValue = this.data.get(name);
 

--- a/src/core/models/Model.ts
+++ b/src/core/models/Model.ts
@@ -140,7 +140,7 @@ export class Model<
     name: string & K,
     value: T[K] | undefined,
     tag: string = ModelChangeTags.NORMAL,
-    forceChange = true,
+    forceChange = false,
   ): void {
     const oldValue = this.data.get(name);
 

--- a/src/core/operations/BaseTagOperation.ts
+++ b/src/core/operations/BaseTagOperation.ts
@@ -18,9 +18,7 @@ export abstract class BaseTagOperation<
     key?: string,
   ) {
     super(operationName, appId, onesignalId);
-    if (key) {
-      this.key = key;
-    }
+    if (key) this.key = key;
   }
 
   /**

--- a/src/core/operations/DeleteSubscriptionOperation.ts
+++ b/src/core/operations/DeleteSubscriptionOperation.ts
@@ -10,9 +10,7 @@ export class DeleteSubscriptionOperation extends BaseSubscriptionOperation {
   constructor(appId: string, onesignalId: string, subscriptionId: string);
   constructor(appId?: string, onesignalId?: string, subscriptionId?: string) {
     super(OPERATION_NAME.DELETE_SUBSCRIPTION, appId, onesignalId);
-    if (subscriptionId) {
-      this.subscriptionId = subscriptionId;
-    }
+    if (subscriptionId) this.subscriptionId = subscriptionId;
   }
 
   override get groupComparisonType(): GroupComparisonValue {

--- a/src/core/operations/LoginUserFromSubscriptionOperation.ts
+++ b/src/core/operations/LoginUserFromSubscriptionOperation.ts
@@ -16,9 +16,7 @@ export class LoginUserFromSubscriptionOperation extends Operation<LoginUserOpera
   constructor(appId: string, onesignalId: string, subscriptionId: string);
   constructor(appId?: string, onesignalId?: string, subscriptionId?: string) {
     super(OPERATION_NAME.LOGIN_USER_FROM_SUBSCRIPTION_USER, appId, onesignalId);
-    if (subscriptionId) {
-      this.subscriptionId = subscriptionId;
-    }
+    if (subscriptionId) this.subscriptionId = subscriptionId;
   }
 
   get subscriptionId(): string {

--- a/src/core/operations/Operation.ts
+++ b/src/core/operations/Operation.ts
@@ -23,10 +23,8 @@ export abstract class Operation<
   constructor(name: string, appId?: string, onesignalId?: string) {
     super();
     this.name = name;
-    if (appId && onesignalId) {
-      this.appId = appId;
-      this.onesignalId = onesignalId;
-    }
+    if (appId) this.appId = appId;
+    if (onesignalId) this.onesignalId = onesignalId;
   }
 
   get name(): string {

--- a/src/core/operations/TrackSessionEndOperation.ts
+++ b/src/core/operations/TrackSessionEndOperation.ts
@@ -14,9 +14,7 @@ export class TrackSessionEndOperation extends Operation<TrackEndOp> {
   constructor(appId: string, onesignalId: string, sessionTime: number);
   constructor(appId?: string, onesignalId?: string, sessionTime?: number) {
     super(OPERATION_NAME.TRACK_SESSION_END, appId, onesignalId);
-    if (sessionTime) {
-      this.sessionTime = sessionTime;
-    }
+    if (sessionTime) this.sessionTime = sessionTime;
   }
 
   /**

--- a/src/core/operations/TransferSubscriptionOperation.ts
+++ b/src/core/operations/TransferSubscriptionOperation.ts
@@ -10,9 +10,7 @@ export class TransferSubscriptionOperation extends BaseSubscriptionOperation {
   constructor(appId: string, onesignalId: string, subscriptionId: string);
   constructor(appId?: string, onesignalId?: string, subscriptionId?: string) {
     super(OPERATION_NAME.TRANSFER_SUBSCRIPTION, appId, onesignalId);
-    if (subscriptionId) {
-      this.subscriptionId = subscriptionId;
-    }
+    if (subscriptionId) this.subscriptionId = subscriptionId;
   }
 
   override get groupComparisonType(): GroupComparisonValue {

--- a/src/entries/pageSdkInit.test.ts
+++ b/src/entries/pageSdkInit.test.ts
@@ -1,6 +1,6 @@
 import { APP_ID } from '__test__/support/constants';
 import { TestEnvironment } from '__test__/support/environment/TestEnvironment';
-import { mockServerConfig } from '__test__/support/helpers/configHelper';
+import { mockServerConfig } from '__test__/support/helpers/requests';
 import { server } from '__test__/support/mocks/server';
 import { http, HttpResponse } from 'msw';
 import Log from 'src/shared/libraries/Log';

--- a/src/onesignal/OneSignal.test.ts
+++ b/src/onesignal/OneSignal.test.ts
@@ -1,0 +1,111 @@
+import { APP_ID, DUMMY_ONESIGNAL_ID } from '__test__/support/constants';
+import { TestEnvironment } from '__test__/support/environment/TestEnvironment';
+import {
+  addAliasFn,
+  deleteAliasFn,
+  mockPageStylesCss,
+  mockServerConfig,
+  setAddAliasResponse,
+  setDeleteAliasResponse,
+} from '__test__/support/helpers/requests';
+import { server } from '__test__/support/mocks/server';
+import { IdentityModel } from 'src/core/models/IdentityModel';
+import { OP_REPO_EXECUTION_INTERVAL } from 'src/core/operationRepo/constants';
+import Database from 'src/shared/services/Database';
+
+vi.useFakeTimers();
+
+describe('OneSignal', () => {
+  beforeAll(async () => {
+    server.use(mockServerConfig(), mockPageStylesCss());
+    const _onesignal = await TestEnvironment.initialize();
+    window.OneSignal = _onesignal;
+
+    await Database.put('identity', {
+      modelId: '123',
+      onesignalId: DUMMY_ONESIGNAL_ID,
+    });
+    await window.OneSignal.init({ appId: APP_ID });
+  });
+
+  beforeEach(() => {
+    // reset the identity model
+    const newIdentityModel = new IdentityModel();
+    newIdentityModel.onesignalId = DUMMY_ONESIGNAL_ID;
+    window.OneSignal.coreDirector
+      .getIdentityModel()
+      .initializeFromJson(newIdentityModel.toJSON());
+  });
+
+  describe('User', () => {
+    describe('aliases', () => {
+      beforeEach(() => {
+        setAddAliasResponse();
+        addAliasFn.mockClear();
+        deleteAliasFn.mockClear();
+      });
+
+      test('can add an alias to the current user', async () => {
+        window.OneSignal.User.addAlias('someLabel', 'someId');
+        const identityModel = window.OneSignal.coreDirector.getIdentityModel();
+        expect(identityModel.getProperty('someLabel')).toBe('someId');
+
+        // should make a request to the backend
+        await vi.advanceTimersByTimeAsync(OP_REPO_EXECUTION_INTERVAL * 2);
+        expect(addAliasFn).toHaveBeenCalledWith({
+          identity: {
+            someLabel: 'someId',
+          },
+        });
+      });
+
+      test('can add multiple aliases to the current user', async () => {
+        window.OneSignal.User.addAlias('someLabel', 'someId');
+        window.OneSignal.User.addAlias('someLabel2', 'someId2');
+
+        const identityModel = window.OneSignal.coreDirector.getIdentityModel();
+        expect(identityModel.getProperty('someLabel')).toBe('someId');
+        expect(identityModel.getProperty('someLabel2')).toBe('someId2');
+
+        await vi.advanceTimersByTimeAsync(OP_REPO_EXECUTION_INTERVAL * 3);
+        expect(addAliasFn).toHaveBeenCalledWith({
+          identity: {
+            someLabel: 'someId',
+          },
+        });
+        expect(addAliasFn).toHaveBeenCalledWith({
+          identity: {
+            someLabel2: 'someId2',
+          },
+        });
+      });
+
+      test('can delete an alias from the current user', async () => {
+        setDeleteAliasResponse();
+
+        window.OneSignal.User.addAlias('someLabel', 'someId');
+        await vi.advanceTimersByTimeAsync(OP_REPO_EXECUTION_INTERVAL * 2);
+        window.OneSignal.User.removeAlias('someLabel');
+
+        const identityModel = window.OneSignal.coreDirector.getIdentityModel();
+        expect(identityModel.getProperty('someLabel')).toBeUndefined();
+
+        await vi.advanceTimersByTimeAsync(OP_REPO_EXECUTION_INTERVAL * 2);
+        expect(deleteAliasFn).toHaveBeenCalled();
+      });
+
+      test('can delete multiple aliases from the current user', async () => {
+        setDeleteAliasResponse();
+
+        window.OneSignal.User.addAlias('someLabel', 'someId');
+        window.OneSignal.User.addAlias('someLabel2', 'someId2');
+        await vi.advanceTimersByTimeAsync(OP_REPO_EXECUTION_INTERVAL * 2);
+        window.OneSignal.User.removeAlias('someLabel');
+        window.OneSignal.User.removeAlias('someLabel2');
+
+        await vi.advanceTimersByTimeAsync(OP_REPO_EXECUTION_INTERVAL * 4);
+        expect(deleteAliasFn).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+});

--- a/src/onesignal/UserNamespace.test.ts
+++ b/src/onesignal/UserNamespace.test.ts
@@ -1,0 +1,335 @@
+import {
+  DUMMY_ONESIGNAL_ID,
+  DUMMY_PUSH_TOKEN,
+} from '__test__/support/constants';
+import { TestEnvironment } from '../../__test__/support/environment/TestEnvironment';
+import UserChangeEvent from '../page/models/UserChangeEvent';
+import { Subscription } from '../shared/models/Subscription';
+import User from './User';
+import UserNamespace from './UserNamespace';
+
+vi.mock('../shared/libraries/Log');
+
+describe('UserNamespace', () => {
+  let userNamespace: UserNamespace;
+
+  beforeEach(async () => {
+    await TestEnvironment.initialize({});
+
+    userNamespace = new UserNamespace(true);
+  });
+
+  describe('User Identity Properties', () => {
+    test('should return correct onesignalId', () => {
+      const user = new User();
+      user.onesignalId = DUMMY_ONESIGNAL_ID;
+
+      vi.spyOn(User, 'createOrGetInstance').mockReturnValue(user);
+
+      userNamespace = new UserNamespace(true);
+      expect(userNamespace.onesignalId).toBe(DUMMY_ONESIGNAL_ID);
+    });
+
+    test('should return correct externalId', () => {
+      const identityModel = OneSignal.coreDirector.getIdentityModel();
+      const externalId = 'some-external-id';
+      identityModel.setProperty('external_id', externalId);
+
+      expect(userNamespace.externalId).toBe(externalId);
+    });
+  });
+
+  describe('Alias Management', () => {
+    test('can add a single alias', () => {
+      const label = 'some-label';
+      const id = 'some-id';
+
+      userNamespace.addAlias(label, id);
+
+      const identityModel = OneSignal.coreDirector.getIdentityModel();
+      expect(identityModel.getProperty(label)).toBe(id);
+    });
+
+    test('can add multiple aliases', () => {
+      const aliases = {
+        someLabel: 'some-id',
+        anotherLabel: 'another-id',
+      };
+
+      userNamespace.addAliases(aliases);
+
+      const identityModel = OneSignal.coreDirector.getIdentityModel();
+      expect(identityModel.getProperty('someLabel')).toBe(aliases.someLabel);
+      expect(identityModel.getProperty('anotherLabel')).toBe(
+        aliases.anotherLabel,
+      );
+    });
+
+    test('can remove a single alias', () => {
+      const label = 'some-label';
+      const id = 'some-id';
+      const identityModel = OneSignal.coreDirector.getIdentityModel();
+
+      // First add the alias
+      userNamespace.addAlias(label, id);
+      expect(identityModel.getProperty(label)).toBe(id);
+
+      // Then remove it
+      userNamespace.removeAlias(label);
+
+      expect(identityModel.getProperty(label)).toBeUndefined();
+    });
+
+    test('can remove multiple aliases', () => {
+      const aliases = {
+        someLabel: 'some-id',
+        anotherLabel: 'another-id',
+      };
+      const identityModel = OneSignal.coreDirector.getIdentityModel();
+
+      // First add the aliases
+      userNamespace.addAliases(aliases);
+      expect(identityModel.getProperty('someLabel')).toBe(aliases.someLabel);
+      expect(identityModel.getProperty('anotherLabel')).toBe(
+        aliases.anotherLabel,
+      );
+
+      // Then remove them
+      userNamespace.removeAliases(Object.keys(aliases));
+
+      expect(identityModel.getProperty('someLabel')).toBeUndefined();
+      expect(identityModel.getProperty('anotherLabel')).toBeUndefined();
+    });
+  });
+
+  describe('Email Management', () => {
+    const getEmailSubscription = (email: string) => {
+      const subscriptionModels =
+        OneSignal.coreDirector.getEmailSubscriptionModels();
+      return subscriptionModels.find((model) => model.token === email);
+    };
+
+    test('can add an email subscription', async () => {
+      const email = 'test@example.com';
+      const addSubscriptionSpy = vi.spyOn(
+        OneSignal.coreDirector,
+        'addSubscriptionModel',
+      );
+
+      await userNamespace.addEmail(email);
+
+      expect(addSubscriptionSpy).toHaveBeenCalled();
+      const subscription = getEmailSubscription(email);
+      expect(subscription).toBeDefined();
+      expect(subscription?.token).toBe(email);
+    });
+
+    test('should remove an email subscription', async () => {
+      const email = 'test@example.com';
+
+      // First add the email
+      await userNamespace.addEmail(email);
+      let subscription = getEmailSubscription(email);
+      expect(subscription).toBeDefined();
+
+      // Then remove it
+      const removeSubscriptionSpy = vi.spyOn(
+        OneSignal.coreDirector,
+        'removeSubscriptionModel',
+      );
+      userNamespace.removeEmail(email);
+
+      expect(removeSubscriptionSpy).toHaveBeenCalled();
+      subscription = getEmailSubscription(email);
+      expect(subscription).toBeUndefined();
+    });
+  });
+
+  describe('SMS Management', () => {
+    const getSmsSubscription = (smsNumber: string) => {
+      const subscriptionModels =
+        OneSignal.coreDirector.getSmsSubscriptionModels();
+      return subscriptionModels.find((model) => model.token === smsNumber);
+    };
+
+    test('should add an SMS subscription', async () => {
+      const smsNumber = '+15551234567';
+      const addSubscriptionSpy = vi.spyOn(
+        OneSignal.coreDirector,
+        'addSubscriptionModel',
+      );
+
+      await userNamespace.addSms(smsNumber);
+
+      expect(addSubscriptionSpy).toHaveBeenCalled();
+      const subscription = getSmsSubscription(smsNumber);
+      expect(subscription).toBeDefined();
+      expect(subscription?.token).toBe(smsNumber);
+    });
+
+    test('should remove an SMS subscription', async () => {
+      const smsNumber = '+15551234567';
+
+      // First add the SMS
+      await userNamespace.addSms(smsNumber);
+      let subscription = getSmsSubscription(smsNumber);
+      expect(subscription).toBeDefined();
+
+      // Then remove it
+      const removeSubscriptionSpy = vi.spyOn(
+        OneSignal.coreDirector,
+        'removeSubscriptionModel',
+      );
+      userNamespace.removeSms(smsNumber);
+
+      expect(removeSubscriptionSpy).toHaveBeenCalled();
+      subscription = getSmsSubscription(smsNumber);
+      expect(subscription).toBeUndefined();
+      expect(subscription?.token).toBe(undefined);
+    });
+  });
+
+  describe('Tag Management', () => {
+    test('should add a single tag', () => {
+      const key = 'test_tag';
+      const value = 'test_value';
+
+      userNamespace.addTag(key, value);
+
+      expect(userNamespace.getTags()).toEqual({ [key]: value });
+    });
+
+    test('should add multiple tags', () => {
+      const tags = {
+        tag1: 'value1',
+        tag2: 'value2',
+      };
+
+      userNamespace.addTags(tags);
+
+      expect(userNamespace.getTags()).toEqual(tags);
+    });
+
+    test('should remove a single tag', () => {
+      const tags = {
+        tag1: 'value1',
+        tag2: 'value2',
+      };
+
+      // First add tags
+      userNamespace.addTags(tags);
+
+      // Then remove one
+      userNamespace.removeTag('tag1');
+
+      expect(userNamespace.getTags()).toEqual({ tag2: 'value2' });
+    });
+
+    test('should remove multiple tags', () => {
+      const tags = {
+        tag1: 'value1',
+        tag2: 'value2',
+        tag3: 'value3',
+      };
+
+      // First add tags
+      userNamespace.addTags(tags);
+
+      // Then remove multiple
+      userNamespace.removeTags(['tag1', 'tag3']);
+
+      expect(userNamespace.getTags()).toEqual({ tag2: 'value2' });
+    });
+
+    test('should return empty object when no tags exist', () => {
+      expect(userNamespace.getTags()).toEqual({});
+    });
+  });
+
+  describe('Language Management', () => {
+    test('should set language', () => {
+      const language = 'fr';
+
+      userNamespace.setLanguage(language);
+
+      expect(userNamespace.getLanguage()).toBe(language);
+    });
+
+    test('should get language', () => {
+      const language = 'es';
+      const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
+      propertiesModel.language = language;
+
+      expect(userNamespace.getLanguage()).toBe(language);
+    });
+
+    test('should return empty string if language is not set', () => {
+      const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
+      propertiesModel.language = undefined;
+
+      expect(userNamespace.getLanguage()).toBe('');
+    });
+  });
+
+  describe('Event Handling', () => {
+    test('should add and trigger event listener', () => {
+      const mockListener = vi.fn();
+      const event: UserChangeEvent = {
+        current: {
+          onesignalId: DUMMY_ONESIGNAL_ID,
+          externalId: undefined,
+        },
+      };
+
+      userNamespace.addEventListener('change', mockListener);
+      UserNamespace.emitter.emit('change', event);
+
+      expect(mockListener).toHaveBeenCalledWith(event);
+    });
+
+    test('should remove event listener', () => {
+      const mockListener = vi.fn();
+      const event: UserChangeEvent = {
+        current: {
+          onesignalId: DUMMY_ONESIGNAL_ID,
+          externalId: undefined,
+        },
+      };
+
+      userNamespace.addEventListener('change', mockListener);
+      userNamespace.removeEventListener('change', mockListener);
+      UserNamespace.emitter.emit('change', event);
+
+      expect(mockListener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Initialization', () => {
+    test('should initialize PushSubscription when initialize is true', () => {
+      const initializedNamespace = new UserNamespace(true);
+
+      expect(initializedNamespace.PushSubscription).toBeDefined();
+      expect(initializedNamespace['_currentUser']).toBeDefined();
+    });
+
+    test('should not initialize user when initialize is false', () => {
+      const uninitializedNamespace = new UserNamespace(false);
+
+      expect(uninitializedNamespace['_currentUser']).toBeUndefined();
+    });
+
+    test('should use provided subscription and permission when initializing', () => {
+      const subscription = new Subscription();
+      subscription.deviceId = 'device-123';
+      subscription.subscriptionToken = DUMMY_PUSH_TOKEN;
+      subscription.optedOut = false;
+      subscription.createdAt = Date.now();
+
+      const permission: NotificationPermission = 'granted';
+
+      const customNamespace = new UserNamespace(true, subscription, permission);
+
+      expect(customNamespace.PushSubscription).toBeDefined();
+    });
+  });
+});

--- a/src/onesignal/UserNamespace.ts
+++ b/src/onesignal/UserNamespace.ts
@@ -1,9 +1,9 @@
-import User from './User';
-import PushSubscriptionNamespace from './PushSubscriptionNamespace';
-import { Subscription } from '../shared/models/Subscription';
-import { EventListenerBase } from '../page/userModel/EventListenerBase';
 import UserChangeEvent from '../page/models/UserChangeEvent';
+import { EventListenerBase } from '../page/userModel/EventListenerBase';
 import Emitter from '../shared/libraries/Emitter';
+import { Subscription } from '../shared/models/Subscription';
+import PushSubscriptionNamespace from './PushSubscriptionNamespace';
+import User from './User';
 
 export default class UserNamespace extends EventListenerBase {
   private _currentUser?: User;
@@ -36,7 +36,7 @@ export default class UserNamespace extends EventListenerBase {
 
   get externalId(): string | undefined {
     const identityModel = OneSignal.coreDirector.getIdentityModel();
-    return identityModel?.data?.external_id;
+    return identityModel?.externalId;
   }
 
   public addAlias(label: string, id: string): void {

--- a/src/shared/api/OneSignalApiBase.ts
+++ b/src/shared/api/OneSignalApiBase.ts
@@ -107,7 +107,6 @@ export class OneSignalApiBase {
       const { status, headers } = response;
       const json = await response.json();
       const retryAfter = headers?.get('Retry-After');
-
       return {
         ok: response.ok,
         result: json,

--- a/src/shared/managers/IDManager.ts
+++ b/src/shared/managers/IDManager.ts
@@ -21,7 +21,7 @@ export const IDManager = {
    * @param id - The ID to test.
    * @returns True if the ID was created via createLocalId.
    */
-  isLocalId(id: string): boolean {
-    return id.startsWith(this.LOCAL_PREFIX);
+  isLocalId(id: string | undefined): boolean {
+    return id?.startsWith(this.LOCAL_PREFIX) ?? false;
   },
 };


### PR DESCRIPTION
# Description
## 1 Line Summary
Continuation of the [Web SDK Refactor project](https://docs.google.com/document/d/1JsbmxVM_n6K9nRXwbJf6mQr5h88qy_vIEiBGY0Ub_lE/edit?tab=t.0#heading=h.ojv84gskof17).

## Details
- Remove singleton id usage since existing identity IndexedDB entry has a random id
- Updated CoreModule to start the oepration repo
- Removed bootstrap method for singleton model store listener to subscribe to events right away
- Added tests for UserNamespace
- Updated IDManager to handle undefined ids like onesignal_id

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1289)
<!-- Reviewable:end -->
