### PR TITLE
fix(api): update User `getTags` and `getLanguage` to return a Promise

### DIFF
--- a/api.json
+++ b/api.json
@@ -455,7 +455,7 @@
         "name": "getTags",
         "isAsync": false,
         "args": [],
-        "returnType": "{ [key: string]: string }"
+        "returnType": "Promise<{ [key: string]: string }>"
       },
       {
         "name": "addEventListener",
@@ -507,7 +507,7 @@
         "name": "getLanguage",
         "isAsync": false,
         "args": [],
-        "returnType": "string"
+        "returnType": "Promise<string>"
       }
     ],
     "properties": [


### PR DESCRIPTION
# Description
## 1 Line Summary

Updates the User `getTags` and `getLanguage` functions in the API spec to return a Promise.

## Details

In order to address https://github.com/OneSignal/react-onesignal/pull/173 we need to accomplish two things:
- update the spec in this repo so that https://github.com/OneSignal/web-shim-codegen can generate the correct types and function signature
  - this PR addresses this point
- update the templates in web-shim ([example](https://github.com/OneSignal/web-shim-codegen/blob/main/src/support/react/oneSignalFunctionTemplates.ts#L35-L54)) so that the function body is generated using a Promise-style
  - change needs to be made in web-shim directly


The end result should be as follows:
**Before:**
```ts
function userGetTags(): { [key: string]: string } {
  let retVal: { [key: string]: string };
  window.OneSignalDeferred?.push((OneSignal: IOneSignalOneSignal) => {
    retVal = OneSignal.User.getTags();
  });
  return retVal;
}
```

**After:**
```ts
function userGetTags(): Promise<{ [key: string]: string }> {
  return new Promise((resolve) => {
    window.OneSignalDeferred?.push((OneSignal: IOneSignalOneSignal) => {
      resolve(OneSignal.User.getTags());
    });
  });
}
```
# Systems Affected
   - [ ] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1303)
<!-- Reviewable:end -->
