### PR TITLE
Removes allowLocalhostAsSecureOrigin usage

### DIFF
--- a/__test__/support/environment/TestContext.ts
+++ b/__test__/support/environment/TestContext.ts
@@ -298,9 +298,7 @@ export default class TestContext {
             workerName: 'OneSignalSDKWorker.js',
             registrationScope: '/',
           },
-          setupBehavior: {
-            allowLocalhostAsSecureOrigin: false,
-          },
+          setupBehavior: {},
           welcomeNotification: {
             url: undefined,
             title: undefined,
@@ -457,7 +455,6 @@ export default class TestContext {
       },
       notificationClickHandlerMatch: NotificationClickMatchBehavior.Origin,
       notificationClickHandlerAction: NotificationClickActionBehavior.Focus,
-      allowLocalhostAsSecureOrigin: true,
     };
   }
 

--- a/src/shared/helpers/ConfigHelper.ts
+++ b/src/shared/helpers/ConfigHelper.ts
@@ -631,9 +631,6 @@ export class ConfigHelper {
             .notificationBehavior
             ? serverConfig.config.notificationBehavior.click.action
             : undefined,
-          allowLocalhostAsSecureOrigin: serverConfig.config.setupBehavior
-            ? serverConfig.config.setupBehavior.allowLocalhostAsSecureOrigin
-            : undefined,
           outcomes: {
             direct: serverConfig.config.outcomes.direct,
             indirect: {

--- a/src/shared/models/AppConfig.ts
+++ b/src/shared/models/AppConfig.ts
@@ -1,10 +1,10 @@
 import { Categories } from '../../page/models/Tags';
 import { OutcomesConfig, OutcomesServerConfig } from './Outcomes';
 import {
-  AppUserConfigPromptOptions,
-  CustomLinkStyle,
-  CustomLinkSize,
   AppUserConfigNotifyButton,
+  AppUserConfigPromptOptions,
+  CustomLinkSize,
+  CustomLinkStyle,
   SlidedownOptions,
 } from './Prompts';
 
@@ -91,7 +91,6 @@ export interface AppUserConfig {
   webhooks?: AppUserConfigWebhooks;
   notificationClickHandlerMatch?: NotificationClickMatchBehavior;
   notificationClickHandlerAction?: NotificationClickActionBehavior;
-  allowLocalhostAsSecureOrigin?: boolean;
   pageUrl?: string;
   outcomes?: OutcomesConfig;
   serviceWorkerOverrideForTypical?: boolean;
@@ -245,9 +244,7 @@ export interface ServerAppConfig {
       workerName?: string;
       registrationScope?: string;
     };
-    setupBehavior?: {
-      allowLocalhostAsSecureOrigin: false;
-    };
+    setupBehavior?: {};
     welcomeNotification: {
       url: string | undefined;
       title: string | undefined;

--- a/src/shared/utils/OneSignalUtils.ts
+++ b/src/shared/utils/OneSignalUtils.ts
@@ -1,20 +1,12 @@
 import bowser, { IBowser } from 'bowser';
-import Environment from '../helpers/Environment';
 import { Utils } from '../context/Utils';
+import Environment from '../helpers/Environment';
 import Log from '../libraries/Log';
 import { bowserCastle } from './bowserCastle';
 
 export class OneSignalUtils {
   public static getBaseUrl() {
     return location.origin;
-  }
-
-  public static isLocalhostAllowedAsSecureOrigin(): boolean {
-    return (
-      OneSignal.config &&
-      OneSignal.config.userConfig &&
-      OneSignal.config.userConfig.allowLocalhostAsSecureOrigin === true
-    );
   }
 
   public static redetectBrowserUserAgent(): IBowser {


### PR DESCRIPTION
# Description
Removes unused `allowLocalhostAsSecureOrigin` flag

## Details
Serviceworker can be run with or without https for localhost. So this flag (and toggle on the dashboard) is not really needed.

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info
Existing tests should cover the functionality affected by the removal of this configuration option.

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info
N/A

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1315)
<!-- Reviewable:end -->
