### PR TITLE
Enables logging by default in production builds

### DIFF
--- a/src/shared/utils/EnvVariables.ts
+++ b/src/shared/utils/EnvVariables.ts
@@ -1,5 +1,5 @@
 // NOTE: We are using a function to get the value of the environment variable to make it easier to test.
-// We also are using typeof check since defining global constants (through Vite) does not work for the service worker.
+// We also are using typeof check since defining global constants (through Vite) DOES NOT work for the service worker.
 // ^ This only applies to development mode since we have separate bundles (entries) for the service worker and the main bundle.
 
 // strings

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -83,7 +83,9 @@ export default defineConfig(({ mode }) => {
     define: {
       __API_TYPE__: JSON.stringify(process.env.API),
       __BUILD_TYPE__: JSON.stringify(process.env.ENV),
-      __LOGGING__: JSON.stringify(getBooleanEnv(process.env.LOGGING)),
+      __LOGGING__: JSON.stringify(
+        getBooleanEnv(process.env.LOGGING) ?? !isProdEnv,
+      ),
       __VERSION__: JSON.stringify(process.env.npm_package_config_sdkVersion),
 
       // ignored for prod


### PR DESCRIPTION
# Description
## Enables logging in production builds by default

## Details
The changes ensure that logging is enabled by default in production builds. 
This is achieved by providing a default value for the `__LOGGING__` Vite define variable, ensuring that it is set to `true` when the `LOGGING` environment variable is not explicitly defined in production.

# Systems Affected
   - [ ] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info
Manual verification to ensure logging works correctly in production builds.

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info
N/A

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---