### PR TITLE
Web SDK Refactor: Fix Async

### DIFF
--- a/__test__/support/helpers/requests.ts
+++ b/__test__/support/helpers/requests.ts
@@ -291,3 +291,37 @@ export const setCreateUserError = ({
   retryAfter?: number;
 }) =>
   getHandler({ uri: getCreateUserUri(), method: 'post', status, retryAfter });
+
+// update user
+export const updateUserFn = vi.fn();
+
+const getUpdateUserUri = (onesignalId = DUMMY_ONESIGNAL_ID) =>
+  `**/api/v1/apps/${APP_ID}/users/by/onesignal_id/${onesignalId}`;
+
+export const setUpdateUserResponse = ({
+  onesignalId = DUMMY_ONESIGNAL_ID,
+  response = {},
+}: { onesignalId?: string; response?: object } = {}) =>
+  getHandler({
+    uri: getUpdateUserUri(onesignalId),
+    method: 'patch',
+    status: 200,
+    response,
+    callback: updateUserFn,
+  });
+
+export const setUpdateUserError = ({
+  onesignalId = DUMMY_ONESIGNAL_ID,
+  status,
+  retryAfter,
+}: {
+  onesignalId?: string;
+  status: number;
+  retryAfter?: number;
+}) =>
+  getHandler({
+    uri: getUpdateUserUri(onesignalId),
+    method: 'patch',
+    status,
+    retryAfter,
+  });

