### PR TITLE
Login Bug Fix

### DIFF
--- a/src/core/executors/LoginUserOperationExecutor.ts
+++ b/src/core/executors/LoginUserOperationExecutor.ts
@@ -1,6 +1,5 @@
 import { ModelChangeTags } from 'src/core/types/models';
 import { ExecutionResult, IOperationExecutor } from 'src/core/types/operation';
-import User from 'src/onesignal/User';
 import OneSignalError from 'src/shared/errors/OneSignalError';
 import Environment from 'src/shared/helpers/Environment';
 import EventHelper from 'src/shared/helpers/EventHelper';
@@ -60,9 +59,7 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
     const startingOp = operations[0];
 
     if (startingOp instanceof LoginUserOperation)
-      return this.loginUser(startingOp, operations.slice(1)).finally(() => {
-        User.createOrGetInstance().isCreatingUser = false;
-      });
+      return this.loginUser(startingOp, operations.slice(1));
 
     throw new Error(`Unrecognized operation: ${startingOp.name}`);
   }

--- a/src/onesignal/User.ts
+++ b/src/onesignal/User.ts
@@ -12,8 +12,6 @@ import {
 import { isObject, isValidEmail, logMethodCall } from '../shared/utils/utils';
 
 export default class User {
-  isCreatingUser = false;
-
   static singletonInstance?: User = undefined;
 
   /**

--- a/src/onesignal/UserDirector.ts
+++ b/src/onesignal/UserDirector.ts
@@ -5,13 +5,9 @@ import { LoginUserOperation } from 'src/core/operations/LoginUserOperation';
 import Log from 'src/shared/libraries/Log';
 import { IDManager } from 'src/shared/managers/IDManager';
 import MainHelper from '../shared/helpers/MainHelper';
-import User from './User';
 
 export default class UserDirector {
   static async createUserOnServer(): Promise<void> {
-    const user = User.createOrGetInstance();
-    if (user.isCreatingUser) return;
-
     const identityModel = OneSignal.coreDirector.getIdentityModel();
     const appId = MainHelper.getAppId();
 
@@ -21,7 +17,6 @@ export default class UserDirector {
     pushOp.id = pushOp.id ?? IDManager.createLocalId();
     const { id, ...rest } = pushOp.toJSON();
 
-    User.createOrGetInstance().isCreatingUser = true;
     OneSignal.coreDirector.operationRepo.enqueue(
       new LoginUserOperation(
         appId,
@@ -37,11 +32,6 @@ export default class UserDirector {
         subscriptionId: id,
       }),
     );
-  }
-
-  static resetUserMetaProperties() {
-    const user = User.createOrGetInstance();
-    user.isCreatingUser = false;
   }
 
   // Resets models similar to Android SDK

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -1,7 +1,6 @@
 import { LoginUserOperation } from 'src/core/operations/LoginUserOperation';
 import { TransferSubscriptionOperation } from 'src/core/operations/TransferSubscriptionOperation';
 import { ModelChangeTags } from 'src/core/types/models';
-import User from 'src/onesignal/User';
 import MainHelper from 'src/shared/helpers/MainHelper';
 import OneSignal from '../../onesignal/OneSignal';
 import UserDirector from '../../onesignal/UserDirector';
@@ -46,8 +45,6 @@ export default class LoginManager {
     );
     const newIdentityOneSignalId = identityModel.onesignalId;
 
-    User.createOrGetInstance().isCreatingUser = true;
-
     const appId = MainHelper.getAppId();
 
     const pushOp = await OneSignal.coreDirector.getPushSubscriptionModel();
@@ -81,7 +78,6 @@ export default class LoginManager {
     if (!identityModel.externalId)
       return Log.debug('Logout: User is not logged in, skipping logout');
 
-    UserDirector.resetUserMetaProperties();
     UserDirector.resetUserModels();
 
     // create a new anonymous user

--- a/src/shared/managers/SubscriptionManager.test.ts
+++ b/src/shared/managers/SubscriptionManager.test.ts
@@ -1,8 +1,18 @@
-import { APP_ID } from '__test__/support/constants';
+import { APP_ID, DUMMY_EXTERNAL_ID } from '__test__/support/constants';
 import TestContext from '__test__/support/environment/TestContext';
 import { TestEnvironment } from '__test__/support/environment/TestEnvironment';
+import { setupSubModelStore } from '__test__/support/environment/TestEnvironmentHelpers';
+import {
+  createUserFn,
+  setCreateUserResponse,
+} from '__test__/support/helpers/requests';
+import {
+  getSubscriptionFn,
+  MockServiceWorker,
+} from '__test__/support/mocks/MockServiceWorker';
 import ContextSW from '../models/ContextSW';
 import { RawPushSubscription } from '../models/RawPushSubscription';
+import { IDManager } from './IDManager';
 import {
   SubscriptionManager,
   SubscriptionManagerConfig,
@@ -24,12 +34,14 @@ const getRawSubscription = (): RawPushSubscription => {
 };
 
 describe('SubscriptionManager', () => {
-  beforeAll(async () => {
+  beforeEach(async () => {
+    vi.resetModules();
     await TestEnvironment.initialize();
   });
 
   describe('updatePushSubscriptionModelWithRawSubscription', () => {
     test('should create the push subscription model if it does not exist', async () => {
+      setCreateUserResponse();
       const context = new ContextSW(TestContext.getFakeMergedConfig());
       const subscriptionManager = new SubscriptionManager(context, subConfig);
       const rawSubscription = getRawSubscription();
@@ -37,13 +49,23 @@ describe('SubscriptionManager', () => {
       let subModels =
         await OneSignal.coreDirector.subscriptionModelStore.list();
       expect(subModels.length).toBe(0);
+
+      // mimicing the event helper checkAndTriggerSubscriptionChanged
+      await OneSignal.database.setPushToken(
+        rawSubscription.w3cEndpoint?.toString(),
+      );
+
       await subscriptionManager._updatePushSubscriptionModelWithRawSubscription(
         rawSubscription,
       );
 
       subModels = await OneSignal.coreDirector.subscriptionModelStore.list();
       expect(subModels.length).toBe(1);
+
+      const id = subModels[0].id;
+      expect(IDManager.isLocalId(id)).toBe(true);
       expect(subModels[0].toJSON()).toEqual({
+        id,
         device_model: '',
         device_os: 56,
         enabled: true,
@@ -54,6 +76,122 @@ describe('SubscriptionManager', () => {
         web_auth: rawSubscription.w3cAuth,
         web_p256: rawSubscription.w3cP256dh,
       });
+
+      await vi.waitUntil(() => createUserFn.mock.calls.length > 0);
+      expect(createUserFn).toHaveBeenCalledWith({
+        identity: {},
+        properties: {
+          language: 'en',
+          timezone_id: 'America/Los_Angeles',
+        },
+        refresh_device_metadata: true,
+        subscriptions: [
+          {
+            device_model: '',
+            device_os: 56,
+            enabled: true,
+            notification_types: 1,
+            sdk: '1',
+            token: rawSubscription.w3cEndpoint?.toString(),
+            type: 'ChromePush',
+            web_auth: rawSubscription.w3cAuth,
+            web_p256: rawSubscription.w3cP256dh,
+          },
+        ],
+      });
+    });
+
+    test('should create user if push subscription model does not have an id', async () => {
+      const generatePushSubscriptionModelSpy = vi.spyOn(
+        OneSignal.coreDirector,
+        'generatePushSubscriptionModel',
+      );
+      const rawSubscription = getRawSubscription();
+      getSubscriptionFn.mockResolvedValue({
+        endpoint: rawSubscription.w3cEndpoint?.toString(),
+      });
+      setCreateUserResponse({
+        externalId: 'some-external-id',
+      });
+
+      const context = new ContextSW(TestContext.getFakeMergedConfig());
+      const subscriptionManager = new SubscriptionManager(context, subConfig);
+
+      // create push sub with no id
+      const identityModel = OneSignal.coreDirector.getIdentityModel();
+      identityModel.onesignalId = IDManager.createLocalId();
+      identityModel.externalId = 'some-external-id';
+
+      await setupSubModelStore({
+        id: '',
+        token: rawSubscription.w3cEndpoint?.toString(),
+        onesignalId: identityModel.onesignalId,
+      });
+
+      await subscriptionManager._updatePushSubscriptionModelWithRawSubscription(
+        rawSubscription,
+      );
+
+      // should not call generatePushSubscriptionModelSpy
+      expect(generatePushSubscriptionModelSpy).not.toHaveBeenCalled();
+
+      expect(createUserFn).toHaveBeenCalledWith({
+        identity: {
+          external_id: 'some-external-id',
+        },
+        properties: {
+          language: 'en',
+          timezone_id: 'America/Los_Angeles',
+        },
+        refresh_device_metadata: true,
+        subscriptions: [
+          {
+            device_model: '',
+            device_os: 56,
+            enabled: true,
+            notification_types: 1,
+            sdk: '1',
+            token: rawSubscription.w3cEndpoint?.toString(),
+            type: 'ChromePush',
+          },
+        ],
+      });
+    });
+
+    test('should update the push subscription model if it already exists', async () => {
+      setCreateUserResponse();
+      const context = new ContextSW(TestContext.getFakeMergedConfig());
+      const subscriptionManager = new SubscriptionManager(context, subConfig);
+      const rawSubscription = getRawSubscription();
+
+      await OneSignal.database.setPushToken(
+        rawSubscription.w3cEndpoint?.toString(),
+      );
+
+      const pushModel = await setupSubModelStore({
+        id: '123',
+        token: rawSubscription.w3cEndpoint?.toString(),
+        onesignalId: DUMMY_EXTERNAL_ID,
+      });
+      pushModel.web_auth = 'old-web-auth';
+      pushModel.web_p256 = 'old-web-p256';
+
+      await subscriptionManager._updatePushSubscriptionModelWithRawSubscription(
+        rawSubscription,
+      );
+
+      const updatedPushModel =
+        (await OneSignal.coreDirector.getPushSubscriptionModel())!;
+      expect(updatedPushModel.token).toBe(
+        rawSubscription.w3cEndpoint?.toString(),
+      );
+      expect(updatedPushModel.web_auth).toBe(rawSubscription.w3cAuth);
+      expect(updatedPushModel.web_p256).toBe(rawSubscription.w3cP256dh);
     });
   });
+});
+
+Object.defineProperty(global.navigator, 'serviceWorker', {
+  value: new MockServiceWorker(),
+  writable: true,
 });

--- a/src/shared/managers/SubscriptionManager.test.ts
+++ b/src/shared/managers/SubscriptionManager.test.ts
@@ -1,0 +1,59 @@
+import { APP_ID } from '__test__/support/constants';
+import TestContext from '__test__/support/environment/TestContext';
+import { TestEnvironment } from '__test__/support/environment/TestEnvironment';
+import ContextSW from '../models/ContextSW';
+import { RawPushSubscription } from '../models/RawPushSubscription';
+import {
+  SubscriptionManager,
+  SubscriptionManagerConfig,
+} from './SubscriptionManager';
+
+const subConfig: SubscriptionManagerConfig = {
+  appId: APP_ID,
+  vapidPublicKey: '',
+  onesignalVapidPublicKey: '',
+};
+
+const getRawSubscription = (): RawPushSubscription => {
+  const rawSubscription = new RawPushSubscription();
+  rawSubscription.w3cAuth = 'auth';
+  rawSubscription.w3cP256dh = 'p256dh';
+  rawSubscription.w3cEndpoint = new URL('https://example.com/endpoint');
+  rawSubscription.safariDeviceToken = 'safariDeviceToken';
+  return rawSubscription;
+};
+
+describe('SubscriptionManager', () => {
+  beforeAll(async () => {
+    await TestEnvironment.initialize();
+  });
+
+  describe('updatePushSubscriptionModelWithRawSubscription', () => {
+    test('should create the push subscription model if it does not exist', async () => {
+      const context = new ContextSW(TestContext.getFakeMergedConfig());
+      const subscriptionManager = new SubscriptionManager(context, subConfig);
+      const rawSubscription = getRawSubscription();
+
+      let subModels =
+        await OneSignal.coreDirector.subscriptionModelStore.list();
+      expect(subModels.length).toBe(0);
+      await subscriptionManager._updatePushSubscriptionModelWithRawSubscription(
+        rawSubscription,
+      );
+
+      subModels = await OneSignal.coreDirector.subscriptionModelStore.list();
+      expect(subModels.length).toBe(1);
+      expect(subModels[0].toJSON()).toEqual({
+        device_model: '',
+        device_os: 56,
+        enabled: true,
+        notification_types: 1,
+        sdk: '1',
+        token: rawSubscription.w3cEndpoint?.toString(),
+        type: 'ChromePush',
+        web_auth: rawSubscription.w3cAuth,
+        web_p256: rawSubscription.w3cP256dh,
+      });
+    });
+  });
+});

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -174,16 +174,19 @@ export class SubscriptionManager {
     rawPushSubscription: RawPushSubscription,
   ) {
     const pushModel = await OneSignal.coreDirector.getPushSubscriptionModel();
-
+    // EventHelper checkAndTriggerSubscriptionChanged is called before this function when permission is granted and so
+    // it will save the push token/id to the database so we don't need to save the token afer generating
     if (!pushModel) {
       OneSignal.coreDirector.generatePushSubscriptionModel(rawPushSubscription);
       return UserDirector.createUserOnServer();
 
       // Bug w/ v160400 release where isCreatingUser was improperly set and never reset
       // so a check if pushModel id is needed to recreate the user
-    } else if (!pushModel.id) {
+    }
+    if (!pushModel.id) {
       return UserDirector.createUserOnServer();
     }
+
     // resubscribing. update existing push subscription model
     const serializedSubscriptionRecord = new FuturePushSubscriptionRecord(
       rawPushSubscription,

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -178,6 +178,11 @@ export class SubscriptionManager {
     if (!pushModel) {
       OneSignal.coreDirector.generatePushSubscriptionModel(rawPushSubscription);
       return UserDirector.createUserOnServer();
+
+      // Bug w/ v160400 release where isCreatingUser was improperly set and never reset
+      // so a check if pushModel id is needed to recreate the user
+    } else if (!pushModel.id) {
+      return UserDirector.createUserOnServer();
     }
     // resubscribing. update existing push subscription model
     const serializedSubscriptionRecord = new FuturePushSubscriptionRecord(


### PR DESCRIPTION
# Description
## 1 Line Summary
Fixes login call for situations where login is called before a user accepts notification permissions.

## Details
With web refactor release, there exists a bug where the developer might call login for a user without granted notification permissions. This will cause an identity entry to be made a local-id and a subscription model will also be created  with a local-id (after accepting permissions).

Login will be called before a push subscription is generated and so the `_login` in LoginManager will set `isCreatingUser` to true. But push subscription is not found so it will return early:
```
    const pushOp = await OneSignal.coreDirector.getPushSubscriptionModel();
    if (!pushOp) return Log.info('No push subscription found');
```

`_updatePushSubscriptionModelWithRawSubscription` will be called on init which attempts to create a user. But `user.isCreatingUser` is true and so it will do an early return when it shouldn't be the case.

So did the following changes:
- removes `isCreatingUser` since calling login with same id is already handled and OneSignal.init should wait for OneSignal.init (if granted permission). Otherwise login operations are enqueued.
- if the case for users without data, we wouldnt need any other changes
- but for users with buggy data (local id for both identity and push sub in IndexeDB), we need to create the user i.e. add this check:
```
 if (!pushModel) {
    OneSignal.coreDirector.generatePushSubscriptionModel(rawPushSubscription);
    return UserDirector.createUserOnServer();
  } else if (!pushModel.id) {
    return UserDirector.createUserOnServer();
  }
```


# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info
**You can clear your data then open branch `fg/login-bug-ref` and run the dev server `npm run dev`. Then see that the data created is buggy and no users api call is made.
You can then check out this branch to see the call gets made.**

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1327)
<!-- Reviewable:end -->
