### PR TITLE
Web SDK Refactor: Adjust Login Logic

### DIFF
--- a/src/onesignal/UserDirector.ts
+++ b/src/onesignal/UserDirector.ts
@@ -1,3 +1,5 @@
+import { IdentityModel } from 'src/core/models/IdentityModel';
+import { PropertiesModel } from 'src/core/models/PropertiesModel';
 import { OP_REPO_EXECUTION_INTERVAL } from 'src/core/operationRepo/constants';
 import { CreateSubscriptionOperation } from 'src/core/operations/CreateSubscriptionOperation';
 import { LoginUserOperation } from 'src/core/operations/LoginUserOperation';
@@ -62,5 +64,20 @@ export default class UserDirector {
   static resetUserMetaProperties() {
     const user = User.createOrGetInstance();
     user.isCreatingUser = false;
+  }
+
+  // Resets models similar to Android SDK
+  // https://github.com/OneSignal/OneSignal-Android-SDK/blob/ed2e87618ea3af81b75f97b0a4cbb8f658c7fc80/OneSignalSDK/onesignal/core/src/main/java/com/onesignal/internal/OneSignalImp.kt#L448
+  static resetUserModels() {
+    // replace models
+    const newIdentityModel = new IdentityModel();
+    const newPropertiesModel = new PropertiesModel();
+
+    const sdkId = IDManager.createLocalId();
+    newIdentityModel.onesignalId = sdkId;
+    newPropertiesModel.onesignalId = sdkId;
+
+    OneSignal.coreDirector.identityModelStore.replace(newIdentityModel);
+    OneSignal.coreDirector.propertiesModelStore.replace(newPropertiesModel);
   }
 }

--- a/src/onesignal/UserDirector.ts
+++ b/src/onesignal/UserDirector.ts
@@ -1,12 +1,11 @@
 import { IdentityModel } from 'src/core/models/IdentityModel';
 import { PropertiesModel } from 'src/core/models/PropertiesModel';
-import { OP_REPO_EXECUTION_INTERVAL } from 'src/core/operationRepo/constants';
 import { CreateSubscriptionOperation } from 'src/core/operations/CreateSubscriptionOperation';
 import { LoginUserOperation } from 'src/core/operations/LoginUserOperation';
 import { IDManager } from 'src/shared/managers/IDManager';
 import MainHelper from '../shared/helpers/MainHelper';
 import Log from '../shared/libraries/Log';
-import { delay, logMethodCall } from '../shared/utils/utils';
+import { logMethodCall } from '../shared/utils/utils';
 import User from './User';
 
 export default class UserDirector {
@@ -50,11 +49,6 @@ export default class UserDirector {
         ...rest,
       }),
     );
-
-    // in case OneSignal.init and OneSignal.login are both called in a short time period
-    // we need this create operation to finish before attempting to execute the login (with external id) operation
-    // otherwise the login operation executor will error since there will be two login operations
-    await delay(OP_REPO_EXECUTION_INTERVAL * 2);
   }
 
   static createAndHydrateUser(): Promise<void> {


### PR DESCRIPTION
# Description
## 1 Line Summary
- Removes unnecessary delay after creating a subscription, this was due to not using local ids via IdManager

## Details
Currently, if we have logic like:
```
 OneSignalDeferred.push(async function (OneSignal) {
        await OneSignal.init({
          appId,
        });
      });
      //uncomment to test login
      OneSignalDeferred.push(async function (OneSignal) {
        await OneSignal.login('fadi-11111');
      });
```
It will error like so, if we dont have the `await delay(OP_REPO_EXECUTION_INTERVAL * 2);` in the UserDirector as init will enqueue login op but so will OneSignal.login. This will group the ops together since (previously) onesignal would be undefined.
<img width="1108" alt="Screenshot 2025-06-04 at 12 07 51 PM" src="https://github.com/user-attachments/assets/aa9c6990-2c29-4ba4-81a2-a7c33d97bbc4" />

And so updated logic to mimic Android and use id manager to generate local ids.
- Add resetUserModels helper to replace Identity and Properties Model for operations like login and logout
- Uses createUserOnServer for logout since were now using local ids when resetting the models. initializeUser has a check for onesignalid property and will not create a user if that field exists. 

This leads to the grouped ops being different and the "last login" to be in a different group due to the different create comparison key (since the id is different).
<img width="1097" alt="Screenshot 2025-06-04 at 1 58 49 PM" src="https://github.com/user-attachments/assets/1c12e603-79a1-465e-a80d-4c80b95180e5" />


# Systems Affected
   - [x] WebSDK

# Validation
## Tests
### Info
Existing tests cover the user login flow.

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info
N/A - no visual changes.

### Checklist
   - [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1307)
<!-- Reviewable:end -->