--- a/src/core/executors/LoginUserOperationExecutor.test.ts
+++ b/src/core/executors/LoginUserOperationExecutor.test.ts
@@ -51,7 +51,8 @@ describe('LoginUserOperationExecutor', () => {
     await TestEnvironment.initialize();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await Database.clear();
     mockUserAgent();
     identityModelStore = new IdentityModelStore();
     propertiesModelStore = new PropertiesModelStore();

--- a/src/core/executors/LoginUserOperationExecutor.ts
+++ b/src/core/executors/LoginUserOperationExecutor.ts
@@ -9,6 +9,7 @@ import {
 } from 'src/shared/helpers/NetworkUtils';
 import Log from 'src/shared/libraries/Log';
 import Database from 'src/shared/services/Database';
+import LocalStorage from 'src/shared/utils/LocalStorage';
 import { getTimeZoneId } from 'src/shared/utils/utils';
 import { IdentityConstants, OPERATION_NAME } from '../constants';
 import { IPropertiesModelKeys } from '../models/PropertiesModel';
@@ -69,6 +70,13 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
     loginUserOp: LoginUserOperation,
     operations: Operation[],
   ): Promise<ExecutionResponse> {
+    const consentRequired = LocalStorage.getConsentRequired();
+    const consentGiven = await Database.getConsentGiven();
+
+    if (consentRequired && !consentGiven) {
+      return new ExecutionResponse(ExecutionResult.FAIL_NORETRY);
+    }
+
     // When there is no existing user to attempt to associate with the externalId provided, we go right to
     // createUser.  If there is no externalId provided this is an insert, if there is this will be an
     // "upsert with retrieval" as the user may already exist.

--- a/src/core/executors/LoginUserOperationExecutor.ts
+++ b/src/core/executors/LoginUserOperationExecutor.ts
@@ -1,6 +1,7 @@
 import { ModelChangeTags } from 'src/core/types/models';
 import { ExecutionResult, IOperationExecutor } from 'src/core/types/operation';
 import User from 'src/onesignal/User';
+import OneSignalError from 'src/shared/errors/OneSignalError';
 import Environment from 'src/shared/helpers/Environment';
 import EventHelper from 'src/shared/helpers/EventHelper';
 import {
@@ -74,7 +75,9 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
     const consentGiven = await Database.getConsentGiven();
 
     if (consentRequired && !consentGiven) {
-      return new ExecutionResponse(ExecutionResult.FAIL_NORETRY);
+      throw new OneSignalError(
+        'Login: Consent required but not given, skipping login',
+      );
     }
 
     // When there is no existing user to attempt to associate with the externalId provided, we go right to

--- a/src/core/listeners/IdentityModelStoreListener.ts
+++ b/src/core/listeners/IdentityModelStoreListener.ts
@@ -20,13 +20,13 @@ export class IdentityModelStoreListener extends SingletonModelStoreListener<Iden
     return null;
   }
 
-  async getUpdateOperation(
+  getUpdateOperation(
     model: IdentityModel,
     property: string,
     _oldValue: unknown,
     newValue: unknown,
-  ): Promise<Operation> {
-    const appId = await MainHelper.getAppId();
+  ): Operation {
+    const appId = MainHelper.getAppId();
     if (newValue != null && typeof newValue === 'string') {
       return new SetAliasOperation(
         appId,

--- a/src/core/listeners/ModelStoreListener.ts
+++ b/src/core/listeners/ModelStoreListener.ts
@@ -25,12 +25,12 @@ export abstract class ModelStoreListener<TModel extends Model> {
     this.store.unsubscribe(this);
   }
 
-  async onModelAdded(model: TModel, tag: string): Promise<void> {
+  onModelAdded(model: TModel, tag: string): void {
     if (tag !== ModelChangeTags.NORMAL) {
       return;
     }
 
-    const operation = await this.getAddOperation(model);
+    const operation = this.getAddOperation(model);
     if (operation != null) {
       this.opRepo.enqueue(operation);
     }
@@ -67,13 +67,13 @@ export abstract class ModelStoreListener<TModel extends Model> {
    * Called when a model has been added to the model store.
    * @return The operation to enqueue when a model has been added, or null if no operation should be enqueued.
    */
-  abstract getAddOperation(model: TModel): Promise<Operation | null>;
+  abstract getAddOperation(model: TModel): Operation | null;
 
   /**
    * Called when a model has been removed from the model store.
    * @return The operation to enqueue when a model has been removed, or null if no operation should be enqueued.
    */
-  abstract getRemoveOperation(model: TModel): Promise<Operation | null>;
+  abstract getRemoveOperation(model: TModel): Operation | null;
 
   /**
    * Called when a model has been updated.
@@ -84,5 +84,5 @@ export abstract class ModelStoreListener<TModel extends Model> {
     property: string,
     oldValue: unknown,
     newValue: unknown,
-  ): Promise<Operation | null>;
+  ): Operation | null;
 }

--- a/src/core/listeners/PropertiesModelStoreListener.ts
+++ b/src/core/listeners/PropertiesModelStoreListener.ts
@@ -19,13 +19,13 @@ export class PropertiesModelStoreListener extends SingletonModelStoreListener<Pr
     return null;
   }
 
-  async getUpdateOperation(
+  getUpdateOperation(
     model: PropertiesModel,
     property: string,
     _oldValue: unknown,
     newValue: unknown,
-  ): Promise<Operation | null> {
-    const appId = await MainHelper.getAppId();
+  ): Operation | null {
+    const appId = MainHelper.getAppId();
     return new SetPropertyOperation(
       appId,
       model.onesignalId,

--- a/src/core/listeners/SingletonModelStoreListener.ts
+++ b/src/core/listeners/SingletonModelStoreListener.ts
@@ -38,12 +38,12 @@ export abstract class SingletonModelStoreListener<TModel extends Model>
     }
   }
 
-  async onModelUpdated(args: ModelChangedArgs, tag: string): Promise<void> {
+  onModelUpdated(args: ModelChangedArgs, tag: string): void {
     if (tag !== ModelChangeTags.NORMAL) {
       return;
     }
 
-    const operation = await this.getUpdateOperation(
+    const operation = this.getUpdateOperation(
       args.model as TModel,
       args.property,
       args.oldValue,
@@ -69,5 +69,5 @@ export abstract class SingletonModelStoreListener<TModel extends Model>
     property: string,
     oldValue: unknown,
     newValue: unknown,
-  ): Promise<Operation | null>;
+  ): Operation | null;
 }

--- a/src/core/listeners/SubscriptionModelStoreListener.ts
+++ b/src/core/listeners/SubscriptionModelStoreListener.ts
@@ -24,11 +24,11 @@ export class SubscriptionModelStoreListener extends ModelStoreListener<Subscript
     this._identityModelStore = identityModelStore;
   }
 
-  async getAddOperation(model: SubscriptionModel): Promise<Operation> {
+  getAddOperation(model: SubscriptionModel): Operation {
     const { enabled, notification_types } =
       SubscriptionModelStoreListener.getSubscriptionEnabledAndStatus(model);
 
-    const appId = await MainHelper.getAppId();
+    const appId = MainHelper.getAppId();
     return new CreateSubscriptionOperation({
       appId,
       onesignalId: this._identityModelStore.model.onesignalId,
@@ -40,8 +40,8 @@ export class SubscriptionModelStoreListener extends ModelStoreListener<Subscript
     });
   }
 
-  async getRemoveOperation(model: SubscriptionModel): Promise<Operation> {
-    const appId = await MainHelper.getAppId();
+  getRemoveOperation(model: SubscriptionModel): Operation {
+    const appId = MainHelper.getAppId();
     return new DeleteSubscriptionOperation(
       appId,
       this._identityModelStore.model.onesignalId,
@@ -49,10 +49,10 @@ export class SubscriptionModelStoreListener extends ModelStoreListener<Subscript
     );
   }
 
-  async getUpdateOperation(model: SubscriptionModel): Promise<Operation> {
+  getUpdateOperation(model: SubscriptionModel): Operation {
     const { enabled, notification_types } =
       SubscriptionModelStoreListener.getSubscriptionEnabledAndStatus(model);
-    const appId = await MainHelper.getAppId();
+    const appId = MainHelper.getAppId();
 
     return new UpdateSubscriptionOperation({
       appId,

--- a/src/core/modelRepo/ModelStore.ts
+++ b/src/core/modelRepo/ModelStore.ts
@@ -137,7 +137,8 @@ export abstract class ModelStore<
   }
 
   private async removeItem(model: TModel, tag: string): Promise<void> {
-    this.models = this.models.filter((m) => m !== model);
+    const index = this.models.findIndex((m) => m.modelId === model.modelId);
+    if (index !== -1) this.models.splice(index, 1);
 
     // no longer listen for changes to this model
     model.unsubscribe(this);

--- a/src/onesignal/UserDirector.ts
+++ b/src/onesignal/UserDirector.ts
@@ -2,9 +2,9 @@ import { IdentityModel } from 'src/core/models/IdentityModel';
 import { PropertiesModel } from 'src/core/models/PropertiesModel';
 import { CreateSubscriptionOperation } from 'src/core/operations/CreateSubscriptionOperation';
 import { LoginUserOperation } from 'src/core/operations/LoginUserOperation';
+import Log from 'src/shared/libraries/Log';
 import { IDManager } from 'src/shared/managers/IDManager';
 import MainHelper from '../shared/helpers/MainHelper';
-import Log from '../shared/libraries/Log';
 import User from './User';
 
 export default class UserDirector {
@@ -13,7 +13,7 @@ export default class UserDirector {
     if (user.isCreatingUser) return;
 
     const identityModel = OneSignal.coreDirector.getIdentityModel();
-    const appId = await MainHelper.getAppId();
+    const appId = MainHelper.getAppId();
 
     const pushOp = await OneSignal.coreDirector.getPushSubscriptionModel();
     if (!pushOp) return Log.info('No push subscription found');

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -2,13 +2,11 @@ import { LoginUserOperation } from 'src/core/operations/LoginUserOperation';
 import { TransferSubscriptionOperation } from 'src/core/operations/TransferSubscriptionOperation';
 import { ModelChangeTags } from 'src/core/types/models';
 import User from 'src/onesignal/User';
+import MainHelper from 'src/shared/helpers/MainHelper';
 import OneSignal from '../../onesignal/OneSignal';
 import UserDirector from '../../onesignal/UserDirector';
-import OneSignalError from '../../shared/errors/OneSignalError';
-import MainHelper from '../../shared/helpers/MainHelper';
 import Log from '../../shared/libraries/Log';
 import Database from '../../shared/services/Database';
-import LocalStorage from '../../shared/utils/LocalStorage';
 
 export default class LoginManager {
   // Other internal classes should await on this if they access users
@@ -22,65 +20,54 @@ export default class LoginManager {
     externalId: string,
     token?: string,
   ): Promise<void> {
-    const consentRequired = LocalStorage.getConsentRequired();
-    const consentGiven = await Database.getConsentGiven();
-
-    if (consentRequired && !consentGiven) {
-      throw new OneSignalError(
-        'Login: Consent required but not given, skipping login',
-      );
+    if (token) {
+      Database.setJWTToken(token);
     }
 
-    try {
-      if (token) {
-        await Database.setJWTToken(token);
-      }
+    let identityModel = OneSignal.coreDirector.getIdentityModel();
+    const currentOneSignalId = identityModel.onesignalId;
+    const currentExternalId = identityModel.externalId;
 
-      let identityModel = OneSignal.coreDirector.getIdentityModel();
-      const currentOneSignalId = identityModel.onesignalId;
-      const currentExternalId = identityModel.externalId;
+    // if the current externalId is the same as the one we're trying to set, do nothing
+    if (currentExternalId === externalId) {
+      Log.debug('Login: External ID already set, skipping login');
+      return;
+    }
 
-      // if the current externalId is the same as the one we're trying to set, do nothing
-      if (currentExternalId === externalId) {
-        Log.debug('Login: External ID already set, skipping login');
-        return;
-      }
+    UserDirector.resetUserModels();
+    identityModel = OneSignal.coreDirector.getIdentityModel();
 
-      UserDirector.resetUserModels();
-      identityModel = OneSignal.coreDirector.getIdentityModel();
+    // avoid duplicate identity requests, this is needed if dev calls init and login in quick succession e.g.
+    // e.g. OneSignalDeferred.push(OneSignal) => OneSignal.init({...})); OneSignalDeferred.push(OneSignal) => OneSignal.login('some-external-id'));
+    identityModel.setProperty(
+      'external_id',
+      externalId,
+      ModelChangeTags.HYDRATE,
+    );
+    const newIdentityOneSignalId = identityModel.onesignalId;
 
-      // avoid duplicate identity requests, this is needed if dev calls init and login in quick succession e.g.
-      // e.g. OneSignalDeferred.push(OneSignal) => OneSignal.init({...})); OneSignalDeferred.push(OneSignal) => OneSignal.login('some-external-id'));
-      identityModel.setProperty(
-        'external_id',
+    User.createOrGetInstance().isCreatingUser = true;
+
+    const appId = MainHelper.getAppId();
+
+    const pushOp = await OneSignal.coreDirector.getPushSubscriptionModel();
+    if (!pushOp) return Log.info('No push subscription found');
+    OneSignal.coreDirector.operationRepo.enqueue(
+      new TransferSubscriptionOperation(
+        appId,
+        newIdentityOneSignalId,
+        pushOp.id,
+      ),
+    );
+
+    await OneSignal.coreDirector.operationRepo.enqueueAndWait(
+      new LoginUserOperation(
+        appId,
+        newIdentityOneSignalId,
         externalId,
-        ModelChangeTags.HYDRATE,
-      );
-      const newIdentityOneSignalId = identityModel.onesignalId;
-
-      const appId = await MainHelper.getAppId();
-      const pushOp = await OneSignal.coreDirector.getPushSubscriptionModel();
-      if (!pushOp) return Log.error('Subscription not found.');
-
-      User.createOrGetInstance().isCreatingUser = true;
-      OneSignal.coreDirector.operationRepo.enqueue(
-        new TransferSubscriptionOperation(
-          appId,
-          newIdentityOneSignalId,
-          pushOp.id,
-        ),
-      );
-      await OneSignal.coreDirector.operationRepo.enqueueAndWait(
-        new LoginUserOperation(
-          appId,
-          newIdentityOneSignalId,
-          externalId,
-          !currentExternalId ? currentOneSignalId : undefined,
-        ),
-      );
-    } catch (e) {
-      Log.error(e);
-    }
+        !currentExternalId ? currentOneSignalId : undefined,
+      ),
+    );
   }
 
   static async logout(): Promise<void> {

--- a/src/shared/helpers/InitHelper.ts
+++ b/src/shared/helpers/InitHelper.ts
@@ -365,7 +365,7 @@ export default class InitHelper {
   }
 
   public static async initSaveState(overridingPageTitle?: string) {
-    const appId = await MainHelper.getAppId();
+    const appId = MainHelper.getAppId();
     const config: AppConfig = OneSignal.config;
     await Database.put('Ids', { type: 'appId', id: appId });
     const pageTitle: string =

--- a/src/shared/helpers/MainHelper.ts
+++ b/src/shared/helpers/MainHelper.ts
@@ -121,7 +121,7 @@ export default class MainHelper {
   }
 
   static async getNotificationIcons() {
-    const appId = await MainHelper.getAppId();
+    const appId = MainHelper.getAppId();
     if (!appId) {
       throw new InvalidStateError(InvalidStateReason.MissingAppId);
     }
@@ -223,13 +223,8 @@ export default class MainHelper {
     return hash;
   }
 
-  static async getAppId(): Promise<string> {
-    if (OneSignal.config.appId) {
-      return Promise.resolve(OneSignal.config.appId);
-    } else {
-      const appId = await Database.get<string>('Ids', 'appId');
-      return appId;
-    }
+  static getAppId(): string {
+    return OneSignal.config?.appId || '';
   }
 
   static async getDeviceId(): Promise<string | undefined> {

--- a/src/shared/managers/sessionManager/SessionManager.ts
+++ b/src/shared/managers/sessionManager/SessionManager.ts
@@ -388,7 +388,7 @@ export class SessionManager implements ISessionManager {
         },
       };
 
-      const appId = await MainHelper.getAppId();
+      const appId = MainHelper.getAppId();
       Utils.enforceAppId(appId);
       Utils.enforceAlias(aliasPair);
       try {


### PR DESCRIPTION
# Description
## 1 Line Summary
Continuation of the [Web SDK Refactor project](https://docs.google.com/document/d/1JsbmxVM_n6K9nRXwbJf6mQr5h88qy_vIEiBGY0Ub_lE/edit?tab=t.0#heading=h.ojv84gskof17). Preserve order when actions like `login` and `addTag` when called without await.

## Details
When making calls like so:
```
OneSignal.login(...)
OneSignal.User.addTag(... , ...)
```
The addTag gets executed first before the login. This is due to login action having too many async operations.
- moves consent check to login user operation executor 
- makes MainHelper sync by having get app id from OneSignal.config

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1310)
<!-- Reviewable:end -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210562926736778