### PR TITLE
Add Fix for Login before Accepting Permissions

### DIFF
--- a/src/core/CoreModuleDirector.ts
+++ b/src/core/CoreModuleDirector.ts
@@ -1,4 +1,5 @@
 import FuturePushSubscriptionRecord from 'src/page/userModel/FuturePushSubscriptionRecord';
+import { IDManager } from 'src/shared/managers/IDManager';
 import SubscriptionHelper from '../../src/shared/helpers/SubscriptionHelper';
 import MainHelper from '../shared/helpers/MainHelper';
 import { RawPushSubscription } from '../shared/models/RawPushSubscription';
@@ -43,7 +44,7 @@ export class CoreModuleDirector {
 
   public generatePushSubscriptionModel(
     rawPushSubscription: RawPushSubscription,
-  ): void {
+  ): SubscriptionModel {
     logMethodCall('CoreModuleDirector.generatePushSubscriptionModel', {
       rawPushSubscription,
     });
@@ -51,9 +52,12 @@ export class CoreModuleDirector {
     model.initializeFromJson(
       new FuturePushSubscriptionRecord(rawPushSubscription).serialize(),
     );
+    model.id = IDManager.createLocalId();
+    Database.setPushId(model.id);
 
     // we enqueue a login operation w/ a create subscription operation the first time we generate/save a push subscription model
-    this.core.subscriptionModelStore.add(model, ModelChangeTags.NO_PROPOGATE);
+    this.core.subscriptionModelStore.add(model, ModelChangeTags.HYDRATE);
+    return model;
   }
 
   public addSubscriptionModel(model: SubscriptionModel): void {

--- a/src/onesignal/UserNamespace.test.ts
+++ b/src/onesignal/UserNamespace.test.ts
@@ -185,6 +185,9 @@ describe('UserNamespace', () => {
     };
 
     test('can add an email subscription', async () => {
+      const identityModel = OneSignal.coreDirector.getIdentityModel();
+      identityModel.onesignalId = IDManager.createLocalId();
+
       const email = 'test@example.com';
       const addSubscriptionSpy = vi.spyOn(
         OneSignal.coreDirector,
@@ -200,6 +203,9 @@ describe('UserNamespace', () => {
     });
 
     test('should remove an email subscription', async () => {
+      const identityModel = OneSignal.coreDirector.getIdentityModel();
+      identityModel.onesignalId = IDManager.createLocalId();
+
       const email = 'test@example.com';
 
       // First add the email
@@ -228,6 +234,9 @@ describe('UserNamespace', () => {
     };
 
     test('should add an SMS subscription', async () => {
+      const identityModel = OneSignal.coreDirector.getIdentityModel();
+      identityModel.onesignalId = IDManager.createLocalId();
+
       const smsNumber = '+15551234567';
       const addSubscriptionSpy = vi.spyOn(
         OneSignal.coreDirector,
@@ -244,6 +253,9 @@ describe('UserNamespace', () => {
 
     test('should remove an SMS subscription', async () => {
       const smsNumber = '+15551234567';
+
+      const identityModel = OneSignal.coreDirector.getIdentityModel();
+      identityModel.onesignalId = IDManager.createLocalId();
 
       // First add the SMS
       await userNamespace.addSms(smsNumber);

--- a/src/shared/managers/SubscriptionManager.test.ts
+++ b/src/shared/managers/SubscriptionManager.test.ts
@@ -101,7 +101,7 @@ describe('SubscriptionManager', () => {
       });
     });
 
-    test('should create user if push subscription model does not have an id', async () => {
+    test('should create user if push subscription model has a local id', async () => {
       const generatePushSubscriptionModelSpy = vi.spyOn(
         OneSignal.coreDirector,
         'generatePushSubscriptionModel',
@@ -123,7 +123,7 @@ describe('SubscriptionManager', () => {
       identityModel.externalId = 'some-external-id';
 
       await setupSubModelStore({
-        id: '',
+        id: IDManager.createLocalId(),
         token: rawSubscription.w3cEndpoint?.toString(),
         onesignalId: identityModel.onesignalId,
       });

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -37,6 +37,7 @@ import { bowserCastle } from '../utils/bowserCastle';
 import { base64ToUint8Array } from '../utils/Encoding';
 import { PermissionUtils } from '../utils/PermissionUtils';
 import { executeCallback, logMethodCall } from '../utils/utils';
+import { IDManager } from './IDManager';
 import SdkEnvironment from './SdkEnvironment';
 export const DEFAULT_DEVICE_ID = '99999999-9999-9999-9999-999999999999';
 
@@ -185,7 +186,11 @@ export class SubscriptionManager {
         OneSignal.coreDirector.generatePushSubscriptionModel(
           rawPushSubscription,
         );
-      return await UserDirector.createUserOnServer();
+      return UserDirector.createUserOnServer();
+    }
+    // for users with data failed to create a user or user+subscriptipn on the server
+    if (IDManager.isLocalId(pushModel.id)) {
+      return UserDirector.createUserOnServer();
     }
 
     // in case of notifcation state changes, we need to update its web_auth, web_p256, and other keys

--- a/src/shared/managers/SubscriptionManager.ts
+++ b/src/shared/managers/SubscriptionManager.ts
@@ -188,12 +188,12 @@ export class SubscriptionManager {
         );
       return UserDirector.createUserOnServer();
     }
-    // for users with data failed to create a user or user+subscriptipn on the server
+    // for users with data failed to create a user or user + subscription on the server
     if (IDManager.isLocalId(pushModel.id)) {
       return UserDirector.createUserOnServer();
     }
 
-    // in case of notifcation state changes, we need to update its web_auth, web_p256, and other keys
+    // in case of notification state changes, we need to update its web_auth, web_p256, and other keys
     const serializedSubscriptionRecord = new FuturePushSubscriptionRecord(
       rawPushSubscription,
     ).serialize();

--- a/src/shared/managers/sessionManager/SessionManager.ts
+++ b/src/shared/managers/sessionManager/SessionManager.ts
@@ -86,6 +86,7 @@ export class SessionManager implements ISessionManager {
     onesignalId: string;
     subscriptionId: string;
   }> {
+    console.trace('_getOneSignalAndSubscriptionIds');
     const identityModel = OneSignal.coreDirector.getIdentityModel();
     const pushSubscriptionModel =
       await OneSignal.coreDirector.getPushSubscriptionModel();

--- a/src/shared/managers/sessionManager/SessionManager.ts
+++ b/src/shared/managers/sessionManager/SessionManager.ts
@@ -86,7 +86,6 @@ export class SessionManager implements ISessionManager {
     onesignalId: string;
     subscriptionId: string;
   }> {
-    console.trace('_getOneSignalAndSubscriptionIds');
     const identityModel = OneSignal.coreDirector.getIdentityModel();
     const pushSubscriptionModel =
       await OneSignal.coreDirector.getPushSubscriptionModel();


### PR DESCRIPTION
# Description
## 1 Line Summary
Addresses ticket: https://app.asana.com/1/780103692902078/project/1208777190614537/task/1210836212667492
Adds check for any existing login calls then create users with a subscription.

Before it would error since `OneSignal.login` would enqueue a login op. And `createUserOnServer` would also create a login op. So this would throw an in op repo since login operation executor expects just one login op.

## Details

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1333)
<!-- Reviewable:end -->
