### PR TITLE
fix: allow email/SMS subscription creation without requiring push subscription

### DIFF
--- a/src/onesignal/UserDirector.ts
+++ b/src/onesignal/UserDirector.ts
@@ -11,27 +11,43 @@ export default class UserDirector {
     const identityModel = OneSignal.coreDirector.getIdentityModel();
     const appId = MainHelper.getAppId();
 
+    const allSubscriptions = await OneSignal.coreDirector.getAllSubscriptionsModels();
+    const hasAnySubscription = allSubscriptions.length > 0;
+    const hasExternalId = !!identityModel.externalId;
+
+    if (!hasAnySubscription && !hasExternalId) {
+      return Log.info('No subscriptions or external ID found, skipping user creation');
+    }
+
     const pushOp = await OneSignal.coreDirector.getPushSubscriptionModel();
-    if (!pushOp) return Log.info('No push subscription found');
+    if (pushOp) {
+      pushOp.id = pushOp.id ?? IDManager.createLocalId();
+      const { id, ...rest } = pushOp.toJSON();
 
-    pushOp.id = pushOp.id ?? IDManager.createLocalId();
-    const { id, ...rest } = pushOp.toJSON();
-
-    OneSignal.coreDirector.operationRepo.enqueue(
-      new LoginUserOperation(
-        appId,
-        identityModel.onesignalId,
-        identityModel.externalId,
-      ),
-    );
-    await OneSignal.coreDirector.operationRepo.enqueueAndWait(
-      new CreateSubscriptionOperation({
-        ...rest,
-        appId,
-        onesignalId: identityModel.onesignalId,
-        subscriptionId: id,
-      }),
-    );
+      OneSignal.coreDirector.operationRepo.enqueue(
+        new LoginUserOperation(
+          appId,
+          identityModel.onesignalId,
+          identityModel.externalId,
+        ),
+      );
+      await OneSignal.coreDirector.operationRepo.enqueueAndWait(
+        new CreateSubscriptionOperation({
+          ...rest,
+          appId,
+          onesignalId: identityModel.onesignalId,
+          subscriptionId: id,
+        }),
+      );
+    } else {
+      OneSignal.coreDirector.operationRepo.enqueue(
+        new LoginUserOperation(
+          appId,
+          identityModel.onesignalId,
+          identityModel.externalId,
+        ),
+      );
+    }
   }
 
   // Resets models similar to Android SDK

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -48,14 +48,15 @@ export default class LoginManager {
     const appId = MainHelper.getAppId();
 
     const pushOp = await OneSignal.coreDirector.getPushSubscriptionModel();
-    if (!pushOp) return Log.info('No push subscription found');
-    OneSignal.coreDirector.operationRepo.enqueue(
-      new TransferSubscriptionOperation(
-        appId,
-        newIdentityOneSignalId,
-        pushOp.id,
-      ),
-    );
+    if (pushOp) {
+      OneSignal.coreDirector.operationRepo.enqueue(
+        new TransferSubscriptionOperation(
+          appId,
+          newIdentityOneSignalId,
+          pushOp.id,
+        ),
+      );
+    }
 
     await OneSignal.coreDirector.operationRepo.enqueueAndWait(
       new LoginUserOperation(


### PR DESCRIPTION
# Description
## 1 Line Summary

Allow Email/SMS subscription creation without a web push subscription

## Details

Currently, users cannot create email or SMS subscriptions after login unless they also have a push subscription. This is because the user creation logic in UserDirector.createUserOnServer() and LoginManager._login() only proceeds when a push subscription exists.

The root cause is that CreateSubscriptionOperation cannot execute when the onesignalId is still a local ID (temporary). User creation is needed to replace the local ID with a real backend ID, but user creation was being prevented when no push subscription existed.

# Systems Affected
   - [ ] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---
