### PR TITLE
Web SDK Refactor: IndexedDB Backward Compatibility 

### DIFF
--- a/src/core/executors/LoginUserOperationExecutor.ts
+++ b/src/core/executors/LoginUserOperationExecutor.ts
@@ -223,6 +223,11 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
         const model =
           this._subscriptionsModelStore.getBySubscriptionId(localId);
         model?.setProperty('id', backendSub.id, ModelChangeTags.HYDRATE);
+        model?.setProperty(
+          'onesignalId',
+          backendOneSignalId,
+          ModelChangeTags.HYDRATE,
+        );
       }
 
       EventHelper.checkAndTriggerUserChanged();

--- a/src/core/executors/RefreshUserOperationExecutor.ts
+++ b/src/core/executors/RefreshUserOperationExecutor.ts
@@ -97,6 +97,7 @@ export class RefreshUserOperationExecutor implements IOperationExecutor {
         model.sdk = sub.sdk ?? '';
         model.device_os = sub.device_os ?? '';
         model.device_model = sub.device_model ?? '';
+        model.onesignalId = op.onesignalId;
 
         // We only add a non-push subscriptions. For push, the device is the source of truth
         // so we don't want to cache these subscriptions from the backend.
@@ -110,7 +111,10 @@ export class RefreshUserOperationExecutor implements IOperationExecutor {
       if (pushSubscriptionId) {
         const cachedPushModel =
           this._subscriptionsModelStore.getBySubscriptionId(pushSubscriptionId);
-        if (cachedPushModel) subscriptionModels.push(cachedPushModel);
+        if (cachedPushModel) {
+          cachedPushModel.onesignalId = op.onesignalId;
+          subscriptionModels.push(cachedPushModel);
+        }
       }
 
       this._identityModelStore.replace(identityModel, ModelChangeTags.HYDRATE);

--- a/src/core/executors/SubscriptionOperationExecutor.ts
+++ b/src/core/executors/SubscriptionOperationExecutor.ts
@@ -114,6 +114,11 @@ export class SubscriptionOperationExecutor implements IOperationExecutor {
           backendSubscriptionId,
           ModelChangeTags.HYDRATE,
         );
+        subscriptionModel?.setProperty(
+          'onesignalId',
+          createOperation.onesignalId,
+          ModelChangeTags.HYDRATE,
+        );
       }
 
       const pushSubscriptionId = await Database.getPushId();

--- a/src/core/modelRepo/ModelStore.ts
+++ b/src/core/modelRepo/ModelStore.ts
@@ -193,7 +193,7 @@ export abstract class ModelStore<
     for (const model of this.models) {
       await Database.put(this.modelName, {
         modelId: model.modelId,
-        modelName: this.modelName,
+        modelName: this.modelName, // TODO: ModelName is a legacy property, could be removed sometime after web refactor launch
         ...model.toJSON(),
       });
     }

--- a/src/core/modelStores/SimpleModelStore.ts
+++ b/src/core/modelStores/SimpleModelStore.ts
@@ -24,6 +24,7 @@ export class SimpleModelStore<TModel extends Model> extends ModelStore<TModel> {
   override create(modelData?: DatabaseModel<TModel>): TModel {
     const model = this._create();
     if (modelData != null) {
+      // TODO: ModelName is a legacy property, could be removed sometime after web refactor launch
       // model name is kept track in the model store, so we don't need to pass it to the model,
       // the model id needs to be passed to the model, so it can stay consistent since reload will generate a new id
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/core/modelStores/SimpleModelStore.ts
+++ b/src/core/modelStores/SimpleModelStore.ts
@@ -1,6 +1,6 @@
 import { ModelStore } from 'src/core/modelRepo/ModelStore';
 import { Model } from 'src/core/models/Model';
-import { ModelNameType } from 'src/core/types/models';
+import { DatabaseModel, ModelNameType } from 'src/core/types/models';
 
 // Implements logic similar to Android SDK's SimpleModelStore
 // Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/common/modeling/SimpleModelStore.kt
@@ -21,12 +21,16 @@ export class SimpleModelStore<TModel extends Model> extends ModelStore<TModel> {
     this.load(); // Automatically load on construction
   }
 
-  override create(modelData?: { modelId?: string } & object): TModel {
+  override create(modelData?: DatabaseModel<TModel>): TModel {
     const model = this._create();
     if (modelData != null) {
-      model.initializeFromJson(modelData);
-      if (modelData.modelId) {
-        model.modelId = modelData.modelId;
+      // model name is kept track in the model store, so we don't need to pass it to the model,
+      // the model id needs to be passed to the model, so it can stay consistent since reload will generate a new id
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { modelId, modelName: _, ...rest } = modelData;
+      model.initializeFromJson(rest);
+      if (modelId) {
+        model.modelId = modelId;
       }
     }
     return model;

--- a/src/core/models/SubscriptionModel.ts
+++ b/src/core/models/SubscriptionModel.ts
@@ -18,7 +18,9 @@ type ISubscriptionModel = Pick<
   | 'enabled'
   | 'web_auth'
   | 'web_p256'
->;
+> & {
+  onesignalId?: string;
+};
 
 // Implements logic similar to Android SDK's SubscriptionModel
 // Reference: https://github.com/OneSignal/OneSignal-Android-SDK/blob/5.1.31/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/user/internal/subscriptions/SubscriptionModel.kt
@@ -28,6 +30,16 @@ export class SubscriptionModel extends Model<ISubscriptionModel> {
     this.sdk = FuturePushSubscriptionRecord.getSdk();
     this.device_model = FuturePushSubscriptionRecord.getDeviceModel();
     this.device_os = FuturePushSubscriptionRecord.getDeviceOS();
+  }
+
+  /**
+   * This is a legacy property, could be removed sometime after web refactor launch
+   */
+  get onesignalId(): string | undefined {
+    return this.getProperty('onesignalId');
+  }
+  set onesignalId(value: string | undefined) {
+    this.setProperty('onesignalId', value);
   }
 
   /**

--- a/src/core/types/models.ts
+++ b/src/core/types/models.ts
@@ -58,12 +58,21 @@ export interface IModelStoreChangeHandler<TModel extends Model> {
   onModelRemoved(model: TModel, tag: string): void;
 }
 
-export interface IModelStore<TModel extends Model>
-  extends IEventNotifier<IModelStoreChangeHandler<TModel>> {
+export type DatabaseModel<TModel extends Model> = ReturnType<
+  TModel['toJSON']
+> & {
+  modelId: string;
+  modelName: string;
+};
+
+export interface IModelStore<
+  TModel extends Model,
+  DBModel extends DatabaseModel<TModel> = DatabaseModel<TModel>,
+> extends IEventNotifier<IModelStoreChangeHandler<TModel>> {
   /**
    * Create a new instance of the model, optionally from a JSON object.
    */
-  create(jsonObject?: object): TModel | null;
+  create(jsonObject?: DBModel | null): TModel | null;
 
   /**
    * List the models that are owned by this model store.

--- a/src/entries/pageSdkInit2.test.ts
+++ b/src/entries/pageSdkInit2.test.ts
@@ -66,6 +66,7 @@ describe('pageSdkInit 2', () => {
         id: expect.any(String),
         modelId: expect.any(String),
         modelName: 'subscriptions',
+        onesignalId: DUMMY_ONESIGNAL_ID,
         notification_types: NotificationType.Subscribed,
         sdk: '1',
         token: email,

--- a/src/entries/pageSdkInit2.test.ts
+++ b/src/entries/pageSdkInit2.test.ts
@@ -60,11 +60,12 @@ describe('pageSdkInit 2', () => {
 
     expect(subscriptions).toEqual([
       {
-        id: expect.any(String),
         device_model: '',
         device_os: 56,
         enabled: true,
+        id: expect.any(String),
         modelId: expect.any(String),
+        modelName: 'subscriptions',
         notification_types: NotificationType.Subscribed,
         sdk: '1',
         token: email,

--- a/src/onesignal/OneSignal.test.ts
+++ b/src/onesignal/OneSignal.test.ts
@@ -199,11 +199,12 @@ describe('OneSignal', () => {
         let dbSubscriptions = await getEmailSubscriptionDbItems();
         expect(dbSubscriptions).toEqual([
           {
-            modelId: expect.any(String),
-            id: expect.any(String),
             ...subscription,
-            device_os: 56,
             device_model: '',
+            device_os: 56,
+            id: expect.any(String),
+            modelId: expect.any(String),
+            modelName: 'subscriptions',
             sdk: '1',
           },
         ]);
@@ -288,11 +289,12 @@ describe('OneSignal', () => {
 
         expect(dbSubscriptions).toEqual([
           {
-            modelId: expect.any(String),
-            id: expect.any(String),
             ...subscription,
-            device_os: 56,
             device_model: '',
+            device_os: 56,
+            id: expect.any(String),
+            modelId: expect.any(String),
+            modelName: 'subscriptions',
             sdk: '1',
           },
         ]);
@@ -365,6 +367,7 @@ describe('OneSignal', () => {
         // should not change the identity in the IndexedDB right away
         expect(identityData).toEqual({
           modelId: expect.any(String),
+          modelName: 'identity',
           onesignal_id: DUMMY_ONESIGNAL_ID,
         });
 
@@ -378,9 +381,10 @@ describe('OneSignal', () => {
         // should also update the identity in the IndexedDB
         identityData = await getIdentityItem();
         expect(identityData).toEqual({
-          modelId: expect.any(String),
-          onesignal_id: DUMMY_ONESIGNAL_ID,
           external_id: externalId,
+          modelId: expect.any(String),
+          modelName: 'identity',
+          onesignal_id: DUMMY_ONESIGNAL_ID,
         });
 
         const identityModel = window.OneSignal.coreDirector.getIdentityModel();
@@ -431,9 +435,10 @@ describe('OneSignal', () => {
 
         const identityData = await getIdentityItem();
         expect(identityData).toEqual({
-          modelId: expect.any(String),
-          onesignal_id: DUMMY_ONESIGNAL_ID,
           external_id: newExternalId,
+          modelId: expect.any(String),
+          modelName: 'identity',
+          onesignal_id: DUMMY_ONESIGNAL_ID,
         });
 
         const identityModel = window.OneSignal.coreDirector.getIdentityModel();
@@ -484,9 +489,10 @@ describe('OneSignal', () => {
         // onesignal id should be changed
         const identityData = await getIdentityItem();
         expect(identityData).toEqual({
-          modelId: expect.any(String),
-          onesignal_id: DUMMY_ONESIGNAL_ID_2,
           external_id: externalId,
+          modelId: expect.any(String),
+          modelName: 'identity',
+          onesignal_id: DUMMY_ONESIGNAL_ID_2,
         });
 
         // subscriptions should be kept
@@ -556,6 +562,7 @@ describe('OneSignal', () => {
         expect(identityData).toEqual({
           modelId: expect.any(String),
           onesignal_id: undefined,
+          modelName: 'identity',
         });
 
         // properties model should be reset
@@ -566,6 +573,7 @@ describe('OneSignal', () => {
         let propertiesData = await getPropertiesItem();
         expect(propertiesData).toEqual({
           modelId: expect.any(String),
+          modelName: 'properties',
         });
         await waitForOperations(3);
 
@@ -578,12 +586,14 @@ describe('OneSignal', () => {
         identityData = await getIdentityItem();
         expect(identityData).toEqual({
           modelId: expect.any(String),
+          modelName: 'identity',
           onesignal_id: DUMMY_ONESIGNAL_ID,
         });
 
         propertiesData = await getPropertiesItem();
         expect(propertiesData).toEqual({
           modelId: expect.any(String),
+          modelName: 'properties',
           onesignalId: DUMMY_ONESIGNAL_ID,
         });
 
@@ -593,6 +603,7 @@ describe('OneSignal', () => {
           {
             id: DUMMY_SUBSCRIPTION_ID,
             modelId: expect.any(String),
+            modelName: 'subscriptions',
             token,
             type,
           },

--- a/src/onesignal/OneSignal.test.ts
+++ b/src/onesignal/OneSignal.test.ts
@@ -205,6 +205,7 @@ describe('OneSignal', () => {
             id: expect.any(String),
             modelId: expect.any(String),
             modelName: 'subscriptions',
+            onesignalId: DUMMY_ONESIGNAL_ID,
             sdk: '1',
           },
         ]);
@@ -295,6 +296,7 @@ describe('OneSignal', () => {
             id: expect.any(String),
             modelId: expect.any(String),
             modelName: 'subscriptions',
+            onesignalId: DUMMY_ONESIGNAL_ID,
             sdk: '1',
           },
         ]);

--- a/src/onesignal/User.ts
+++ b/src/onesignal/User.ts
@@ -113,6 +113,7 @@ export default class User {
       id: IDManager.createLocalId(),
       enabled: true,
       notification_types: NotificationType.Subscribed,
+      onesignalId: OneSignal.coreDirector.getIdentityModel().onesignalId,
       token,
       type,
     };


### PR DESCRIPTION
# Description
## 1 Line Summary
Continuation of the [Web SDK Refactor project](https://docs.google.com/document/d/1JsbmxVM_n6K9nRXwbJf6mQr5h88qy_vIEiBGY0Ub_lE/edit?tab=t.0#heading=h.ojv84gskof17). This is kind of optional, but if we want to rollback this release then the data should be compatible with old version.

## Details
- For the `checkIfSlidedownShouldBeShown` method if SlidedownManager it checks if user is already subscribed by checking if its a valid subscription via `getSubscriptionStateFromBrowserContext` which checks if `onesignalid` exists in the db subscription data.
- So added a onesignalId property for the subscription models and updated relevant executor logic to keep it up to date.
- Adjusted tests accordingly.

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info
The tests have been updated to reflect the new changes and ensure that the OneSignal ID is correctly associated with subscriptions.

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info
N/A

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1305)
<!-- Reviewable:end -->
