### PR TITLE
SDK-2921 Mangle Non-API JSON Properties

### DIFF
--- a/build/scripts/validate.js
+++ b/build/scripts/validate.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+import { indexedDB } from 'fake-indexeddb';
+import 'fake-indexeddb/auto';
+import { readFileSync } from 'fs';
+import { JSDOM } from 'jsdom';
+
+const loadJson = (path) => JSON.parse(readFileSync(path, 'utf-8'));
+
+const SHOW_VERBOSE = process.env.VERBOSE === 'true';
+
+const setupEnvironment = () => {
+  const { window } = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+    url: 'https://test.example.com',
+    pretendToBeVisual: true,
+    runScripts: 'dangerously',
+  });
+
+  window.OneSignalDeferred = [];
+  window.indexedDB = indexedDB;
+  window.IDBRequest = global.IDBRequest;
+  window.IDBTransaction = global.IDBTransaction;
+  window.IDBDatabase = global.IDBDatabase;
+  window.IDBObjectStore = global.IDBObjectStore;
+  window.IDBIndex = global.IDBIndex;
+  window.IDBCursor = global.IDBCursor;
+  window.navigator.serviceWorker = {};
+
+  return window;
+};
+
+const validateNamespace = (obj, spec, apiSpec, path = 'OneSignal') => {
+  const errors = [];
+
+  spec.functions?.forEach(({ name }) => {
+    if (typeof obj[name] === 'function') {
+      if (SHOW_VERBOSE) console.log(`✓ ${path}.${name}()`);
+    } else {
+      errors.push(`${path}.${name}() - function missing`);
+    }
+  });
+
+  spec.properties?.forEach(({ name }) => {
+    const exists =
+      name in obj ||
+      Object.getOwnPropertyDescriptor(Object.getPrototypeOf(obj), name);
+    if (exists) {
+      if (SHOW_VERBOSE) console.log(`✓ ${path}.${name}`);
+    } else {
+      errors.push(`${path}.${name} - property missing`);
+    }
+  });
+
+  spec.namespaces?.forEach((name) => {
+    if (obj[name] && typeof obj[name] === 'object') {
+      if (SHOW_VERBOSE) console.log(`✓ ${path}.${name} namespace`);
+
+      const nestedSpec = apiSpec[name];
+      if (nestedSpec) {
+        const nestedErrors = validateNamespace(
+          obj[name],
+          nestedSpec,
+          apiSpec,
+          `${path}.${name}`,
+        );
+        errors.push(...nestedErrors);
+      }
+    } else {
+      errors.push(`${path}.${name} - namespace missing`);
+    }
+  });
+
+  return errors;
+};
+
+const validateBundle = async () => {
+  console.log('🔍 Validating OneSignal bundle...\n');
+
+  const apiSpec = loadJson('api.json');
+  const bundle = readFileSync(
+    'build/releases/OneSignalSDK.page.es6.js',
+    'utf-8',
+  );
+  const window = setupEnvironment();
+
+  const script = window.document.createElement('script');
+  script.textContent = bundle;
+  window.document.head.appendChild(script);
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  if (!window.OneSignal) throw new Error('OneSignal not found');
+
+  const errors = validateNamespace(
+    window.OneSignal,
+    apiSpec.OneSignal,
+    apiSpec,
+  );
+
+  if (errors.length > 0) {
+    console.log('❌ Validation failures:');
+    errors.forEach((error) => console.log(`  ${error}`));
+    process.exit(1);
+  }
+
+  console.log('✅ All API validations passed!');
+};
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  validateBundle().catch((error) => {
+    console.error('💥 Validation failed:', error.message);
+    process.exit(1);
+  });
+}
+
+export { validateBundle };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build:staging:watch": "ENV=staging BUILD_ORIGIN=staging.onesignal.com API=staging API_ORIGIN=staging.onesignal.com npm run build:watch",
     "build:prod": "ENV=production API=production npm run build && size-limit",
     "build:prod:watch": "ENV=production API=production npm run build:watch",
+    "postbuild:prod": "npm run validate:build",
     "build:dev-dev": "API=development npm run build:dev",
     "build:dev-dev:watch": "API=development npm run build:dev:watch",
     "build:dev-prod": "API=production API_ORIGIN=onesignal.com npm run build:dev",
@@ -32,6 +33,7 @@
     "build:dev-stag:watch": "API=staging API_ORIGIN=onesignal.com npm run build:dev:watch",
     "test": "vitest run --coverage",
     "test:watch": "vitest watch --coverage",
