### PR TITLE
Web SDK Refactor: Transfer Subscription Logic

### DIFF
--- a/__test__/support/environment/TestEnvironment.ts
+++ b/__test__/support/environment/TestEnvironment.ts
@@ -7,7 +7,7 @@ import {
   ServerAppConfig,
 } from '../../../src/shared/models/AppConfig';
 import { DUMMY_ONESIGNAL_ID, DUMMY_PUSH_TOKEN } from '../constants';
-import { getDummyPushSubscriptionOSModel } from '../helpers/core';
+import { generateNewSubscription } from '../helpers/core';
 import BrowserUserAgent from '../models/BrowserUserAgent';
 import {
   initOSGlobals,
@@ -46,9 +46,7 @@ export class TestEnvironment {
     }
 
     if (config.useMockPushSubscriptionModel) {
-      OneSignal.coreDirector.addSubscriptionModel(
-        getDummyPushSubscriptionOSModel(),
-      );
+      OneSignal.coreDirector.addSubscriptionModel(generateNewSubscription());
       vi.spyOn(MainHelper, 'getCurrentPushToken').mockResolvedValue(
         DUMMY_PUSH_TOKEN,
       );

--- a/__test__/support/helpers/core.ts
+++ b/__test__/support/helpers/core.ts
@@ -1,5 +1,3 @@
-import { IdentityModel } from 'src/core/models/IdentityModel';
-import { PropertiesModel } from 'src/core/models/PropertiesModel';
 import { SubscriptionModel } from 'src/core/models/SubscriptionModel';
 import { SubscriptionType } from 'src/core/types/subscription';
 import CoreModule from '../../../src/core/CoreModule';
@@ -22,18 +20,6 @@ export function generateNewSubscription(modelId = '0000000000') {
   return model;
 }
 
-export function getDummyIdentityOSModel(modelId = DUMMY_MODEL_ID) {
-  const model = new IdentityModel();
-  model.modelId = modelId;
-  return model;
-}
-
-export function getDummyPropertyOSModel(modelId = DUMMY_MODEL_ID) {
-  const model = new PropertiesModel();
-  model.modelId = modelId;
-  return model;
-}
-
 export function getDummyPushSubscriptionOSModel() {
   const model = new SubscriptionModel();
   model.modelId = DUMMY_MODEL_ID;
@@ -51,13 +37,3 @@ export async function getCoreModuleDirector(): Promise<CoreModuleDirector> {
   await coreModule.init();
   return new CoreModuleDirector(coreModule);
 }
-
-export const passIfBroadcastNTimes = (
-  target: number,
-  broadcastCount: number,
-  resolve: () => void,
-) => {
-  if (broadcastCount === target) {
-    resolve();
-  }
-};

--- a/__test__/support/helpers/core.ts
+++ b/__test__/support/helpers/core.ts
@@ -2,11 +2,6 @@ import { SubscriptionModel } from 'src/core/models/SubscriptionModel';
 import { SubscriptionType } from 'src/core/types/subscription';
 import CoreModule from '../../../src/core/CoreModule';
 import { CoreModuleDirector } from '../../../src/core/CoreModuleDirector';
-import {
-  DUMMY_MODEL_ID,
-  DUMMY_PUSH_TOKEN,
-  DUMMY_SUBSCRIPTION_ID,
-} from '../constants';
 
 export function generateNewSubscription(modelId = '0000000000') {
   const model = new SubscriptionModel();
@@ -17,17 +12,6 @@ export function generateNewSubscription(modelId = '0000000000') {
     token: 'myToken',
   });
 
-  return model;
-}
-
-export function getDummyPushSubscriptionOSModel() {
-  const model = new SubscriptionModel();
-  model.modelId = DUMMY_MODEL_ID;
-  model.mergeData({
-    type: SubscriptionType.ChromePush,
-    id: DUMMY_SUBSCRIPTION_ID,
-    token: DUMMY_PUSH_TOKEN,
-  });
   return model;
 }
 

--- a/__test__/support/helpers/requests.ts
+++ b/__test__/support/helpers/requests.ts
@@ -140,8 +140,8 @@ export const setDeleteAliasError = ({
 const getSetSubscriptionUri = (onesignalId = DUMMY_ONESIGNAL_ID) =>
   `**/api/v1/apps/${APP_ID}/users/by/onesignal_id/${onesignalId}/subscriptions`;
 
-export const setSubscriptionFn = vi.fn();
-export const setSubscriptionResponse = ({
+export const createSubscriptionFn = vi.fn();
+export const setCreateSubscriptionResponse = ({
   onesignalId,
   response = {},
 }: { onesignalId?: string; response?: object } = {}) =>
@@ -150,7 +150,7 @@ export const setSubscriptionResponse = ({
     method: 'post',
     status: 200,
     response,
-    callback: setSubscriptionFn,
+    callback: createSubscriptionFn,
   });
 
 export const deleteSubscriptionFn = vi.fn();
@@ -168,6 +168,41 @@ export const setDeleteSubscriptionResponse = ({
     status: 200,
     response,
     callback: deleteSubscriptionFn,
+  });
+
+export const updateSubscriptionFn = vi.fn();
+export const getUpdateSubscriptionUri = (
+  subscriptionId = DUMMY_SUBSCRIPTION_ID,
+) => `**/api/v1/apps/${APP_ID}/subscriptions/${subscriptionId}`;
+export const setUpdateSubscriptionResponse = ({
+  subscriptionId,
+  response = {},
+}: { subscriptionId?: string; response?: object } = {}) =>
+  getHandler({
+    uri: getUpdateSubscriptionUri(subscriptionId),
+    method: 'patch',
+    status: 200,
+    response,
+    callback: updateSubscriptionFn,
+  });
+
+// transfer subscription
+export const transferSubscriptionFn = vi.fn();
+
+export const getTransferSubscriptionUri = (
+  subscriptionId = DUMMY_SUBSCRIPTION_ID,
+) => `**/api/v1/apps/${APP_ID}/subscriptions/${subscriptionId}/owner`;
+
+export const setTransferSubscriptionResponse = ({
+  subscriptionId,
+  response = {},
+}: { subscriptionId?: string; response?: object } = {}) =>
+  getHandler({
+    uri: getTransferSubscriptionUri(subscriptionId),
+    method: 'patch',
+    status: 200,
+    response,
+    callback: transferSubscriptionFn,
   });
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/__test__/unit/core/coreModuleDirector.test.ts
+++ b/__test__/unit/core/coreModuleDirector.test.ts
@@ -2,8 +2,8 @@ import { mockUserAgent } from '__test__/support/environment/TestEnvironmentHelpe
 import { CoreModuleDirector } from '../../../src/core/CoreModuleDirector';
 import { TestEnvironment } from '../../support/environment/TestEnvironment';
 import {
+  generateNewSubscription,
   getCoreModuleDirector,
-  getDummyPushSubscriptionOSModel,
 } from '../../support/helpers/core';
 
 describe('CoreModuleDirector tests', () => {
@@ -26,7 +26,7 @@ describe('CoreModuleDirector tests', () => {
     });
 
     test('returns current subscription when available', async () => {
-      const pushModelCurrent = getDummyPushSubscriptionOSModel();
+      const pushModelCurrent = generateNewSubscription();
       vi.spyOn(
         CoreModuleDirector.prototype,
         'getPushSubscriptionModelByCurrentToken',
@@ -35,7 +35,7 @@ describe('CoreModuleDirector tests', () => {
     });
 
     test('returns last known subscription when current is unavailable', async () => {
-      const pushModelLastKnown = getDummyPushSubscriptionOSModel();
+      const pushModelLastKnown = generateNewSubscription();
       vi.spyOn(
         CoreModuleDirector.prototype,
         'getPushSubscriptionModelByLastKnownToken',
@@ -44,13 +44,13 @@ describe('CoreModuleDirector tests', () => {
     });
 
     test('returns current subscription over last known', async () => {
-      const pushModelCurrent = getDummyPushSubscriptionOSModel();
+      const pushModelCurrent = generateNewSubscription();
       vi.spyOn(
         CoreModuleDirector.prototype,
         'getPushSubscriptionModelByCurrentToken',
       ).mockResolvedValue(pushModelCurrent);
 
-      const pushModelLastKnown = getDummyPushSubscriptionOSModel();
+      const pushModelLastKnown = generateNewSubscription();
       vi.spyOn(
         CoreModuleDirector.prototype,
         'getPushSubscriptionModelByLastKnownToken',

--- a/__test__/unit/http/sdkVersion.test.ts
+++ b/__test__/unit/http/sdkVersion.test.ts
@@ -1,4 +1,5 @@
 import { mockUserAgent } from '__test__/support/environment/TestEnvironmentHelpers';
+import { generateNewSubscription } from '__test__/support/helpers/core';
 import { nock } from '__test__/support/helpers/general';
 import AliasPair from '../../../src/core/requestService/AliasPair';
 import { RequestService } from '../../../src/core/requestService/RequestService';
@@ -8,7 +9,6 @@ import {
   DUMMY_EXTERNAL_ID,
   DUMMY_SUBSCRIPTION_ID,
 } from '../../support/constants';
-import { getDummyPushSubscriptionOSModel } from '../../support/helpers/core';
 import { expectHeaderToBeSent } from '../../support/helpers/sdkVersion';
 
 describe('Sdk Version Header Tests', () => {
@@ -71,7 +71,7 @@ describe('Sdk Version Header Tests', () => {
       { appId: APP_ID },
       new AliasPair(AliasPair.EXTERNAL_ID, DUMMY_EXTERNAL_ID),
       {
-        subscription: getDummyPushSubscriptionOSModel().data,
+        subscription: generateNewSubscription().data,
       },
     );
     expectHeaderToBeSent();

--- a/__test__/unit/pushSubscription/nativePermissionChange.test.ts
+++ b/__test__/unit/pushSubscription/nativePermissionChange.test.ts
@@ -19,6 +19,7 @@ import EventHelper from '../../../src/shared/helpers/EventHelper';
 import MainHelper from '../../../src/shared/helpers/MainHelper';
 import { NotificationPermission } from '../../../src/shared/models/NotificationPermission';
 
+vi.mock('src/shared/libraries/Log');
 const triggerNotificationSpy = vi.spyOn(
   PermissionUtils,
   'triggerNotificationPermissionChanged',

--- a/src/core/executors/LoginUserOperationExecutor.ts
+++ b/src/core/executors/LoginUserOperationExecutor.ts
@@ -58,7 +58,9 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
     const startingOp = operations[0];
 
     if (startingOp instanceof LoginUserOperation)
-      return this.loginUser(startingOp, operations.slice(1));
+      return this.loginUser(startingOp, operations.slice(1)).finally(() => {
+        User.createOrGetInstance().isCreatingUser = false;
+      });
 
     throw new Error(`Unrecognized operation: ${startingOp.name}`);
   }
@@ -171,9 +173,6 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
     if (response.ok) {
       const backendOneSignalId = response.result.identity.onesignal_id;
       const opOneSignalId = createUserOperation.onesignalId;
-
-      const user = User.createOrGetInstance();
-      user.isCreatingUser = false;
 
       const idTranslations: Record<string, string> = {
         [createUserOperation.onesignalId]: backendOneSignalId,

--- a/src/core/operationRepo/constants.ts
+++ b/src/core/operationRepo/constants.ts
@@ -1,5 +1,5 @@
 // Reference: OneSignalSDK/onesignal/core/src/main/java/com/onesignal/core/internal/config/ConfigModel.kt
-export const OP_REPO_DEFAULT_FAIL_RETRY_BACKOFF = 15000;
-export const OP_REPO_POST_CREATE_DELAY = 5000;
-export const OP_REPO_EXECUTION_INTERVAL = 5000;
-export const OP_REPO_POST_CREATE_RETRY_UP_TO = 60_000;
+export const OP_REPO_DEFAULT_FAIL_RETRY_BACKOFF = 5000;
+export const OP_REPO_POST_CREATE_DELAY = 3000;
+export const OP_REPO_EXECUTION_INTERVAL = 3000;
+export const OP_REPO_POST_CREATE_RETRY_UP_TO = 30_000;

--- a/src/entries/pageSdkInit.ts
+++ b/src/entries/pageSdkInit.ts
@@ -42,7 +42,7 @@ function onesignalSdkInit() {
   Object.defineProperty(window.OneSignalDeferred, 'push', {
     value: async function (item: OneSignalDeferredLoadedCallback) {
       await promise;
-      OneSignal.push(item);
+      return OneSignal.push(item);
     },
   });
 }

--- a/src/entries/pageSdkInit2.test.ts
+++ b/src/entries/pageSdkInit2.test.ts
@@ -1,49 +1,49 @@
 // separate test file to avoid side effects from pageSdkInit.test.ts
-import { APP_ID, DUMMY_ONESIGNAL_ID } from '__test__/support/constants';
+import {
+  APP_ID,
+  DUMMY_ONESIGNAL_ID,
+  DUMMY_PUSH_TOKEN,
+  DUMMY_SUBSCRIPTION_ID,
+} from '__test__/support/constants';
 import { TestEnvironment } from '__test__/support/environment/TestEnvironment';
-import { mockServerConfig } from '__test__/support/helpers/requests';
+import { setupSubModelStore } from '__test__/support/environment/TestEnvironmentHelpers';
+import {
+  mockServerConfig,
+  setCreateUserResponse,
+  setGetUserResponse,
+} from '__test__/support/helpers/requests';
 import { server } from '__test__/support/mocks/server';
-import { http, HttpResponse } from 'msw';
-import { UserData } from 'src/core/types/api';
 import { ModelName } from 'src/core/types/models';
-import { NotificationType } from 'src/core/types/subscription';
-import { default as InitHelper } from 'src/shared/helpers/InitHelper';
 import Log from 'src/shared/libraries/Log';
-import Database from 'src/shared/services/Database';
-
-// skip over creating dom elements
-vi.spyOn(InitHelper, 'sessionInit').mockImplementation(() => Promise.resolve());
+import Database, { SubscriptionItem } from 'src/shared/services/Database';
 
 describe('pageSdkInit 2', () => {
   beforeEach(async () => {
     await TestEnvironment.initialize();
+    server.use(mockServerConfig());
   });
 
   test('can login and addEmail', async () => {
-    server.use(
-      mockServerConfig(),
-      http.post('**/apps/*/users', () =>
-        HttpResponse.json(
-          {
-            properties: {},
-            identity: {
-              onesignal_id: DUMMY_ONESIGNAL_ID,
-            },
-            subscriptions: undefined,
-          } satisfies UserData,
-          { status: 200 },
-        ),
-      ),
-    );
+    const subModel = await setupSubModelStore({
+      id: DUMMY_SUBSCRIPTION_ID,
+      token: DUMMY_PUSH_TOKEN,
+    });
+
+    setGetUserResponse();
+    setCreateUserResponse({
+      onesignalId: DUMMY_ONESIGNAL_ID,
+    });
 
     const errorSpy = vi.spyOn(Log, 'error').mockImplementation(() => '');
 
+    // wait for init so it can initialize user namespace otherwise it won't be available for addEmail
     window.OneSignalDeferred = [];
     window.OneSignalDeferred.push(async function (OneSignal) {
       await OneSignal.init({
         appId: APP_ID,
       });
     });
+
     await import('./pageSdkInit');
 
     const email = 'joe@example.com';
@@ -52,23 +52,37 @@ describe('pageSdkInit 2', () => {
       OneSignal.User.addEmail(email);
     });
 
-    let subscriptions;
+    // wait for email sub to be added
+    let subscriptions: SubscriptionItem[] = [];
     await vi.waitUntil(async () => {
       subscriptions = await Database.getAll(ModelName.Subscriptions);
-      return subscriptions.length > 0;
+      return subscriptions.length >= 2;
     });
+    subscriptions.sort((a, b) => a.type.localeCompare(b.type));
 
+    // should the push subscription and the email be added to the subscriptions modelstore
+    const shared = {
+      device_model: '',
+      device_os: 56,
+      enabled: true,
+      modelName: 'subscriptions',
+      notification_types: 1,
+      sdk: '1',
+    };
     expect(subscriptions).toEqual([
       {
-        device_model: '',
-        device_os: 56,
-        enabled: true,
+        ...shared,
+        id: subModel.id,
+        modelId: subModel.modelId,
+        onesignalId: DUMMY_ONESIGNAL_ID,
+        token: subModel.token,
+        type: 'ChromePush',
+      },
+      {
+        ...shared,
         id: expect.any(String),
         modelId: expect.any(String),
-        modelName: 'subscriptions',
-        onesignalId: DUMMY_ONESIGNAL_ID,
-        notification_types: NotificationType.Subscribed,
-        sdk: '1',
+        onesignalId: expect.any(String),
         token: email,
         type: 'Email',
       },

--- a/src/entries/pageSdkInit2.test.ts
+++ b/src/entries/pageSdkInit2.test.ts
@@ -94,7 +94,7 @@ describe('pageSdkInit 2', () => {
     });
 
     // wait user subscriptions to be refresh/replaced
-    await waitForOperations(3);
+    await waitForOperations(4);
     const subscriptions = await Database.getAll<SubscriptionItem>(
       ModelName.Subscriptions,
     );

--- a/src/onesignal/User.ts
+++ b/src/onesignal/User.ts
@@ -117,6 +117,7 @@ export default class User {
       token,
       type,
     };
+
     const newSubscription = new SubscriptionModel();
     newSubscription.mergeData(subscription);
     OneSignal.coreDirector.addSubscriptionModel(newSubscription);

--- a/src/onesignal/UserDirector.ts
+++ b/src/onesignal/UserDirector.ts
@@ -29,12 +29,12 @@ export default class UserDirector {
         identityModel.externalId,
       ),
     );
-    return OneSignal.coreDirector.operationRepo.enqueueAndWait(
+    await OneSignal.coreDirector.operationRepo.enqueueAndWait(
       new CreateSubscriptionOperation({
+        ...rest,
         appId,
         onesignalId: identityModel.onesignalId,
         subscriptionId: id,
-        ...rest,
       }),
     );
   }

--- a/src/onesignal/UserDirector.ts
+++ b/src/onesignal/UserDirector.ts
@@ -51,10 +51,6 @@ export default class UserDirector {
     );
   }
 
-  static createAndHydrateUser(): Promise<void> {
-    return UserDirector.createUserOnServer();
-  }
-
   static resetUserMetaProperties() {
     const user = User.createOrGetInstance();
     user.isCreatingUser = false;

--- a/src/onesignal/UserDirector.ts
+++ b/src/onesignal/UserDirector.ts
@@ -14,7 +14,6 @@ export default class UserDirector {
 
     const identityModel = OneSignal.coreDirector.getIdentityModel();
     const appId = await MainHelper.getAppId();
-    user.isCreatingUser = true;
 
     const pushOp = await OneSignal.coreDirector.getPushSubscriptionModel();
     if (!pushOp) return Log.info('No push subscription found');
@@ -22,6 +21,7 @@ export default class UserDirector {
     pushOp.id = pushOp.id ?? IDManager.createLocalId();
     const { id, ...rest } = pushOp.toJSON();
 
+    User.createOrGetInstance().isCreatingUser = true;
     OneSignal.coreDirector.operationRepo.enqueue(
       new LoginUserOperation(
         appId,

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -68,6 +68,7 @@ export default class LoginManager {
           pushOp.id,
         ),
       );
+      User.createOrGetInstance().isCreatingUser = true;
       await OneSignal.coreDirector.operationRepo.enqueueAndWait(
         new LoginUserOperation(
           appId,
@@ -96,6 +97,6 @@ export default class LoginManager {
     UserDirector.resetUserModels();
 
     // create a new anonymous user
-    UserDirector.createUserOnServer();
+    return UserDirector.createUserOnServer();
   }
 }

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -1,6 +1,7 @@
 import { LoginUserOperation } from 'src/core/operations/LoginUserOperation';
 import { TransferSubscriptionOperation } from 'src/core/operations/TransferSubscriptionOperation';
 import { ModelChangeTags } from 'src/core/types/models';
+import User from 'src/onesignal/User';
 import OneSignal from '../../onesignal/OneSignal';
 import UserDirector from '../../onesignal/UserDirector';
 import OneSignalError from '../../shared/errors/OneSignalError';

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -62,6 +62,7 @@ export default class LoginManager {
       const pushOp = await OneSignal.coreDirector.getPushSubscriptionModel();
       if (!pushOp) return Log.error('Subscription not found.');
 
+      User.createOrGetInstance().isCreatingUser = true;
       OneSignal.coreDirector.operationRepo.enqueue(
         new TransferSubscriptionOperation(
           appId,
@@ -69,7 +70,6 @@ export default class LoginManager {
           pushOp.id,
         ),
       );
-      User.createOrGetInstance().isCreatingUser = true;
       await OneSignal.coreDirector.operationRepo.enqueueAndWait(
         new LoginUserOperation(
           appId,

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -177,7 +177,7 @@ export class SubscriptionManager {
 
     if (!pushModel) {
       OneSignal.coreDirector.generatePushSubscriptionModel(rawPushSubscription);
-      return UserDirector.createAndHydrateUser();
+      return UserDirector.createUserOnServer();
     }
     // resubscribing. update existing push subscription model
     const serializedSubscriptionRecord = new FuturePushSubscriptionRecord(

--- a/src/shared/managers/sessionManager/SessionManager.test.ts
+++ b/src/shared/managers/sessionManager/SessionManager.test.ts
@@ -4,7 +4,10 @@ import { SessionManager } from './SessionManager';
 import { DUMMY_EXTERNAL_ID } from '__test__/support/constants';
 import { setAddAliasResponse } from '__test__/support/helpers/requests';
 import LoginManager from 'src/page/managers/LoginManager';
+import Log from 'src/shared/libraries/Log';
 import { SessionOrigin } from 'src/shared/models/Session';
+
+vi.spyOn(Log, 'error').mockImplementation(() => '');
 
 describe('SessionManager', () => {
   describe('Switching Users', () => {


### PR DESCRIPTION
# Description
## 1 Line Summary
Continuation of the [Web SDK Refactor project](https://docs.google.com/document/d/1JsbmxVM_n6K9nRXwbJf6mQr5h88qy_vIEiBGY0Ub_lE/edit?tab=t.0#heading=h.ojv84gskof17). Updates to logic to transfer subscription.

## Details
Before, if a user called login with different external ids. The external id would stay local but the remote subscription wouldn't be updated properly with the external id.
- Updates login call to enqueue a transfer subscription op to keep subscriptions in sync with external id changes.
- Removes unused methods (for web sdk refactor) like hydrateUser & hydrateSubscriptions in CoreModuleDirector .
- Shortens some op repo delays to 3s
- Updates `OneSignalDiffered` push to return a promise so it can be awaited and easily tested 
- Allowed logout to be awaited by return createUserOnServer promise 

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1308)
<!-- Reviewable:end -->
