### PR TITLE
Wait for user to provide consent before executing operations

### DIFF
--- a/__test__/setupTests.ts
+++ b/__test__/setupTests.ts
@@ -18,7 +18,7 @@ beforeEach(async () => {
 afterEach(() => {
   server.resetHandlers();
   if (typeof OneSignal !== 'undefined') {
-    OneSignal.coreDirector?.operationRepo.clear();
+    OneSignal.coreDirector?.operationRepo._clear();
     OneSignal.emitter?.removeAllListeners();
   }
 });

--- a/__test__/support/environment/TestContext.ts
+++ b/__test__/support/environment/TestContext.ts
@@ -221,7 +221,7 @@ export default class TestContext {
                 right: 0,
                 bottom: 0,
               },
-              enabled: true,
+              enabled: false,
               message: {
                 subscribing: 'Thanks for subscribing!',
                 unsubscribing: "You won't receive notifications again",
@@ -239,7 +239,7 @@ export default class TestContext {
               prompts: [
                 {
                   type: DelayedPromptType.Push,
-                  autoPrompt: true,
+                  autoPrompt: false,
                   text: {
                     acceptButton: 'Allow',
                     cancelButton: 'No Thanks',
@@ -252,7 +252,7 @@ export default class TestContext {
             fullscreen: {
               title: 'example.com',
               caption: 'You can unsubscribe anytime',
-              enabled: true,
+              enabled: false,
               message: 'This is an example notification message.',
               acceptButton: 'Continue',
               cancelButton: 'No Thanks',
@@ -262,7 +262,7 @@ export default class TestContext {
               customizeTextEnabled: true,
             },
             customlink: {
-              enabled: true,
+              enabled: false,
               style: 'button',
               size: 'medium',
               color: {
@@ -350,7 +350,7 @@ export default class TestContext {
   static getFakeAppUserConfig(appId: string = APP_ID): AppUserConfig {
     return {
       appId,
-      autoRegister: true,
+      autoRegister: false,
       autoResubscribe: true,
       path: '/fake-page',
       serviceWorkerPath: 'fakeWorkerName.js',
@@ -365,7 +365,7 @@ export default class TestContext {
           prompts: [
             {
               type: DelayedPromptType.Push,
-              autoPrompt: true,
+              autoPrompt: false,
               text: {
                 acceptButton: 'Allow',
                 cancelButton: 'No Thanks',

--- a/index.html
+++ b/index.html
@@ -27,6 +27,9 @@
           //   },
           // },
         });
+
+        // for testing consent required
+        // OneSignal.setConsentRequired(true);
       });
 
       // function pushSubscriptionChangeListener(event) {

--- a/index.html
+++ b/index.html
@@ -14,8 +14,12 @@
 
       window.OneSignalDeferred = window.OneSignalDeferred || [];
       OneSignalDeferred.push(async function (OneSignal) {
+        // for testing consent required
+        // OneSignal.setConsentRequired(true);
+
         await OneSignal.init({
           appId,
+          // requiresUserPrivacyConsent: true, // requires custom site sestting in dashboard
           // promptOptions: {
           //   slidedown: {
           //     prompts: [
@@ -28,7 +32,6 @@
           // },
         });
 
-        // for testing consent required
         // OneSignal.setConsentRequired(true);
       });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "idb": "^8.0.3",
-        "jsonp": "github:OneSignal/jsonp#onesignal",
-        "uuid": "^11.1.0"
+        "jsonp": "github:OneSignal/jsonp#onesignal"
       },
       "devDependencies": {
         "@size-limit/file": "^11.2.0",
@@ -24,7 +23,7 @@
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^5.36.1",
         "@typescript-eslint/parser": "^5.36.1",
-        "@vitest/coverage-v8": "4.0.0-beta.8",
+        "@vitest/coverage-v8": "4.0.0-beta.9",
         "concurrently": "^9.2.0",
         "deepmerge": "^4.2.2",
         "eslint": "^8.23.0",
@@ -43,7 +42,7 @@
         "vite-bundle-analyzer": "^1.1.0",
         "vite-plugin-mkcert": "^1.17.8",
         "vite-tsconfig-paths": "^5.1.4",
-        "vitest": "4.0.0-beta.8"
+        "vitest": "4.0.0-beta.9"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -943,9 +942,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -1769,14 +1768,14 @@
       "license": "ISC"
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.0-beta.8.tgz",
-      "integrity": "sha512-vd8D6P/PWtHXjH5Sot8PuGKchYC7Uns46Dpr1fg57kD8SOdXJybxtg/EdYvD5/OUW2q0iQCFes79WbH+LelwaA==",
+      "version": "4.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.0-beta.9.tgz",
+      "integrity": "sha512-XODBzMIBTyfYBtbSZjkeNO4bPFkNnJ58Tmjbg2q1ptyUqsimL0K7fUPDSMZMtU4V1XXjieTBvMnQTPOIzAtptQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.0.0-beta.8",
+        "@vitest/utils": "4.0.0-beta.9",
         "ast-v8-to-istanbul": "^0.3.3",
         "debug": "^4.4.1",
         "istanbul-lib-coverage": "^3.2.2",
@@ -1791,8 +1790,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.0.0-beta.8",
-        "vitest": "4.0.0-beta.8"
+        "@vitest/browser": "4.0.0-beta.9",
+        "vitest": "4.0.0-beta.9"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1801,16 +1800,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.0-beta.8.tgz",
-      "integrity": "sha512-40DZ7nl5AkASkDNaVR7TqsbeJCs5D+dyQNM5cIvgjG3KK+ATeWxtXJbmRNqgdbq+FL3v/pchnrJM1R9BFkTdUQ==",
+      "version": "4.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.0-beta.9.tgz",
+      "integrity": "sha512-gt34h5GvmtHvRlhSoGUVGDgR0DHBZrGmRM5Jr2za6FcwA93weXIoBMbJmp9TwSor9FRDyzumY+INVJ0LXfXqwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.0-beta.8",
-        "@vitest/utils": "4.0.0-beta.8",
-        "chai": "^5.2.1",
+        "@vitest/spy": "4.0.0-beta.9",
+        "@vitest/utils": "4.0.0-beta.9",
+        "chai": "^6.0.1",
         "tinyrainbow": "^2.0.0"
       },
       "funding": {
@@ -1818,13 +1817,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.0-beta.8.tgz",
-      "integrity": "sha512-a5ynR/Fsrciuq17i8lzS5NH3ICxwFZMlQ4bXPzGV+KlIcVHu20a/8q6KekqUaVBxCbmohORLFXFx9IptHS9gXA==",
+      "version": "4.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.0-beta.9.tgz",
+      "integrity": "sha512-HQrMUmESI9R6xkhdhSH4gpH/lDo1I3dvfqTcGM8546QaoEBK52ajdtilBWlfV0XpkhH/Evr8Pwo0iNoEcwR2AA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.0-beta.8",
+        "@vitest/spy": "4.0.0-beta.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -1845,9 +1844,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.0-beta.8.tgz",
-      "integrity": "sha512-sr5HPeeRff4gTpDwI2Kvz8dS2CmDCCZ1PRu3IOeLTcSJjhEWmk3IJILjqaA8yyj+QzWjnqAxr2rmZNpO0h/5Vw==",
+      "version": "4.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.0-beta.9.tgz",
+      "integrity": "sha512-C3wJZcCGfzcibumKKhKPauqgxq+9+osXQK1+81yeDaJ6+gZyulw5ZMALJaH7SAIPzkKaYMtkvZJEPaNv/q5AWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1858,13 +1857,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.0-beta.8.tgz",
-      "integrity": "sha512-m7jrT+KMEgONclBI7y3ptUD+/uhRzzHLblws84fo+WesCjS8WT8q7RoPMgqymj5kmzIF5sTh6NOvrNEE5LaLCQ==",
+      "version": "4.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.0-beta.9.tgz",
+      "integrity": "sha512-KAIfV8x69/jEuKjDyYhQyupoKoeOc3Gv/qZEMRa66biKdQC/a/7YJ7uuX9RklbpWhlZBT7tkGXgV/lJ+Gw0m6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.0-beta.8",
+        "@vitest/utils": "4.0.0-beta.9",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -1873,13 +1872,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.0-beta.8.tgz",
-      "integrity": "sha512-2hzc/ksGlZ8Rcg11VD/AhTwSaPEsdtrNA+TCV4w6tuZ7I2X+XJXimfk/Cehz5zMgfFuV8tFmGimb/BpyIbNiMg==",
+      "version": "4.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.0-beta.9.tgz",
+      "integrity": "sha512-Ok6d/dw5feoT1GFapI/4Nb/g+FZrGA9ha1mEh9qkBFUDGI9mX1bNm1Qyz43vyXu7M/1Jz2GuuMX4WebtOVgheA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.0-beta.8",
+        "@vitest/pretty-format": "4.0.0-beta.9",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -1888,9 +1887,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.0-beta.8.tgz",
-      "integrity": "sha512-WfHF35GCf5xx3B1oRrhWMVAfcBBYO4WHAYLbeeaZ1ZSW5/VBXJ/M37bLxRRKnXcgffwcsWA7xpjWnL0dQ1q5NA==",
+      "version": "4.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.0-beta.9.tgz",
+      "integrity": "sha512-uDUHqM3ANfowSvWSbU6FL70AATOdv9LReXzU+vM65VyFZ5lBM2zTNicgdmU2dpAdlI0k0SEdlB8dyv+Kp4VAqg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1898,13 +1897,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.0-beta.8.tgz",
-      "integrity": "sha512-+eV3yrDooGMnHHVQ1aqzPJIBlxEsaQg/5BVFRSkbBgfiKqM9HZbqYK736s0D8tfdMLOjeB+7u7Tw0emd/h3MlQ==",
+      "version": "4.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.0-beta.9.tgz",
+      "integrity": "sha512-NEGPSUj7EZNeMpgBjk6nTn1Y1ApYQtjAvm3u/e/dd9qShbhF+yuNngccn9ulDZrW2F9hBdEQq7V3Dupa0zoSsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.0-beta.8",
+        "@vitest/pretty-format": "4.0.0-beta.9",
         "loupe": "^3.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -2034,16 +2033,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/assertion-error": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/ast-v8-to-istanbul": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.3.tgz",
@@ -2156,30 +2145,13 @@
       }
     },
     "node_modules/chai": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
-      "integrity": "sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.0.1.tgz",
+      "integrity": "sha512-/JOoU2//6p5vCXh00FpNgtlw0LjvhGttaWc+y7wpW9yjBm3ys0dI8tSKZxIOgNruz5J0RleccatSIC3uxEZP0g==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2429,16 +2401,6 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3951,9 +3913,9 @@
       }
     },
     "node_modules/loupe": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.0.tgz",
-      "integrity": "sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3965,13 +3927,13 @@
       "license": "ISC"
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.18",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
+      "integrity": "sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/magicast": {
@@ -4344,16 +4306,6 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5619,19 +5571,6 @@
         "requires-port": "^1.0.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/varint": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
@@ -5791,21 +5730,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.0-beta.8.tgz",
-      "integrity": "sha512-wN/RDeCd5uXHV6tELw4AJzeP5rxR4YWXN3ems+59ZummmiovNjlfwG+CEZp5GitlxDQu7muoY4VPrSUxPzzKiQ==",
+      "version": "4.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.0-beta.9.tgz",
+      "integrity": "sha512-DDEbcetwyfXdiZjb9tAN1kD8nyamkqvfVZ/FlSGVcvjP6wfpDt1aqrZmpAgajDnW4DO1n5CYLnThOY83woPmDw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "4.0.0-beta.8",
-        "@vitest/mocker": "4.0.0-beta.8",
-        "@vitest/pretty-format": "^4.0.0-beta.8",
-        "@vitest/runner": "4.0.0-beta.8",
-        "@vitest/snapshot": "4.0.0-beta.8",
-        "@vitest/spy": "4.0.0-beta.8",
-        "@vitest/utils": "4.0.0-beta.8",
-        "chai": "^5.2.1",
+        "@vitest/expect": "4.0.0-beta.9",
+        "@vitest/mocker": "4.0.0-beta.9",
+        "@vitest/pretty-format": "^4.0.0-beta.9",
+        "@vitest/runner": "4.0.0-beta.9",
+        "@vitest/snapshot": "4.0.0-beta.9",
+        "@vitest/spy": "4.0.0-beta.9",
+        "@vitest/utils": "4.0.0-beta.9",
         "debug": "^4.4.1",
         "es-module-lexer": "^1.7.0",
         "expect-type": "^1.2.2",
@@ -5834,8 +5771,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "4.0.0-beta.8",
-        "@vitest/ui": "4.0.0-beta.8",
+        "@vitest/browser": "4.0.0-beta.9",
+        "@vitest/ui": "4.0.0-beta.9",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "52.15 kB",
+      "limit": "52.143 kB",
       "gzip": true
     },
     {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "dependencies": {
     "idb": "^8.0.3",
-    "jsonp": "github:OneSignal/jsonp#onesignal",
-    "uuid": "^11.1.0"
+    "jsonp": "github:OneSignal/jsonp#onesignal"
   },
   "scripts": {
     "dev": "LOGGING=false vite",
@@ -56,7 +55,7 @@
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",
-    "@vitest/coverage-v8": "4.0.0-beta.8",
+    "@vitest/coverage-v8": "4.0.0-beta.9",
     "concurrently": "^9.2.0",
     "deepmerge": "^4.2.2",
     "eslint": "^8.23.0",
@@ -75,7 +74,7 @@
     "vite-bundle-analyzer": "^1.1.0",
     "vite-plugin-mkcert": "^1.17.8",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "4.0.0-beta.8"
+    "vitest": "4.0.0-beta.9"
   },
   "size-limit": [
     {
@@ -85,7 +84,7 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "52.21 kB",
+      "limit": "52.15 kB",
       "gzip": true
     },
     {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "52.143 kB",
+      "limit": "52.19 kB",
       "gzip": true
     },
     {

--- a/src/core/CoreModule.ts
+++ b/src/core/CoreModule.ts
@@ -65,7 +65,7 @@ export default class CoreModule {
     );
 
     this.listeners = this.initializeListeners();
-    this.initPromise = this.operationRepo.start();
+    this.initPromise = this.operationRepo._start();
   }
 
   public async init() {

--- a/src/core/executors/IdentityOperationExecutor.test.ts
+++ b/src/core/executors/IdentityOperationExecutor.test.ts
@@ -176,7 +176,7 @@ describe('IdentityOperationExecutor', () => {
       ]);
 
       // in missing retry window
-      newRecordsState.add(ONESIGNAL_ID);
+      newRecordsState._add(ONESIGNAL_ID);
       setAddAliasError({ status: 404, retryAfter: 20 });
       const res6 = await executor.execute(ops);
       expect(res6.result).toBe(ExecutionResult.FAIL_RETRY);
@@ -215,7 +215,7 @@ describe('IdentityOperationExecutor', () => {
       expect(res5.result).toBe(ExecutionResult.SUCCESS);
 
       // in missing retry window
-      newRecordsState.add(ONESIGNAL_ID);
+      newRecordsState._add(ONESIGNAL_ID);
       setDeleteAliasError({ status: 404, retryAfter: 20 });
       const res6 = await executor.execute(ops);
       expect(res6.result).toBe(ExecutionResult.FAIL_RETRY);

--- a/src/core/executors/IdentityOperationExecutor.ts
+++ b/src/core/executors/IdentityOperationExecutor.ts
@@ -135,7 +135,9 @@ export class IdentityOperationExecutor implements IOperationExecutor {
       case ResponseStatusType.MISSING: {
         if (
           status === 404 &&
-          this._newRecordState.isInMissingRetryWindow(lastOperation.onesignalId)
+          this._newRecordState._isInMissingRetryWindow(
+            lastOperation.onesignalId,
+          )
         )
           return new ExecutionResponse(
             ExecutionResult.FAIL_RETRY,

--- a/src/core/executors/LoginUserOperationExecutor.ts
+++ b/src/core/executors/LoginUserOperationExecutor.ts
@@ -3,9 +3,7 @@ import {
   ExecutionResult,
   type IOperationExecutor,
 } from 'src/core/types/operation';
-import { getConsentGiven } from 'src/shared/database/config';
 import { getTimeZoneId } from 'src/shared/helpers/general';
-import { getConsentRequired } from 'src/shared/helpers/localStorage';
 import {
   getResponseStatusType,
   ResponseStatusType,
@@ -79,13 +77,6 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
     loginUserOp: LoginUserOperation,
     operations: Operation[],
   ): Promise<ExecutionResponse> {
-    const consentRequired = getConsentRequired();
-    const consentGiven = await getConsentGiven();
-
-    if (consentRequired && !consentGiven) {
-      throw new Error('Consent required but not given');
-    }
-
     // When there is no existing user to attempt to associate with the externalId provided, we go right to
     // createUser.  If there is no externalId provided this is an insert, if there is this will be an
     // "upsert with retrieval" as the user may already exist.

--- a/src/core/executors/RefreshUserOperationExecutor.test.ts
+++ b/src/core/executors/RefreshUserOperationExecutor.test.ts
@@ -275,7 +275,7 @@ describe('RefreshUserOperationExecutor', () => {
       });
 
       // -- in missing retry window
-      newRecordsState.add(ONESIGNAL_ID);
+      newRecordsState._add(ONESIGNAL_ID);
       setGetUserError({
         status: 404,
         retryAfter: 20,

--- a/src/core/executors/RefreshUserOperationExecutor.ts
+++ b/src/core/executors/RefreshUserOperationExecutor.ts
@@ -153,7 +153,7 @@ export class RefreshUserOperationExecutor implements IOperationExecutor {
       case ResponseStatusType.MISSING: {
         if (
           status === 404 &&
-          this._newRecordState.isInMissingRetryWindow(op.onesignalId)
+          this._newRecordState._isInMissingRetryWindow(op.onesignalId)
         )
           return new ExecutionResponse(
             ExecutionResult.FAIL_RETRY,

--- a/src/core/executors/SubscriptionOperationExecutor.test.ts
+++ b/src/core/executors/SubscriptionOperationExecutor.test.ts
@@ -57,7 +57,7 @@ describe('SubscriptionOperationExecutor', () => {
   beforeEach(() => {
     subscriptionModelStore = OneSignal.coreDirector.subscriptionModelStore;
     newRecordsState = OneSignal.coreDirector.newRecordsState;
-    newRecordsState.records.clear();
+    newRecordsState._records.clear();
 
     identityModelStore = OneSignal.coreDirector.identityModelStore;
     propertiesModelStore = OneSignal.coreDirector.propertiesModelStore;
@@ -316,7 +316,7 @@ describe('SubscriptionOperationExecutor', () => {
       });
 
       // Missing error in retry window
-      newRecordsState.add(ONESIGNAL_ID);
+      newRecordsState._add(ONESIGNAL_ID);
       setCreateSubscriptionError({ status: 404, retryAfter: 20 });
       const res7 = await executor.execute([createOp]);
       expect(res7).toMatchObject({
@@ -448,7 +448,7 @@ describe('SubscriptionOperationExecutor', () => {
       });
 
       // Missing error with record in retry window
-      newRecordsState.add(SUB_ID);
+      newRecordsState._add(SUB_ID);
       const res3 = await executor.execute([updateOp]);
       expect(res3).toMatchObject({
         result: ExecutionResult.FAIL_RETRY,
@@ -501,7 +501,7 @@ describe('SubscriptionOperationExecutor', () => {
       expect(result.result).toBe(ExecutionResult.SUCCESS);
 
       // Missing error with record in retry window
-      newRecordsState.add(SUB_ID);
+      newRecordsState._add(SUB_ID);
       setDeleteSubscriptionError({ status: 404, retryAfter: 5 });
       const res2 = await executor.execute([deleteOp]);
       expect(res2).toMatchObject({

--- a/src/core/executors/SubscriptionOperationExecutor.ts
+++ b/src/core/executors/SubscriptionOperationExecutor.ts
@@ -177,7 +177,7 @@ export class SubscriptionOperationExecutor implements IOperationExecutor {
       case ResponseStatusType.MISSING: {
         if (
           status === 404 &&
-          this._newRecordState.isInMissingRetryWindow(
+          this._newRecordState._isInMissingRetryWindow(
             createOperation.onesignalId,
           )
         ) {
@@ -242,7 +242,7 @@ export class SubscriptionOperationExecutor implements IOperationExecutor {
         if (
           status === 404 &&
           [lastOp.onesignalId, lastOp.subscriptionId].some((id) =>
-            this._newRecordState.isInMissingRetryWindow(id),
+            this._newRecordState._isInMissingRetryWindow(id),
           )
         ) {
           return new ExecutionResponse(
@@ -319,7 +319,7 @@ export class SubscriptionOperationExecutor implements IOperationExecutor {
       case ResponseStatusType.MISSING:
         if (
           [op.onesignalId, op.subscriptionId].some((id) =>
-            this._newRecordState.isInMissingRetryWindow(id),
+            this._newRecordState._isInMissingRetryWindow(id),
           )
         ) {
           return new ExecutionResponse(

--- a/src/core/executors/UpdateUserOperationExecutor.test.ts
+++ b/src/core/executors/UpdateUserOperationExecutor.test.ts
@@ -163,7 +163,7 @@ describe('UpdateUserOperationExecutor', () => {
       });
 
       // Missing error in retry window
-      newRecordsState.add(ONESIGNAL_ID);
+      newRecordsState._add(ONESIGNAL_ID);
       setUpdateUserError({ status: 404, retryAfter: 20 });
       const res5 = await executor.execute([setTagOp]);
       expect(res5).toMatchObject({

--- a/src/core/executors/UpdateUserOperationExecutor.ts
+++ b/src/core/executors/UpdateUserOperationExecutor.ts
@@ -138,7 +138,7 @@ export class UpdateUserOperationExecutor implements IOperationExecutor {
       case ResponseStatusType.MISSING: {
         if (
           status === 404 &&
-          this._newRecordState.isInMissingRetryWindow(onesignalId)
+          this._newRecordState._isInMissingRetryWindow(onesignalId)
         ) {
           return new ExecutionResponse(
             ExecutionResult.FAIL_RETRY,

--- a/src/core/operationRepo/NewRecordsState.ts
+++ b/src/core/operationRepo/NewRecordsState.ts
@@ -6,27 +6,27 @@ import {
 } from './constants';
 
 export class NewRecordsState {
-  private _records: Map<string, number> = new Map();
+  private _recordsMap: Map<string, number> = new Map();
 
-  public get records(): Map<string, number> {
-    return this._records;
+  public get _records(): Map<string, number> {
+    return this._recordsMap;
   }
 
-  public add(id: string): void {
-    this._records.set(id, Date.now());
+  public _add(id: string): void {
+    this._recordsMap.set(id, Date.now());
   }
 
-  public canAccess(key: string | undefined): boolean {
+  public _canAccess(key: string | undefined): boolean {
     if (!key) return true;
 
-    const timeLastMovedOrCreated = this._records.get(key);
+    const timeLastMovedOrCreated = this._recordsMap.get(key);
     if (!timeLastMovedOrCreated) return true;
 
     return Date.now() - timeLastMovedOrCreated >= OP_REPO_POST_CREATE_DELAY;
   }
 
-  public isInMissingRetryWindow(key: string): boolean {
-    const timeLastMovedOrCreated = this._records.get(key);
+  public _isInMissingRetryWindow(key: string): boolean {
+    const timeLastMovedOrCreated = this._recordsMap.get(key);
     if (!timeLastMovedOrCreated) return false;
 
     return (

--- a/src/core/operationRepo/OperationRepo.test.ts
+++ b/src/core/operationRepo/OperationRepo.test.ts
@@ -26,7 +26,6 @@ vi.spyOn(Log, 'error').mockImplementation((msg) => {
     return '';
   return msg;
 });
-const debugSpy = vi.spyOn(Log, 'debug');
 
 vi.useFakeTimers();
 
@@ -500,30 +499,6 @@ describe('OperationRepo', () => {
       await vi.advanceTimersByTimeAsync(OP_REPO_EXECUTION_INTERVAL);
       expect(executeOperationsSpy).toHaveBeenCalledTimes(2);
     });
-  });
-
-  test('should not execute operations if consent is not given', async () => {
-    isConsentRequired.mockReturnValue(true);
-    setConsentRequired(true);
-
-    opRepo.enqueue(mockOperation);
-    await executeOps(opRepo);
-
-    await vi.waitUntil(() => opRepo._timerID === undefined);
-    expect(debugSpy).toHaveBeenCalledWith(
-      'Consent not given; not executing operations',
-    );
-
-    // operation did not execute
-    expect(opRepo.queue).toEqual([
-      {
-        operation: mockOperation,
-        bucket: 0,
-        retries: 0,
-      },
-    ]);
-
-    await db.clear('operations');
   });
 });
 

--- a/src/core/operationRepo/OperationRepo.ts
+++ b/src/core/operationRepo/OperationRepo.ts
@@ -48,65 +48,65 @@ export class OperationQueueItem {
 
 // OperationRepo Class
 export class OperationRepo implements IOperationRepo, IStartableService {
-  private executorsMap: Map<string, IOperationExecutor>;
+  private _executorsMap: Map<string, IOperationExecutor>;
   public queue: OperationQueueItem[] = [];
-  public timerID: NodeJS.Timeout | undefined = undefined;
-  private enqueueIntoBucket = 0;
-  private operationModelStore: OperationModelStore;
-  private newRecordState: NewRecordsState;
+  public _timerID: NodeJS.Timeout | undefined = undefined;
+  private _enqueueIntoBucket = 0;
+  private _operationModelStore: OperationModelStore;
+  private _newRecordState: NewRecordsState;
 
   constructor(
     executors: IOperationExecutor[],
     operationModelStore: OperationModelStore,
     newRecordState: NewRecordsState,
   ) {
-    this.operationModelStore = operationModelStore;
-    this.newRecordState = newRecordState;
+    this._operationModelStore = operationModelStore;
+    this._newRecordState = newRecordState;
 
-    this.executorsMap = new Map<string, IOperationExecutor>();
+    this._executorsMap = new Map<string, IOperationExecutor>();
     for (const executor of executors) {
       for (const operation of executor.operations) {
-        this.executorsMap.set(operation, executor);
+        this._executorsMap.set(operation, executor);
       }
     }
   }
 
-  public clear(): void {
+  public _clear(): void {
     this.queue = [];
   }
 
-  public get records(): Map<string, number> {
-    return this.newRecordState.records;
+  public get _records(): Map<string, number> {
+    return this._newRecordState._records;
   }
 
-  private get executeBucket(): number {
-    return this.enqueueIntoBucket === 0 ? 0 : this.enqueueIntoBucket - 1;
+  private get _executeBucket(): number {
+    return this._enqueueIntoBucket === 0 ? 0 : this._enqueueIntoBucket - 1;
   }
 
-  public containsInstanceOf<T extends Operation>(
+  public _containsInstanceOf<T extends Operation>(
     type: new (...args: any[]) => T,
   ): boolean {
     return this.queue.some((item) => item.operation instanceof type);
   }
 
-  public async start(): Promise<void> {
+  public async _start(): Promise<void> {
     await this._loadSavedOperations();
     this._processQueueForever();
   }
 
-  public pause(): void {
-    clearInterval(this.timerID);
-    this.timerID = undefined;
+  public _pause(): void {
+    clearInterval(this._timerID);
+    this._timerID = undefined;
     Log.debug('OperationRepo: Paused');
   }
 
   public enqueue(operation: Operation): void {
     Log.debug(`OperationRepo.enqueue(operation: ${operation})`);
 
-    this.internalEnqueue(
+    this._internalEnqueue(
       new OperationQueueItem({
         operation,
-        bucket: this.enqueueIntoBucket,
+        bucket: this._enqueueIntoBucket,
       }),
       true,
     );
@@ -116,10 +116,10 @@ export class OperationRepo implements IOperationRepo, IStartableService {
     Log.debug(`OperationRepo.enqueueAndWaitoperation: ${operation})`);
 
     await new Promise((resolve) => {
-      this.internalEnqueue(
+      this._internalEnqueue(
         new OperationQueueItem({
           operation,
-          bucket: this.enqueueIntoBucket,
+          bucket: this._enqueueIntoBucket,
           resolver: resolve,
         }),
         true,
@@ -127,7 +127,7 @@ export class OperationRepo implements IOperationRepo, IStartableService {
     });
   }
 
-  private internalEnqueue(
+  private _internalEnqueue(
     queueItem: OperationQueueItem,
     addToStore: boolean,
     index?: number,
@@ -149,31 +149,31 @@ export class OperationRepo implements IOperationRepo, IStartableService {
     }
 
     if (addToStore) {
-      this.operationModelStore.add(queueItem.operation);
+      this._operationModelStore.add(queueItem.operation);
     }
   }
 
   private async _processQueueForever(): Promise<void> {
-    this.enqueueIntoBucket++;
+    this._enqueueIntoBucket++;
     let runningOps = false;
 
     if (isConsentRequired()) {
-      this.pause();
+      this._pause();
       Log.debug('Consent not given; not executing operations');
       return;
     }
 
-    this.timerID = setInterval(async () => {
+    this._timerID = setInterval(async () => {
       if (runningOps) return Log.debug('Operations in progress');
 
-      const ops = this._getNextOps(this.executeBucket);
+      const ops = this._getNextOps(this._executeBucket);
 
       if (ops) {
         runningOps = true;
         await this._executeOperations(ops);
         runningOps = false;
       } else {
-        this.enqueueIntoBucket++;
+        this._enqueueIntoBucket++;
       }
     }, OP_REPO_EXECUTION_INTERVAL);
   }
@@ -181,7 +181,7 @@ export class OperationRepo implements IOperationRepo, IStartableService {
   public async _executeOperations(ops: OperationQueueItem[]): Promise<void> {
     try {
       const startingOp = ops[0];
-      const executor = this.executorsMap.get(startingOp.operation.name);
+      const executor = this._executorsMap.get(startingOp.operation.name);
 
       if (!executor) {
         throw new Error(
@@ -203,7 +203,7 @@ export class OperationRepo implements IOperationRepo, IStartableService {
         );
 
         Object.values(idTranslations).forEach((id) =>
-          this.newRecordState.add(id),
+          this._newRecordState._add(id),
         );
       }
 
@@ -212,7 +212,7 @@ export class OperationRepo implements IOperationRepo, IStartableService {
         case ExecutionResult.SUCCESS:
           // Remove operations from store
           ops.forEach((op) => {
-            this.operationModelStore.remove(op.operation.modelId);
+            this._operationModelStore.remove(op.operation.modelId);
           });
           ops.forEach((op) => op.resolver?.(true));
           break;
@@ -222,14 +222,14 @@ export class OperationRepo implements IOperationRepo, IStartableService {
         case ExecutionResult.FAIL_CONFLICT:
           Log.error(`Operation execution failed without retry: ${operations}`);
           ops.forEach((op) => {
-            this.operationModelStore.remove(op.operation.modelId);
+            this._operationModelStore.remove(op.operation.modelId);
           });
           ops.forEach((op) => op.resolver?.(false));
           break;
 
         case ExecutionResult.SUCCESS_STARTING_ONLY:
           // Remove starting operation and re-add others to the queue
-          this.operationModelStore.remove(startingOp.operation.modelId);
+          this._operationModelStore.remove(startingOp.operation.modelId);
 
           startingOp.resolver?.(true);
           ops
@@ -255,7 +255,7 @@ export class OperationRepo implements IOperationRepo, IStartableService {
           Log.error(
             `Operation execution failed with eventual retry, pausing the operation repo: ${operations}`,
           );
-          this.pause();
+          this._pause();
           ops.toReversed().forEach((op) => {
             removeOpFromDB(op.operation);
             this.queue.unshift(op);
@@ -271,7 +271,7 @@ export class OperationRepo implements IOperationRepo, IStartableService {
             bucket: 0,
           });
           this.queue.unshift(queueItem);
-          this.operationModelStore.addAt(0, queueItem.operation);
+          this._operationModelStore.addAt(0, queueItem.operation);
         }
       }
 
@@ -288,7 +288,7 @@ export class OperationRepo implements IOperationRepo, IStartableService {
 
       // On failure remove operations from store
       ops.forEach((op) => {
-        this.operationModelStore.remove(op.operation.modelId);
+        this._operationModelStore.remove(op.operation.modelId);
       });
       ops.forEach((op) => op.resolver?.(false));
     }
@@ -313,7 +313,7 @@ export class OperationRepo implements IOperationRepo, IStartableService {
     const startingOpIndex = this.queue.findIndex(
       (item) =>
         item.operation.canStartExecute &&
-        this.newRecordState.canAccess(item.operation.applyToRecordId) &&
+        this._newRecordState._canAccess(item.operation.applyToRecordId) &&
         item.bucket <= bucketFilter,
     );
 
@@ -351,7 +351,7 @@ export class OperationRepo implements IOperationRepo, IStartableService {
       if (itemKey === '' && startingKey === '')
         throw new Error('Both comparison keys cannot be blank!');
 
-      if (!this.newRecordState.canAccess(item.operation.applyToRecordId))
+      if (!this._newRecordState._canAccess(item.operation.applyToRecordId))
         continue;
 
       if (itemKey === startingKey) {
@@ -367,14 +367,14 @@ export class OperationRepo implements IOperationRepo, IStartableService {
   }
 
   public async _loadSavedOperations(): Promise<void> {
-    await this.operationModelStore.loadOperations();
-    const operations = this.operationModelStore.list().toReversed();
+    await this._operationModelStore.loadOperations();
+    const operations = this._operationModelStore.list().toReversed();
 
     for (const operation of operations) {
-      this.internalEnqueue(
+      this._internalEnqueue(
         new OperationQueueItem({
           operation,
-          bucket: this.enqueueIntoBucket,
+          bucket: this._enqueueIntoBucket,
         }),
         false,
         0,

--- a/src/core/operationRepo/OperationRepo.ts
+++ b/src/core/operationRepo/OperationRepo.ts
@@ -5,7 +5,6 @@ import {
   type IStartableService,
 } from 'src/core/types/operation';
 import { db } from 'src/shared/database/client';
-import { isConsentRequired } from 'src/shared/database/config';
 import { delay } from 'src/shared/helpers/general';
 import Log from 'src/shared/libraries/Log';
 import { type OperationModelStore } from '../modelRepo/OperationModelStore';
@@ -156,12 +155,6 @@ export class OperationRepo implements IOperationRepo, IStartableService {
   private async _processQueueForever(): Promise<void> {
     this._enqueueIntoBucket++;
     let runningOps = false;
-
-    if (isConsentRequired()) {
-      this._pause();
-      Log.debug('Consent not given; not executing operations');
-      return;
-    }
 
     this._timerID = setInterval(async () => {
       if (runningOps) return Log.debug('Operations in progress');

--- a/src/core/types/operation.ts
+++ b/src/core/types/operation.ts
@@ -54,11 +54,11 @@ export interface IOperationExecutor {
 
 export interface IOperationRepo {
   enqueue(operation: Operation, flush?: boolean): void;
-  containsInstanceOf<T extends Operation>(
+  _containsInstanceOf<T extends Operation>(
     type: new (...args: any[]) => T,
   ): boolean;
 }
 
 export interface IStartableService {
-  start(): void;
+  _start(): void;
 }

--- a/src/core/utils/typePredicates.ts
+++ b/src/core/utils/typePredicates.ts
@@ -1,18 +1,3 @@
-import { IdentityModel } from '../models/IdentityModel';
-
-export function isIdentityObject(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  obj?: any,
-): obj is IdentityModel {
-  return obj?.onesignal_id !== undefined;
-}
-
-export function isFutureSubscriptionObject(obj: {
-  type?: string;
-}): obj is { type: string } {
-  return obj?.type !== undefined;
-}
-
 export function isCompleteSubscriptionObject(obj?: {
   type?: string;
   id?: string;

--- a/src/onesignal/NotificationsNamespace.test.ts
+++ b/src/onesignal/NotificationsNamespace.test.ts
@@ -4,44 +4,63 @@ import {
   EmptyArgumentError,
   WrongTypeArgumentError,
 } from 'src/shared/errors/common';
+import Log from 'src/shared/libraries/Log';
+import * as utils from 'src/shared/utils/utils';
 import NotificationsNamespace from './NotificationsNamespace';
 
-describe('NotificationsNamespace', () => {
+beforeEach(() => {
+  TestEnvironment.initialize();
+});
+
+test('should set the default url', async () => {
+  const notifications = new NotificationsNamespace();
+  await notifications.setDefaultUrl('https://test.com');
+
+  const appState = await getAppState();
+  expect(appState.defaultNotificationUrl).toBe('https://test.com');
+
+  await expect(notifications.setDefaultUrl(undefined)).rejects.toThrow(
+    EmptyArgumentError('url'),
+  );
+
+  // @ts-expect-error - testing throwing invalid type
+  await expect(notifications.setDefaultUrl(1)).rejects.toThrow(
+    WrongTypeArgumentError('url'),
+  );
+});
+
+test('should set the default title', async () => {
+  const notifications = new NotificationsNamespace();
+  await notifications.setDefaultTitle('My notification title');
+
+  const appState = await getAppState();
+  expect(appState.defaultNotificationTitle).toBe('My notification title');
+
+  // @ts-expect-error - testing throwing invalid type
+  await expect(notifications.setDefaultTitle(1)).rejects.toThrow(
+    WrongTypeArgumentError('title'),
+  );
+
+  await expect(notifications.setDefaultTitle(undefined)).rejects.toThrow(
+    EmptyArgumentError('title'),
+  );
+});
+
+const warnSpy = vi.spyOn(Log, 'warn');
+describe('Consent Required', () => {
   beforeEach(() => {
+    OneSignal.setConsentRequired(true);
     TestEnvironment.initialize();
   });
 
-  test('should set the default url', async () => {
+  test('should not show native prompt if consent is required but not given', async () => {
+    const initAndSupportedSpy = vi.spyOn(
+      utils,
+      'awaitOneSignalInitAndSupported',
+    );
     const notifications = new NotificationsNamespace();
-    await notifications.setDefaultUrl('https://test.com');
-
-    const appState = await getAppState();
-    expect(appState.defaultNotificationUrl).toBe('https://test.com');
-
-    await expect(notifications.setDefaultUrl(undefined)).rejects.toThrow(
-      EmptyArgumentError('url'),
-    );
-
-    // @ts-expect-error - testing throwing invalid type
-    await expect(notifications.setDefaultUrl(1)).rejects.toThrow(
-      WrongTypeArgumentError('url'),
-    );
-  });
-
-  test('should set the default title', async () => {
-    const notifications = new NotificationsNamespace();
-    await notifications.setDefaultTitle('My notification title');
-
-    const appState = await getAppState();
-    expect(appState.defaultNotificationTitle).toBe('My notification title');
-
-    // @ts-expect-error - testing throwing invalid type
-    await expect(notifications.setDefaultTitle(1)).rejects.toThrow(
-      WrongTypeArgumentError('title'),
-    );
-
-    await expect(notifications.setDefaultTitle(undefined)).rejects.toThrow(
-      EmptyArgumentError('title'),
-    );
+    await notifications.requestPermission();
+    expect(warnSpy).toHaveBeenCalledWith('Consent required but not given');
+    expect(initAndSupportedSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/onesignal/NotificationsNamespace.ts
+++ b/src/onesignal/NotificationsNamespace.ts
@@ -1,4 +1,8 @@
-import { getAppState, setAppState } from 'src/shared/database/config';
+import {
+  getAppState,
+  isConsentRequiredButNotGiven,
+  setAppState,
+} from 'src/shared/database/config';
 import {
   EmptyArgumentError,
   MalformedArgumentError,
@@ -115,6 +119,7 @@ export default class NotificationsNamespace extends EventListenerBase {
    * @PublicApi
    */
   async requestPermission(): Promise<void> {
+    if (isConsentRequiredButNotGiven()) return;
     await awaitOneSignalInitAndSupported();
     await OneSignal.context.promptsManager.internalShowNativePrompt();
   }

--- a/src/onesignal/OneSignal.test.ts
+++ b/src/onesignal/OneSignal.test.ts
@@ -58,10 +58,6 @@ import { RawPushSubscription } from 'src/shared/models/RawPushSubscription';
 mockPageStylesCss();
 
 describe('OneSignal', () => {
-  beforeAll(() => {
-    setConsentRequired(true);
-  });
-
   beforeEach(() => {
     TestEnvironment.initialize({
       initUserAndPushSubscription: true,
@@ -674,6 +670,8 @@ describe('OneSignal', () => {
         });
 
         test('login then accept web push permissions - it should make two user calls', async () => {
+          const { promise, resolve } = Promise.withResolvers();
+          OneSignal.emitter.on(OneSignal.EVENTS.SUBSCRIPTION_CHANGED, resolve);
           setGetUserResponse();
           setCreateUserResponse({
             onesignalId: ONESIGNAL_ID,
@@ -719,6 +717,7 @@ describe('OneSignal', () => {
             ...BASE_IDENTITY,
             subscriptions: [],
           });
+          await promise;
 
           // second call creates the subscription
           await vi.waitUntil(() => createUserFn.mock.calls.length === 2);

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -35,7 +35,6 @@ import { CoreModuleDirector } from '../core/CoreModuleDirector';
 import LoginManager from '../page/managers/LoginManager';
 import Context from '../page/models/Context';
 import type { OneSignalDeferredLoadedCallback } from '../page/models/OneSignalDeferredLoadedCallback';
-import TimedLocalStorage from '../page/modules/TimedLocalStorage';
 import MainHelper from '../shared/helpers/MainHelper';
 import Emitter from '../shared/libraries/Emitter';
 import Log from '../shared/libraries/Log';
@@ -236,9 +235,9 @@ export default class OneSignal {
     await db.put('Options', { key: 'userConsent', value: consent });
 
     if (consent) {
-      OneSignal.coreDirector.operationRepo.start();
+      OneSignal.coreDirector.operationRepo._start();
     } else {
-      OneSignal.coreDirector.operationRepo.pause();
+      OneSignal.coreDirector.operationRepo._pause();
     }
 
     if (consent && OneSignal.pendingInit) await OneSignal._delayedInit();
@@ -275,7 +274,6 @@ export default class OneSignal {
   static config: AppConfig | null = null;
   static _sessionInitAlreadyRunning = false;
   static _isNewVisitor = false;
-  static timedLocalStorage = TimedLocalStorage;
   static initialized = false;
   static _didLoadITILibrary = false;
   static notifyButton: Bell | null = null;

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -238,7 +238,7 @@ export default class OneSignal {
     if (consent) {
       OneSignal.coreDirector.operationRepo.start();
     } else {
-      OneSignal.coreDirector.operationRepo._pause();
+      OneSignal.coreDirector.operationRepo.pause();
     }
 
     if (consent && OneSignal.pendingInit) await OneSignal._delayedInit();

--- a/src/onesignal/SlidedownNamespace.test.ts
+++ b/src/onesignal/SlidedownNamespace.test.ts
@@ -1,0 +1,34 @@
+import { TestEnvironment } from '__test__/support/environment/TestEnvironment';
+import Log from 'src/shared/libraries/Log';
+import SlidedownNamespace from './SlidedownNamespace';
+
+const warnSpy = vi.spyOn(Log, 'warn');
+
+describe('Consent Required', () => {
+  beforeEach(() => {
+    TestEnvironment.initialize();
+    OneSignal.setConsentRequired(true);
+  });
+
+  test('should not show slidedown if consent is required but not given', async () => {
+    const slidedown = new SlidedownNamespace();
+    await slidedown.promptPush();
+    expect(warnSpy).toHaveBeenCalledWith('Consent required but not given');
+
+    warnSpy.mockClear();
+    await slidedown.promptPushCategories();
+    expect(warnSpy).toHaveBeenCalledWith('Consent required but not given');
+
+    warnSpy.mockClear();
+    await slidedown.promptSms();
+    expect(warnSpy).toHaveBeenCalledWith('Consent required but not given');
+
+    warnSpy.mockClear();
+    await slidedown.promptEmail();
+    expect(warnSpy).toHaveBeenCalledWith('Consent required but not given');
+
+    warnSpy.mockClear();
+    await slidedown.promptSmsAndEmail();
+    expect(warnSpy).toHaveBeenCalledWith('Consent required but not given');
+  });
+});

--- a/src/onesignal/SlidedownNamespace.ts
+++ b/src/onesignal/SlidedownNamespace.ts
@@ -1,8 +1,8 @@
+import { isConsentRequiredButNotGiven } from 'src/shared/database/config';
 import type { AutoPromptOptions } from '../page/managers/PromptsManager';
 import { EventListenerBase } from '../page/userModel/EventListenerBase';
 import { DelayedPromptType } from '../shared/prompts/constants';
 import { awaitOneSignalInitAndSupported } from '../shared/utils/utils';
-
 export default class SlidedownNamespace extends EventListenerBase {
   constructor() {
     super();
@@ -13,6 +13,7 @@ export default class SlidedownNamespace extends EventListenerBase {
    * @PublicApi
    */
   async promptPush(options?: AutoPromptOptions): Promise<void> {
+    if (isConsentRequiredButNotGiven()) return;
     await awaitOneSignalInitAndSupported();
     await OneSignal.context.promptsManager.internalShowParticularSlidedown(
       DelayedPromptType.Push,
@@ -21,6 +22,7 @@ export default class SlidedownNamespace extends EventListenerBase {
   }
 
   async promptPushCategories(options?: AutoPromptOptions): Promise<void> {
+    if (isConsentRequiredButNotGiven()) return;
     await awaitOneSignalInitAndSupported();
     const isPushEnabled =
       await OneSignal.context.subscriptionManager.isPushNotificationsEnabled();
@@ -31,6 +33,7 @@ export default class SlidedownNamespace extends EventListenerBase {
   }
 
   async promptSms(options?: AutoPromptOptions): Promise<void> {
+    if (isConsentRequiredButNotGiven()) return;
     await awaitOneSignalInitAndSupported();
     await OneSignal.context.promptsManager.internalShowSmsSlidedown({
       ...options,
@@ -38,6 +41,7 @@ export default class SlidedownNamespace extends EventListenerBase {
   }
 
   async promptEmail(options?: AutoPromptOptions): Promise<void> {
+    if (isConsentRequiredButNotGiven()) return;
     await awaitOneSignalInitAndSupported();
     await OneSignal.context.promptsManager.internalShowEmailSlidedown({
       ...options,
@@ -45,6 +49,7 @@ export default class SlidedownNamespace extends EventListenerBase {
   }
 
   async promptSmsAndEmail(options?: AutoPromptOptions): Promise<void> {
+    if (isConsentRequiredButNotGiven()) return;
     await awaitOneSignalInitAndSupported();
     await OneSignal.context.promptsManager.internalShowSmsAndEmailSlidedown({
       ...options,

--- a/src/onesignal/User.ts
+++ b/src/onesignal/User.ts
@@ -2,6 +2,7 @@ import { IdentityConstants } from 'src/core/constants';
 import { SubscriptionModel } from 'src/core/models/SubscriptionModel';
 import { LoginUserOperation } from 'src/core/operations/LoginUserOperation';
 import { ModelChangeTags } from 'src/core/types/models';
+import { isConsentRequiredButNotGiven } from 'src/shared/database/config';
 import {
   EmptyArgumentError,
   MalformedArgumentError,
@@ -90,6 +91,7 @@ export default class User {
   /* PUBLIC API METHODS */
   public addAlias(label: string, id: string): void {
     logMethodCall('addAlias', { label, id });
+    if (isConsentRequiredButNotGiven()) return;
 
     this.validateStringLabel(label, 'label');
     this.validateStringLabel(id, 'id');
@@ -99,6 +101,8 @@ export default class User {
 
   public addAliases(aliases: { [key: string]: string }): void {
     logMethodCall('addAliases', { aliases });
+    if (isConsentRequiredButNotGiven()) return;
+
     this.validateObject(aliases, 'aliases');
 
     for (const label of Object.keys(aliases)) {
@@ -111,11 +115,15 @@ export default class User {
 
   public removeAlias(label: string): void {
     logMethodCall('removeAlias', { label });
+    if (isConsentRequiredButNotGiven()) return;
+
     this.removeAliases([label]);
   }
 
   public removeAliases(aliases: string[]): void {
     logMethodCall('removeAliases', { aliases });
+    if (isConsentRequiredButNotGiven()) return;
+
     this.validateArray(aliases, 'aliases');
 
     const newAliases = Object.fromEntries(
@@ -126,6 +134,7 @@ export default class User {
 
   public addEmail(email: string): void {
     logMethodCall('addEmail', { email });
+    if (isConsentRequiredButNotGiven()) return;
 
     this.validateStringLabel(email, 'email');
 
@@ -139,6 +148,7 @@ export default class User {
 
   public addSms(sms: string): void {
     logMethodCall('addSms', { sms });
+    if (isConsentRequiredButNotGiven()) return;
 
     this.validateStringLabel(sms, 'sms');
 
@@ -150,6 +160,7 @@ export default class User {
 
   public removeEmail(email: string): void {
     logMethodCall('removeEmail', { email });
+    if (isConsentRequiredButNotGiven()) return;
 
     this.validateStringLabel(email, 'email');
 
@@ -165,6 +176,7 @@ export default class User {
 
   public removeSms(smsNumber: string): void {
     logMethodCall('removeSms', { smsNumber });
+    if (isConsentRequiredButNotGiven()) return;
 
     this.validateStringLabel(smsNumber, 'smsNumber');
 
@@ -178,6 +190,7 @@ export default class User {
 
   public addTag(key: string, value: string): void {
     logMethodCall('addTag', { key, value });
+    if (isConsentRequiredButNotGiven()) return;
 
     this.validateStringLabel(key, 'key');
     this.validateStringLabel(value, 'value');
@@ -186,12 +199,11 @@ export default class User {
   }
 
   public addTags(tags: { [key: string]: string }): void {
-    if (IDManager.isLocalId(this.onesignalId)) {
-      Log.warn('Call after login to sync tags');
-    }
-
     logMethodCall('addTags', { tags });
+    if (isConsentRequiredButNotGiven()) return;
 
+    if (IDManager.isLocalId(this.onesignalId))
+      Log.warn('Call after login to sync tags');
     this.validateObject(tags, 'tags');
 
     const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
@@ -201,6 +213,7 @@ export default class User {
 
   public removeTag(tagKey: string): void {
     logMethodCall('removeTag', { tagKey });
+    if (isConsentRequiredButNotGiven()) return;
 
     this.validateStringLabel(tagKey, 'tagKey');
 
@@ -209,6 +222,7 @@ export default class User {
 
   public removeTags(tagKeys: string[]): void {
     logMethodCall('removeTags', { tagKeys });
+    if (isConsentRequiredButNotGiven()) return;
 
     this.validateArray(tagKeys, 'tagKeys');
 

--- a/src/onesignal/UserNamespace.ts
+++ b/src/onesignal/UserNamespace.ts
@@ -1,3 +1,4 @@
+import { isConsentRequiredButNotGiven } from 'src/shared/database/config';
 import type { UserChangeEvent } from '../page/models/UserChangeEvent';
 import { EventListenerBase } from '../page/userModel/EventListenerBase';
 import Emitter from '../shared/libraries/Emitter';
@@ -92,6 +93,7 @@ export default class UserNamespace extends EventListenerBase {
   }
 
   public setLanguage(language: string): void {
+    if (isConsentRequiredButNotGiven()) return;
     this._currentUser?.setLanguage(language);
   }
 

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -3,6 +3,7 @@ import { LoginUserOperation } from 'src/core/operations/LoginUserOperation';
 import { TransferSubscriptionOperation } from 'src/core/operations/TransferSubscriptionOperation';
 import { ModelChangeTags } from 'src/core/types/models';
 import { db } from 'src/shared/database/client';
+import { isConsentRequired } from 'src/shared/database/config';
 import MainHelper from 'src/shared/helpers/MainHelper';
 import { IDManager } from 'src/shared/managers/IDManager';
 import UserDirector from '../../onesignal/UserDirector';
@@ -23,6 +24,8 @@ export default class LoginManager {
     if (token) {
       db.put('Ids', { id: token, type: 'jwtToken' });
     }
+
+    if (isConsentRequired()) return;
 
     let identityModel = OneSignal.coreDirector.getIdentityModel();
     const currentOneSignalId = !IDManager.isLocalId(identityModel.onesignalId)

--- a/src/page/managers/slidedownManager/SlidedownManager.test.ts
+++ b/src/page/managers/slidedownManager/SlidedownManager.test.ts
@@ -9,7 +9,9 @@ import {
   setupIdentityModel,
   setupLoadStylesheet,
 } from '__test__/support/helpers/setup';
+import { SlidedownManager } from 'src/page/managers/slidedownManager/SlidedownManager';
 import ChannelCaptureContainer from 'src/page/slidedown/ChannelCaptureContainer';
+import Log from 'src/shared/libraries/Log';
 import { IDManager } from 'src/shared/managers/IDManager';
 import { DelayedPromptType } from 'src/shared/prompts/constants';
 import { SubscriptionType } from 'src/shared/subscriptions/constants';
@@ -26,104 +28,120 @@ beforeEach(() => {
   mockPhoneLibraryLoading();
 });
 
-test('can show email slidedown', async () => {
-  const addEmailSpy = vi.spyOn(OneSignal.User, 'addEmail');
-  setCreateUserResponse();
-  await OneSignal.Slidedown.promptEmail();
+describe('Slidedown Types', () => {
+  test('can show email slidedown', async () => {
+    const addEmailSpy = vi.spyOn(OneSignal.User, 'addEmail');
+    setCreateUserResponse();
+    await OneSignal.Slidedown.promptEmail();
 
-  expect(getMessageText()).toBe(message);
+    expect(getMessageText()).toBe(message);
 
-  const submitButton = getSubmitButton();
-  const emailInput = getEmailInput();
+    const submitButton = getSubmitButton();
+    const emailInput = getEmailInput();
 
-  // should validate empty email
-  expect(getEmailValidationMessage()).toBe('Please enter a valid email');
-  expect(addEmailSpy).not.toHaveBeenCalled();
+    // should validate empty email
+    expect(getEmailValidationMessage()).toBe('Please enter a valid email');
+    expect(addEmailSpy).not.toHaveBeenCalled();
 
-  // can add email subscription
-  emailInput.value = 'test@test.com';
-  submitButton.click();
+    // can add email subscription
+    emailInput.value = 'test@test.com';
+    submitButton.click();
 
-  expect(addEmailSpy).toHaveBeenCalled();
-  await vi.waitUntil(() => createUserFn.mock.calls.length > 0);
-  expect(createUserFn).toHaveBeenCalledWith({
-    identity: {},
-    ...BASE_IDENTITY,
-    subscriptions: [
-      {
-        ...BASE_SUB,
-        token: 'test@test.com',
-        type: SubscriptionType.Email,
-      },
-    ],
+    expect(addEmailSpy).toHaveBeenCalled();
+    await vi.waitUntil(() => createUserFn.mock.calls.length > 0);
+    expect(createUserFn).toHaveBeenCalledWith({
+      identity: {},
+      ...BASE_IDENTITY,
+      subscriptions: [
+        {
+          ...BASE_SUB,
+          token: 'test@test.com',
+          type: SubscriptionType.Email,
+        },
+      ],
+    });
+  });
+
+  test('can show sms slidedown', async () => {
+    const addSmsSpy = vi.spyOn(OneSignal.User, 'addSms');
+    setCreateUserResponse();
+    await OneSignal.Slidedown.promptSms();
+
+    expect(getMessageText()).toBe(message);
+
+    const submitButton = getSubmitButton();
+    const smsInput = getSmsInput();
+
+    // has validation message
+    expect(getSmsValidationMessage()).toBe('Please enter a valid phone number');
+
+    // can add sms subscription
+    smsInput.value = '+11234567890';
+    submitButton.click();
+
+    expect(addSmsSpy).toHaveBeenCalled();
+    await vi.waitUntil(() => createUserFn.mock.calls.length > 0);
+    expect(createUserFn).toHaveBeenCalledWith({
+      identity: {},
+      ...BASE_IDENTITY,
+      subscriptions: [
+        {
+          ...BASE_SUB,
+          token: '+1234567890',
+          type: SubscriptionType.SMS,
+        },
+      ],
+    });
+  });
+
+  test('can add sms and email', async () => {
+    const addSmsSpy = vi.spyOn(OneSignal.User, 'addSms');
+    const addEmailSpy = vi.spyOn(OneSignal.User, 'addEmail');
+    setCreateUserResponse();
+    await OneSignal.Slidedown.promptSmsAndEmail();
+
+    const submitButton = getSubmitButton();
+    const smsInput = getSmsInput();
+    const emailInput = getEmailInput();
+
+    // can add sms and email subscription
+    smsInput.value = '+11234567890';
+    emailInput.value = 'test@test.com';
+    submitButton.click();
+
+    expect(addSmsSpy).toHaveBeenCalled();
+    expect(addEmailSpy).toHaveBeenCalled();
+    await vi.waitUntil(() => createUserFn.mock.calls.length > 0);
+    expect(createUserFn).toHaveBeenCalledWith({
+      identity: {},
+      ...BASE_IDENTITY,
+      subscriptions: [
+        {
+          ...BASE_SUB,
+          token: 'test@test.com',
+          type: SubscriptionType.Email,
+        },
+        {
+          ...BASE_SUB,
+          token: '+1234567890',
+          type: SubscriptionType.SMS,
+        },
+      ],
+    });
   });
 });
 
-test('can show sms slidedown', async () => {
-  const addSmsSpy = vi.spyOn(OneSignal.User, 'addSms');
-  setCreateUserResponse();
-  await OneSignal.Slidedown.promptSms();
-
-  expect(getMessageText()).toBe(message);
-
-  const submitButton = getSubmitButton();
-  const smsInput = getSmsInput();
-
-  // has validation message
-  expect(getSmsValidationMessage()).toBe('Please enter a valid phone number');
-
-  // can add sms subscription
-  smsInput.value = '+11234567890';
-  submitButton.click();
-
-  expect(addSmsSpy).toHaveBeenCalled();
-  await vi.waitUntil(() => createUserFn.mock.calls.length > 0);
-  expect(createUserFn).toHaveBeenCalledWith({
-    identity: {},
-    ...BASE_IDENTITY,
-    subscriptions: [
-      {
-        ...BASE_SUB,
-        token: '+1234567890',
-        type: SubscriptionType.SMS,
-      },
-    ],
+const warnSpy = vi.spyOn(Log, 'warn');
+describe('Consent Required', () => {
+  beforeEach(() => {
+    TestEnvironment.initialize();
+    OneSignal.setConsentRequired(true);
   });
-});
 
-test('can add sms and email', async () => {
-  const addSmsSpy = vi.spyOn(OneSignal.User, 'addSms');
-  const addEmailSpy = vi.spyOn(OneSignal.User, 'addEmail');
-  setCreateUserResponse();
-  await OneSignal.Slidedown.promptSmsAndEmail();
-
-  const submitButton = getSubmitButton();
-  const smsInput = getSmsInput();
-  const emailInput = getEmailInput();
-
-  // can add sms and email subscription
-  smsInput.value = '+11234567890';
-  emailInput.value = 'test@test.com';
-  submitButton.click();
-
-  expect(addSmsSpy).toHaveBeenCalled();
-  expect(addEmailSpy).toHaveBeenCalled();
-  await vi.waitUntil(() => createUserFn.mock.calls.length > 0);
-  expect(createUserFn).toHaveBeenCalledWith({
-    identity: {},
-    ...BASE_IDENTITY,
-    subscriptions: [
-      {
-        ...BASE_SUB,
-        token: 'test@test.com',
-        type: SubscriptionType.Email,
-      },
-      {
-        ...BASE_SUB,
-        token: '+1234567890',
-        type: SubscriptionType.SMS,
-      },
-    ],
+  test('should not show slidedown if consent is required but not given', async () => {
+    const slidedownManager = new SlidedownManager(OneSignal.context);
+    await slidedownManager.createSlidedown({});
+    expect(warnSpy).toHaveBeenCalledWith('Consent required but not given');
   });
 });
 

--- a/src/page/managers/slidedownManager/SlidedownManager.ts
+++ b/src/page/managers/slidedownManager/SlidedownManager.ts
@@ -3,6 +3,7 @@ import type {
   TagsObjectWithBoolean,
 } from 'src/page/tags/types';
 import type { ContextInterface } from 'src/shared/context/types';
+import { isConsentRequiredButNotGiven } from 'src/shared/database/config';
 import {
   ChannelCaptureError,
   ExistingChannelError,
@@ -435,6 +436,7 @@ export class SlidedownManager {
 
   public async createSlidedown(options: AutoPromptOptions): Promise<void> {
     logMethodCall('createSlidedown');
+    if (isConsentRequiredButNotGiven()) return;
     try {
       const showPrompt = await this.checkIfSlidedownShouldBeShown(options);
       if (!showPrompt) {

--- a/src/shared/config/types.ts
+++ b/src/shared/config/types.ts
@@ -66,8 +66,8 @@ export interface AppConfig {
 }
 
 export interface AppUserConfig {
-  [key: string]: any;
   appId?: string;
+  bell?: Partial<AppUserConfigNotifyButton>;
   autoRegister?: boolean;
   autoResubscribe?: boolean;
   path?: string;
@@ -84,6 +84,7 @@ export interface AppUserConfig {
   pageUrl?: string;
   outcomes?: OutcomesConfig;
   serviceWorkerOverrideForTypical?: boolean;
+  requiresUserPrivacyConsent?: boolean;
 }
 
 export interface AppUserConfigWelcomeNotification {

--- a/src/shared/database/client.test.ts
+++ b/src/shared/database/client.test.ts
@@ -14,9 +14,9 @@ beforeEach(async () => {
 
 describe('general', () => {
   const values: IndexedDBSchema['Options']['value'][] = [
-    { key: 'consentGiven', value: true },
     { key: 'defaultIcon', value: 'icon' },
     { key: 'defaultTitle', value: 'title' },
+    { key: 'userConsent', value: true },
   ];
 
   test('should set _isNewVisitor to true if OneSignal is defined', async () => {
@@ -34,9 +34,9 @@ describe('general', () => {
       await db.put('Options', value);
     }
 
-    const retrievedValue = await db.get('Options', 'consentGiven');
+    const retrievedValue = await db.get('Options', 'userConsent');
     expect(retrievedValue).toEqual({
-      key: 'consentGiven',
+      key: 'userConsent',
       value: true,
     });
 
@@ -46,18 +46,18 @@ describe('general', () => {
 
   test('can set/update a value', async () => {
     const db = await getDb();
-    await db.put('Options', { key: 'consentGiven', value: 'optionsValue' });
-    const retrievedValue = await db.get('Options', 'consentGiven');
+    await db.put('Options', { key: 'userConsent', value: 'optionsValue' });
+    const retrievedValue = await db.get('Options', 'userConsent');
     expect(retrievedValue).toEqual({
-      key: 'consentGiven',
+      key: 'userConsent',
       value: 'optionsValue',
     });
 
     // can update value
-    await db.put('Options', { key: 'consentGiven', value: 'optionsValue2' });
-    const retrievedValue2 = await db.get('Options', 'consentGiven');
+    await db.put('Options', { key: 'userConsent', value: 'optionsValue2' });
+    const retrievedValue2 = await db.get('Options', 'userConsent');
     expect(retrievedValue2).toEqual({
-      key: 'consentGiven',
+      key: 'userConsent',
       value: 'optionsValue2',
     });
 
@@ -76,8 +76,8 @@ describe('general', () => {
     }
 
     // can remove a single value
-    await db.delete('Options', 'consentGiven');
-    const retrievedValue = await db.get('Options', 'consentGiven');
+    await db.delete('Options', 'userConsent');
+    const retrievedValue = await db.get('Options', 'userConsent');
     expect(retrievedValue).toBeUndefined();
 
     // can remove remaining values

--- a/src/shared/database/config.ts
+++ b/src/shared/database/config.ts
@@ -1,4 +1,5 @@
 import { getConsentRequired } from '../helpers/localStorage';
+import Log from '../libraries/Log';
 import { AppState } from '../models/AppState';
 import { db, getIdsValue, getOptionsValue } from './client';
 
@@ -73,8 +74,12 @@ export const getConsentGiven = async () => {
   return (await getOptionsValue<boolean>('userConsent')) ?? false;
 };
 
-export const isConsentRequired = () => {
+export const isConsentRequiredButNotGiven = () => {
   const consentRequired = getConsentRequired();
   const consentGiven = OneSignal._consentGiven;
-  return consentRequired && !consentGiven;
+
+  const requiredButNotGiven = consentRequired && !consentGiven;
+  if (requiredButNotGiven) Log.warn('Consent required but not given');
+
+  return requiredButNotGiven;
 };

--- a/src/shared/database/config.ts
+++ b/src/shared/database/config.ts
@@ -68,5 +68,5 @@ export const setAppState = async (appState: AppState) => {
 };
 
 export const getConsentGiven = async () => {
-  return await getOptionsValue<boolean>('consentGiven');
+  return await getOptionsValue<boolean>('userConsent');
 };

--- a/src/shared/database/config.ts
+++ b/src/shared/database/config.ts
@@ -1,3 +1,4 @@
+import { getConsentRequired } from '../helpers/localStorage';
 import { AppState } from '../models/AppState';
 import { db, getIdsValue, getOptionsValue } from './client';
 
@@ -67,6 +68,13 @@ export const setAppState = async (appState: AppState) => {
     });
 };
 
+// make sure to also set OneSignal._consentGiven when updating 'userConsent'
 export const getConsentGiven = async () => {
-  return await getOptionsValue<boolean>('userConsent');
+  return (await getOptionsValue<boolean>('userConsent')) ?? false;
+};
+
+export const isConsentRequired = () => {
+  const consentRequired = getConsentRequired();
+  const consentGiven = OneSignal._consentGiven;
+  return consentRequired && !consentGiven;
 };

--- a/src/shared/database/types.ts
+++ b/src/shared/database/types.ts
@@ -12,7 +12,6 @@ export type IdKey = 'appId' | 'registrationId' | 'userId' | 'jwtToken';
 
 export type OptionKey =
   | 'appState'
-  | 'consentGiven'
   | 'defaultIcon'
   | 'defaultTitle'
   | 'defaultUrl'

--- a/src/shared/helpers/localStorage.ts
+++ b/src/shared/helpers/localStorage.ts
@@ -17,7 +17,12 @@ export function setConsentRequired(value: boolean): void {
 }
 
 export function getConsentRequired(): boolean {
-  return localStorage.getItem(REQUIRES_PRIVACY_CONSENT) === 'true';
+  const requiresUserPrivacyConsent =
+    OneSignal.config?.userConfig.requiresUserPrivacyConsent ?? false;
+  return (
+    localStorage.getItem(REQUIRES_PRIVACY_CONSENT) === 'true' ||
+    requiresUserPrivacyConsent
+  );
 }
 
 export function setLocalPageViewCount(count: number): void {


### PR DESCRIPTION
# Description
## 1 Line Summary
Addresses: https://app.asana.com/1/780103692902078/project/1198177413178126/task/1211152956512052?focus=true
- move consent logic out of login operation executor and move it to operation repo

## Details
Current erorr:
<img width="543" height="460" alt="Screenshot 2025-08-27 at 12 16 03 PM" src="https://github.com/user-attachments/assets/21b285be-982c-4ff6-bdf1-0fe37d8f8645" />

- Currently if the developer sets consent required to true but user never gives consent. The display notification is still shown (but subscription is never created. Additionally the Login Operation executor throws an error. 

Changes:
- Updates default test context to not have prompts manager autoprompt to not trigger operations like login
- Adds new `isConsentRequiredButNotGiven` helper to check against consent required and consent given flags.
- Adds new prop `OneSignal._consentGiven` which is loaded in init . This is needed since we dont we to add delay for the login call and don want to make actions like addTags async.
- Removes 'consentGiven' from db schema as this was a typo when it shouldve been 'userConsent'
- Add isConsentRequiredButNotGiven checks to `addTag`, `addTags`, `addEmail`, `addSms`, etc.
- Adds user config check `requiresUserPrivacyConsent` to `getConsentRequired` call.

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1363)
<!-- Reviewable:end -->
