### PR TITLE
Updates OneSignal API URL

### DIFF
--- a/__test__/README.md
+++ b/__test__/README.md
@@ -62,7 +62,7 @@ import { server } from '__test__/support/mocks/server';
 import { http, HttpResponse } from 'msw';
 
 server.use(
-  http.get('https://api.onesignal.com/v1/notifications', () =>
+  http.get('https://api.onesignal.com/notifications', () =>
     HttpResponse.json({ result: {}, status: 200 }),
   ),
 );

--- a/preview/README.md
+++ b/preview/README.md
@@ -66,7 +66,7 @@ If no custom origins are set, defaults will be used: `localhost` for build and `
 API_ORIGIN=texas npm run build:dev-prod
 ```
 
-This sets the BUILD environment origin to `texas` which will result in SDK files being fetched from `https://texas:4001/sdks/web/v##/` and the API environment origin to production which will make all onesignal api calls to the production origin `https://onesignal.com/api/v1/apps/<app>`
+This sets the BUILD environment origin to `texas` which will result in SDK files being fetched from `https://texas:4001/sdks/web/v##/` and the API environment origin to production which will make all onesignal api calls to the production origin `https://api.onesignal.com/apps/<app>`
 
 ```
 BUILD_ORIGIN=localhost API_ORIGIN=texas npm run build:dev-dev

--- a/src/shared/managers/SdkEnvironment.test.ts
+++ b/src/shared/managers/SdkEnvironment.test.ts
@@ -33,8 +33,10 @@ describe('SdkEnvironment', () => {
   });
 
   test('can get api url ', () => {
+    // staging
+    global.__API_ORIGIN__ = 'onesignal-staging.com';
     expect(SdkEnvironment.getOneSignalApiUrl().toString()).toBe(
-      'https://onesignal.com/api/v1',
+      'https://onesignal-staging.com/api/v1',
     );
 
     // development -  turbine endpoint

--- a/src/shared/managers/SdkEnvironment.test.ts
+++ b/src/shared/managers/SdkEnvironment.test.ts
@@ -64,6 +64,6 @@ describe('SdkEnvironment', () => {
     // production
     expect(
       SdkEnvironment.getOneSignalApiUrl(EnvironmentKind.Production).toString(),
-    ).toBe('https://onesignal.com/api/v1');
+    ).toBe('https://api.onesignal.com/');
   });
 });

--- a/src/shared/managers/SdkEnvironment.ts
+++ b/src/shared/managers/SdkEnvironment.ts
@@ -98,7 +98,7 @@ export default class SdkEnvironment {
       case EnvironmentKind.Staging:
         return new URL(`https://${apiOrigin}/api/v1`);
       case EnvironmentKind.Production:
-        return new URL('https://onesignal.com/api/v1');
+        return new URL('https://api.onesignal.com');
       default:
         throw new InvalidArgumentError(
           'buildEnv',


### PR DESCRIPTION
# Description
## Updates OneSignal API url

## Details
Addresses ticket: https://app.asana.com/0/home/1209206699711965/1207914352046248
Update api url to be `api.onesignal.com` 

# Systems Affected
   - [x] WebSDK

# Validation
## Tests
### Info
Existing tests cover the functionality, and they have been updated to reflect the correct API URL.

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1318)
<!-- Reviewable:end -->