+    "validate:build": "node build/scripts/validate.js",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx; prettylint 'src/**/*' 'test/**/*' '__test__/**/*' --no-editorconfig"
   },
   "config": {
@@ -83,12 +85,12 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "52.322 kB",
+      "limit": "47.26 kB",
       "gzip": true
     },
     {
       "path": "./build/releases/OneSignalSDK.sw.js",
-      "limit": "14.564 kB",
+      "limit": "13.3 kB",
       "gzip": true
     },
     {

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -40,7 +40,6 @@ import { ProcessOneSignalPushCalls } from '../page/utils/ProcessOneSignalPushCal
 import MainHelper from '../shared/helpers/MainHelper';
 import Emitter from '../shared/libraries/Emitter';
 import Log from '../shared/libraries/Log';
-import OneSignalEvent from '../shared/services/OneSignalEvent';
 import DebugNamespace from './DebugNamesapce';
 import NotificationsNamespace from './NotificationsNamespace';
 import { ONESIGNAL_EVENTS } from './OneSignalEvents';
@@ -271,7 +270,6 @@ export default class OneSignal {
   static _didLoadITILibrary = false;
   static notifyButton: Bell | null = null;
   static database = db;
-  static event = OneSignalEvent;
   private static pendingInit = true;
 
   static emitter: Emitter = new Emitter();

--- a/src/shared/libraries/Log.ts
+++ b/src/shared/libraries/Log.ts
@@ -1,7 +1,7 @@
 import { IS_SERVICE_WORKER, LOGGING } from '../utils/EnvVariables';
 
 export default class Log {
-  private static _shouldLog(): boolean {
+  private static shouldLog(): boolean {
     if (IS_SERVICE_WORKER)
       return !!(self as unknown as ServiceWorkerGlobalScope).shouldLog;
     try {
@@ -30,7 +30,7 @@ export default class Log {
 
   private static createLogMethod(consoleMethod: keyof Console) {
     return (...args: unknown[]): void => {
-      if (LOGGING || this._shouldLog() || consoleMethod === 'error') {
+      if (LOGGING || this.shouldLog() || consoleMethod === 'error') {
         (console[consoleMethod] as (...args: unknown[]) => void)(...args);
       }
     };

--- a/src/shared/useragent/detect.ts
+++ b/src/shared/useragent/detect.ts
@@ -2,9 +2,9 @@ import { Browser } from './constants';
 import type { BrowserValue } from './types';
 
 interface BrowserConfig {
-  _name: string;
-  _pattern: RegExp;
-  _versionPattern: RegExp;
+  name: string;
+  pattern: RegExp;
+  versionPattern: RegExp;
 }
 
 interface IBrowserResult {
@@ -15,67 +15,67 @@ interface IBrowserResult {
 // Top popular browsers set
 const BROWSER_CONFIGS: BrowserConfig[] = [
   {
-    _name: 'Opera',
-    _pattern: /(?:opera|opr|opios)/i,
-    _versionPattern: /(?:opera|opr|opios)[ /](\d+(?:\.\d+)?)/i,
+    name: 'Opera',
+    pattern: /(?:opera|opr|opios)/i,
+    versionPattern: /(?:opera|opr|opios)[ /](\d+(?:\.\d+)?)/i,
   },
   {
-    _name: 'Facebook',
-    _pattern: /FBAN\//i,
-    _versionPattern: /FBAV\/(\d+(?:\.\d+)?)/i,
+    name: 'Facebook',
+    pattern: /FBAN\//i,
+    versionPattern: /FBAV\/(\d+(?:\.\d+)?)/i,
   },
   {
-    _name: 'Samsung Browser',
-    _pattern: /samsungbrowser/i,
-    _versionPattern: /samsungbrowser[ /](\d+(?:\.\d+)?)/i,
+    name: 'Samsung Browser',
+    pattern: /samsungbrowser/i,
+    versionPattern: /samsungbrowser[ /](\d+(?:\.\d+)?)/i,
   },
   {
-    _name: 'Yandex Browser',
-    _pattern: /yabrowser/i,
-    _versionPattern: /yabrowser[ /](\d+(?:\.\d+)?)/i,
+    name: 'Yandex Browser',
+    pattern: /yabrowser/i,
+    versionPattern: /yabrowser[ /](\d+(?:\.\d+)?)/i,
   },
   {
-    _name: 'Vivaldi',
-    _pattern: /vivaldi/i,
-    _versionPattern: /vivaldi[ /](\d+(?:\.\d+)?)/i,
+    name: 'Vivaldi',
+    pattern: /vivaldi/i,
+    versionPattern: /vivaldi[ /](\d+(?:\.\d+)?)/i,
   },
   {
-    _name: 'UC Browser',
-    _pattern: /ucbrowser/i,
-    _versionPattern: /ucbrowser[ /](\d+(?:\.\d+)?)/i,
+    name: 'UC Browser',
+    pattern: /ucbrowser/i,
+    versionPattern: /ucbrowser[ /](\d+(?:\.\d+)?)/i,
   },
   {
-    _name: 'Microsoft Edge',
-    _pattern: /edg/i,
-    _versionPattern: /edg[ /](\d+(?:\.\d+)?)/i,
+    name: 'Microsoft Edge',
+    pattern: /edg/i,
+    versionPattern: /edg[ /](\d+(?:\.\d+)?)/i,
   },
   {
-    _name: 'Firefox',
-    _pattern: /firefox|iceweasel|fxios/i,
-    _versionPattern: /(?:firefox|iceweasel|fxios)[ /](\d+(?:\.\d+)?)/i,
+    name: 'Firefox',
+    pattern: /firefox|iceweasel|fxios/i,
+    versionPattern: /(?:firefox|iceweasel|fxios)[ /](\d+(?:\.\d+)?)/i,
   },
   {
-    _name: 'Chromium',
-    _pattern: /chromium/i,
-    _versionPattern: /chromium[ /](\d+(?:\.\d+)?)/i,
+    name: 'Chromium',
+    pattern: /chromium/i,
+    versionPattern: /chromium[ /](\d+(?:\.\d+)?)/i,
   },
   {
-    _name: 'Chrome',
-    _pattern: /chrome|crios|crmo/i,
-    _versionPattern: /(?:chrome|crios|crmo)[ /](\d+(?:\.\d+)?)/i,
+    name: 'Chrome',
+    pattern: /chrome|crios|crmo/i,
+    versionPattern: /(?:chrome|crios|crmo)[ /](\d+(?:\.\d+)?)/i,
   },
   {
-    _name: 'Safari',
-    _pattern: /safari|applewebkit/i,
-    _versionPattern: /version[ /](\d+(?:\.\d+)?)/i,
+    name: 'Safari',
+    pattern: /safari|applewebkit/i,
+    versionPattern: /version[ /](\d+(?:\.\d+)?)/i,
   },
 ];
 
 export function getBrowser(userAgent: string): IBrowserResult {
   for (const config of BROWSER_CONFIGS) {
-    if (config._pattern.test(userAgent)) {
-      const version = userAgent.match(config._versionPattern)?.[1] ?? '';
-      return { name: config._name, version };
+    if (config.pattern.test(userAgent)) {
+      const version = userAgent.match(config.versionPattern)?.[1] ?? '';
+      return { name: config.name, version };
     }
   }
   return { name: 'Unknown', version: '' };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,9 +63,73 @@ export default defineConfig(({ mode }) => {
       minify: isProdEnv ? 'terser' : false,
       terserOptions: {
         mangle: {
+          toplevel: true,
           properties: {
-            // Enable property name mangling/minification for private-style properties (starting with _)
-            regex: /^_/,
+            undeclared: true,
+            keep_quoted: true, // mangle obj.prop unless it's quoted (e.g. obj['prop'])
+
+            reserved: [
+              // OneSignal methods
+              'OneSignal',
+              'login',
+              'logout',
+              'init',
+              'setConsentGiven',
+              'setConsentRequired',
+
+              // general
+              'addEventListener',
+              'removeEventListener',
+
+              // namesapces
+              'Notifications',
+              'setDefaultUrl',
+              'isPushSupported',
+              'requestPermission',
+              'permissionNative',
+              'permission',
+              'setDefaultTitle',
+
+              'Slidedown',
+              'promptPush',
+              'promptPushCategories',
+              'promptSms',
+              'promptEmail',
+              'promptSmsAndEmail',
+
+              'Debug',
+              'setLogLevel',
+
+              'Session',
+              'sendOutcome',
+              'sendUniqueOutcome',
+
+              'User',
+              'addAlias',
+              'addAliases',
+              'removeAlias',
+              'removeAliases',
+              'addEmail',
+              'removeEmail',
+              'addSms',
+              'removeSms',
+              'addTag',
+              'addTags',
+              'removeTag',
+              'removeTags',
+              'getTags',
+              'setLanguage',
+              'getLanguage',
+              'onesignalId',
+              'externalId',
+
+              'PushSubscription',
+              'optIn',
+              'optOut',
+              'id',
+              'token',
+              'optedIn',
+            ],
           },
         },
       },


### PR DESCRIPTION
# Description
## 1 Line Summary
- adds more aggressive mangling of properties but preserves important exposed properties like User.addTag, login , etc.

## Details
- sets aggressive mangling  `regex: /./,` but adds reserved strings to avoid minifying
- adds validator script to check bundle meets api spec in terms exposed of properties (not typings)
- adds postbuild script to validate production builds which runs anytime `npm run build:prod` runs

Before:
```
# SDK-2919
  build/releases/OneSignalSDK.page.js
  Size limit: 450 B
  Size:       450 B gzipped
  
  build/releases/OneSignalSDK.page.es6.js
  Size limit: 52.2 kB
  Size:       52.2 kB gzipped
  
  build/releases/OneSignalSDK.sw.js
  Size limit: 14.56 kB
  Size:       14.56 kB gzipped
  
  build/releases/OneSignalSDK.page.styles.css
  Size limit: 8.81 kB
  Size:       8.8 kB  gzipped
```

Now:
```
build/releases/OneSignalSDK.page.js
  Size limit: 450 B
  Size:       450 B gzipped
  
  build/releases/OneSignalSDK.page.es6.js
  Size limit: 46.99 kB
  Size:       46.99 kB gzipped
  
  build/releases/OneSignalSDK.sw.js
  Size limit: 13.19 kB
  Size:       13.19 kB gzipped
  
  build/releases/OneSignalSDK.page.styles.css
  Size limit: 8.81 kB
  Size:       8.8 kB  gzipped
```

Validator example:
```
> npm run validate:build


> onesignal-web-sdk@1.2.0 validate:build
> node build/scripts/validate.js

🔍 Validating OneSignal bundle...

✓ OneSignal.login()
✓ OneSignal.logout()
✓ OneSignal.init()
✓ OneSignal.setConsentGiven()
✓ OneSignal.setConsentRequired()
✓ OneSignal.Slidedown namespace
✓ OneSignal.Slidedown.promptPush()
✓ OneSignal.Slidedown.promptPushCategories()
✓ OneSignal.Slidedown.promptSms()
✓ OneSignal.Slidedown.promptEmail()
✓ OneSignal.Slidedown.promptSmsAndEmail()
✓ OneSignal.Slidedown.addEventListener()
✓ OneSignal.Slidedown.removeEventListener()
✓ OneSignal.Notifications namespace
✓ OneSignal.Notifications.setDefaultUrl()
✓ OneSignal.Notifications.setDefaultTitle()
✓ OneSignal.Notifications.isPushSupported()
✓ OneSignal.Notifications.requestPermission()
✓ OneSignal.Notifications.addEventListener()
✓ OneSignal.Notifications.removeEventListener()
✓ OneSignal.Notifications.permissionNative
✓ OneSignal.Notifications.permission
✓ OneSignal.Session namespace
✓ OneSignal.Session.sendOutcome()
✓ OneSignal.Session.sendUniqueOutcome()
✓ OneSignal.User namespace
✓ OneSignal.User.addAlias()
✓ OneSignal.User.addAliases()
✓ OneSignal.User.removeAlias()
✓ OneSignal.User.removeAliases()
✓ OneSignal.User.addEmail()
✓ OneSignal.User.removeEmail()
✓ OneSignal.User.addSms()
✓ OneSignal.User.removeSms()
✓ OneSignal.User.addTag()
✓ OneSignal.User.addTags()
✓ OneSignal.User.removeTag()
✓ OneSignal.User.removeTags()
✓ OneSignal.User.getTags()
✓ OneSignal.User.addEventListener()
✓ OneSignal.User.removeEventListener()
✓ OneSignal.User.setLanguage()
✓ OneSignal.User.getLanguage()
✓ OneSignal.User.onesignalId
✓ OneSignal.User.externalId
✓ OneSignal.User.PushSubscription namespace
✓ OneSignal.User.PushSubscription.optIn()
✓ OneSignal.User.PushSubscription.optOut()
✓ OneSignal.User.PushSubscription.addEventListener()
✓ OneSignal.User.PushSubscription.removeEventListener()
✓ OneSignal.User.PushSubscription.id
✓ OneSignal.User.PushSubscription.token
✓ OneSignal.User.PushSubscription.optedIn
✓ OneSignal.Debug namespace
✓ OneSignal.Debug.setLogLevel()
✅ All API validations passed!
```

# Systems Affected
   - [ ] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1358)
<!-- Reviewable:end -->
