### PR TITLE
Fix Categories Tags

### DIFF
--- a/__test__/support/environment/TestEnvironment.ts
+++ b/__test__/support/environment/TestEnvironment.ts
@@ -6,11 +6,12 @@ import type {
   ServerAppConfig,
 } from 'src/shared/config/types';
 import type { RecursivePartial } from 'src/shared/context/types';
-import { updateIdentityModel } from '../helpers/setup';
+import { updateIdentityModel, updatePropertiesModel } from '../helpers/setup';
 import { initOSGlobals, stubNotification } from './TestEnvironmentHelpers';
 
 export interface TestEnvironmentConfig {
   userConfig?: AppUserConfig;
+  initOneSignalId?: boolean;
   initUserAndPushSubscription?: boolean; // default: false - initializes User & PushSubscription in UserNamespace (e.g. creates an anonymous user)
   permission?: NotificationPermission;
   addPrompts?: boolean;
@@ -24,12 +25,19 @@ Object.defineProperty(document, 'readyState', {
 });
 
 export class TestEnvironment {
-  static initialize(config: TestEnvironmentConfig = {}) {
+  static initialize(
+    config: TestEnvironmentConfig = {
+      initOneSignalId: true,
+    },
+  ) {
     mockJsonp();
     const oneSignal = initOSGlobals(config);
     OneSignal.coreDirector.operationRepo.queue = [];
 
-    updateIdentityModel('onesignal_id', ONESIGNAL_ID);
+    if (config.initOneSignalId) {
+      updateIdentityModel('onesignal_id', ONESIGNAL_ID);
+      updatePropertiesModel('onesignalId', ONESIGNAL_ID);
+    }
 
     // Set URL if provided
     if (config.url) {

--- a/__test__/support/environment/TestEnvironmentHelpers.ts
+++ b/__test__/support/environment/TestEnvironmentHelpers.ts
@@ -7,6 +7,7 @@ import { CoreModuleDirector } from '../../../src/core/CoreModuleDirector';
 import NotificationsNamespace from '../../../src/onesignal/NotificationsNamespace';
 import OneSignal from '../../../src/onesignal/OneSignal';
 import { ONESIGNAL_EVENTS } from '../../../src/onesignal/OneSignalEvents';
+import User from '../../../src/onesignal/User';
 import UserNamespace from '../../../src/onesignal/UserNamespace';
 import Context from '../../../src/page/models/Context';
 import Emitter from '../../../src/shared/libraries/Emitter';
@@ -26,9 +27,12 @@ export function initOSGlobals(config: TestEnvironmentConfig = {}) {
   global.OneSignal.emitter = new Emitter();
   const core = new CoreModule();
   global.OneSignal.coreDirector = new CoreModuleDirector(core);
-  global.OneSignal.User = new UserNamespace(
-    !!config.initUserAndPushSubscription,
-  ); // TO DO: pass in subscription, and permission
+
+  // Clear the User singleton before creating new instance
+  User.singletonInstance = undefined;
+
+  const userNamespace = new UserNamespace(!!config.initUserAndPushSubscription); // TO DO: pass in subscription, and permission
+  global.OneSignal.User = userNamespace;
   global.OneSignal.Notifications = new NotificationsNamespace(
     config.permission,
   );

--- a/__test__/support/helpers/setup.ts
+++ b/__test__/support/helpers/setup.ts
@@ -1,4 +1,4 @@
-import { ONESIGNAL_ID } from '__test__/constants';
+import { ONESIGNAL_ID, PUSH_TOKEN } from '__test__/constants';
 import { IdentityModel } from 'src/core/models/IdentityModel';
 import { PropertiesModel } from 'src/core/models/PropertiesModel';
 import { SubscriptionModel } from 'src/core/models/SubscriptionModel';
@@ -10,6 +10,7 @@ import type {
   PropertiesSchema,
   SubscriptionSchema,
 } from 'src/shared/database/types';
+import { RawPushSubscription } from 'src/shared/models/RawPushSubscription';
 
 export const setIsPushEnabled = async (isPushEnabled: boolean) => {
   await db.put('Options', { key: 'isPushEnabled', value: isPushEnabled });
@@ -139,4 +140,13 @@ export const setupLoadStylesheet = async () => {
     OneSignal.context.dynamicResourceLoader,
     'loadSdkStylesheet',
   ).mockResolvedValue(ResourceLoadState.Loaded);
+};
+
+export const getRawPushSubscription = () => {
+  const rawPushSubscription = new RawPushSubscription();
+  rawPushSubscription.w3cEndpoint = new URL(PUSH_TOKEN);
+  rawPushSubscription.w3cP256dh = 'w3cP256dh';
+  rawPushSubscription.w3cAuth = 'w3cAuth';
+  rawPushSubscription.safariDeviceToken = 'safariDeviceToken';
+  return rawPushSubscription;
 };

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "52.19 kB",
+      "limit": "52.18 kB",
       "gzip": true
     },
     {

--- a/src/core/listeners/PropertiesModelStoreListener.ts
+++ b/src/core/listeners/PropertiesModelStoreListener.ts
@@ -29,6 +29,7 @@ export class PropertiesModelStoreListener extends SingletonModelStoreListener<Pr
     newValue: unknown,
   ): Operation | null {
     const appId = MainHelper.getAppId();
+
     return new SetPropertyOperation(
       appId,
       model.onesignalId,

--- a/src/onesignal/OneSignal.test.ts
+++ b/src/onesignal/OneSignal.test.ts
@@ -36,6 +36,7 @@ import {
 import {
   getDbSubscriptions,
   getIdentityItem,
+  getRawPushSubscription,
   setupIdentityModel,
   setupPropertiesModel,
   updateIdentityModel,
@@ -52,7 +53,6 @@ import MainHelper from 'src/shared/helpers/MainHelper';
 import Log from 'src/shared/libraries/Log';
 import { IDManager } from 'src/shared/managers/IDManager';
 import { SubscriptionManagerPage } from 'src/shared/managers/subscription/page';
-import { RawPushSubscription } from 'src/shared/models/RawPushSubscription';
 
 mockPageStylesCss();
 
@@ -693,9 +693,8 @@ describe('OneSignal - No Consent Required', () => {
             ModelChangeTags.NO_PROPAGATE,
           );
           setPushToken('');
-          subscribeFcmFromPageSpy.mockImplementation(
-            // @ts-expect-error - subscribeFcmFromPage is a private method of SubscriptionManagerPage
-            async () => rawPushSubscription,
+          subscribeFcmFromPageSpy.mockImplementation(async () =>
+            getRawPushSubscription(),
           );
 
           // new/empty user
@@ -1074,9 +1073,8 @@ describe('OneSignal - No Consent Required', () => {
       const changeEvent = vi.fn();
       OneSignal.User.PushSubscription.addEventListener('change', changeEvent);
 
-      subscribeFcmFromPageSpy.mockImplementation(
-        // @ts-expect-error - subscribeFcmFromPage is a private method of SubscriptionManagerPage
-        async () => rawPushSubscription,
+      subscribeFcmFromPageSpy.mockImplementation(async () =>
+        getRawPushSubscription(),
       );
 
       // @ts-expect-error - Notification is not defined in the global scope
@@ -1195,18 +1193,11 @@ vi.spyOn(Log, 'error').mockImplementation(() => '');
 const debugSpy = vi.spyOn(Log, 'debug');
 const warnSpy = vi.spyOn(Log, 'warn');
 
-const rawPushSubscription = new RawPushSubscription();
-rawPushSubscription.w3cEndpoint = new URL(PUSH_TOKEN);
-rawPushSubscription.w3cP256dh = 'w3cP256dh';
-rawPushSubscription.w3cAuth = 'w3cAuth';
-rawPushSubscription.safariDeviceToken = 'safariDeviceToken';
-
 const getPropertiesItem = async () => (await db.getAll('properties'))[0];
 
 const subscribeFcmFromPageSpy = vi.spyOn(
   SubscriptionManagerPage.prototype,
-  // @ts-expect-error - subscribeFcmFromPage is a private method of SubscriptionManagerPage
-  'subscribeFcmFromPage',
+  '_subscribeFcmFromPage',
 );
 
 const showLocalNotificationSpy = vi.spyOn(MainHelper, 'showLocalNotification');

--- a/src/onesignal/User.ts
+++ b/src/onesignal/User.ts
@@ -31,10 +31,21 @@ export default class User {
     if (!User.singletonInstance) {
       User.singletonInstance = new User();
       const identityModel = OneSignal.coreDirector.getIdentityModel();
+      const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
+
+      const onesignalId =
+        identityModel.onesignalId ?? IDManager.createLocalId();
       if (!identityModel.onesignalId) {
-        const onesignalId = IDManager.createLocalId();
         identityModel.setProperty(
           IdentityConstants.ONESIGNAL_ID,
+          onesignalId,
+          ModelChangeTags.NO_PROPAGATE,
+        );
+      }
+
+      if (!propertiesModel.onesignalId) {
+        propertiesModel.setProperty(
+          'onesignalId',
           onesignalId,
           ModelChangeTags.NO_PROPAGATE,
         );

--- a/src/onesignal/User.ts
+++ b/src/onesignal/User.ts
@@ -210,7 +210,6 @@ export default class User {
   }
 
   public addTags(tags: { [key: string]: string }): void {
-    logMethodCall('addTags', { tags });
     if (isConsentRequiredButNotGiven()) return;
 
     if (IDManager.isLocalId(this.onesignalId))

--- a/src/onesignal/UserNamespace.test.ts
+++ b/src/onesignal/UserNamespace.test.ts
@@ -453,6 +453,7 @@ describe('Initialization', () => {
 
   test('properties model should have onesignalId for existing user', () => {
     // with an existing onesignalId
+    updateIdentityModel('onesignal_id', ONESIGNAL_ID);
     const user = new UserNamespace(true);
     expect(IDManager.isLocalId(user.onesignalId)).toBe(false);
 

--- a/src/onesignal/UserNamespace.test.ts
+++ b/src/onesignal/UserNamespace.test.ts
@@ -1,9 +1,10 @@
 import { ONESIGNAL_ID, PUSH_TOKEN } from '__test__/constants';
+import { TestEnvironment } from '__test__/support/environment/TestEnvironment';
 import { updateIdentityModel } from '__test__/support/helpers/setup';
+import { IdentityConstants } from 'src/core/constants';
 import { ModelChangeTags } from 'src/core/types/models';
 import Log from 'src/shared/libraries/Log';
 import { IDManager } from 'src/shared/managers/IDManager';
-import { TestEnvironment } from '../../__test__/support/environment/TestEnvironment';
 import type { UserChangeEvent } from '../page/models/UserChangeEvent';
 import { Subscription } from '../shared/models/Subscription';
 import User from './User';
@@ -13,542 +14,589 @@ const errorSpy = vi.spyOn(Log, 'error').mockImplementation(() => '');
 const warnSpy = vi.spyOn(Log, 'warn').mockImplementation(() => '');
 vi.useFakeTimers();
 
-describe('UserNamespace', () => {
-  let userNamespace: UserNamespace;
+const setup = () => {
+  TestEnvironment.initialize({});
+  delete User.singletonInstance;
+};
 
-  beforeEach(() => {
-    TestEnvironment.initialize({});
+setup();
+beforeEach(() => {
+  setup();
+});
 
-    userNamespace = new UserNamespace(true);
+describe('User Identity Properties', () => {
+  test('should return correct onesignalId', () => {
+    const userNamespace = new UserNamespace(true);
+
+    updateIdentityModel('onesignal_id', undefined);
+    expect(userNamespace.onesignalId).toBe(undefined);
+
+    const localId = IDManager.createLocalId();
+    updateIdentityModel('onesignal_id', localId);
+    expect(userNamespace.onesignalId).toBe(localId);
+
+    updateIdentityModel('onesignal_id', ONESIGNAL_ID);
+    expect(userNamespace.onesignalId).toBe(ONESIGNAL_ID);
   });
 
-  describe('User Identity Properties', () => {
-    test('should return correct onesignalId', () => {
-      userNamespace = new UserNamespace(true);
+  test('should return correct externalId', () => {
+    const userNamespace = new UserNamespace(true);
+    const externalId = 'some-external-id';
+    updateIdentityModel('external_id', externalId);
 
-      updateIdentityModel('onesignal_id', undefined);
-      expect(userNamespace.onesignalId).toBe(undefined);
+    expect(userNamespace.externalId).toBe(externalId);
+  });
+});
 
-      const localId = IDManager.createLocalId();
-      updateIdentityModel('onesignal_id', localId);
-      expect(userNamespace.onesignalId).toBe(localId);
+describe('Alias Management', () => {
+  test('can add a single alias', () => {
+    const userNamespace = new UserNamespace(true);
+    const label = 'some-label';
+    const id = 'some-id';
 
-      updateIdentityModel('onesignal_id', ONESIGNAL_ID);
-      expect(userNamespace.onesignalId).toBe(ONESIGNAL_ID);
-    });
+    userNamespace.addAlias(label, id);
 
-    test('should return correct externalId', () => {
-      const externalId = 'some-external-id';
-      updateIdentityModel('external_id', externalId);
-
-      expect(userNamespace.externalId).toBe(externalId);
-    });
+    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    expect(identityModel.getProperty(label)).toBe(id);
   });
 
-  describe('Alias Management', () => {
-    test('can add a single alias', () => {
-      const label = 'some-label';
-      const id = 'some-id';
-
-      userNamespace.addAlias(label, id);
-
-      const identityModel = OneSignal.coreDirector.getIdentityModel();
-      expect(identityModel.getProperty(label)).toBe(id);
-    });
-
-    test('can add multiple aliases', () => {
-      const aliases = {
-        someLabel: 'some-id',
-        anotherLabel: 'another-id',
-      };
-
-      userNamespace.addAliases(aliases);
-
-      const identityModel = OneSignal.coreDirector.getIdentityModel();
-      expect(identityModel.getProperty('someLabel')).toBe(aliases.someLabel);
-      expect(identityModel.getProperty('anotherLabel')).toBe(
-        aliases.anotherLabel,
-      );
-    });
-
-    test('can remove a single alias', () => {
-      const label = 'some-label';
-      const id = 'some-id';
-      const identityModel = OneSignal.coreDirector.getIdentityModel();
-
-      // First add the alias
-      userNamespace.addAlias(label, id);
-      expect(identityModel.getProperty(label)).toBe(id);
-
-      // Then remove it
-      userNamespace.removeAlias(label);
-
-      expect(identityModel.getProperty(label)).toBeUndefined();
-    });
-
-    test('can remove multiple aliases', () => {
-      const aliases = {
-        someLabel: 'some-id',
-        anotherLabel: 'another-id',
-      };
-      const identityModel = OneSignal.coreDirector.getIdentityModel();
-
-      // First add the aliases
-      userNamespace.addAliases(aliases);
-      expect(identityModel.getProperty('someLabel')).toBe(aliases.someLabel);
-      expect(identityModel.getProperty('anotherLabel')).toBe(
-        aliases.anotherLabel,
-      );
-
-      // Then remove them
-      userNamespace.removeAliases(Object.keys(aliases));
-
-      expect(identityModel.getProperty('someLabel')).toBeUndefined();
-      expect(identityModel.getProperty('anotherLabel')).toBeUndefined();
-    });
-
-    test('can validate add aliases', () => {
-      // wrong types
-      // @ts-expect-error - mock invalid argument
-      expect(() => userNamespace.addAlias(1234, '5678')).toThrowError(
-        '"label" is the wrong type',
-      );
-      // @ts-expect-error - mock invalid argument
-      expect(() => userNamespace.addAlias('some-label', 1234)).toThrowError(
-        '"id" is the wrong type',
-      );
-      // @ts-expect-error - mock invalid argument
-      expect(() => userNamespace.addAliases(['some-label'])).toThrowError(
-        '"aliases" is the wrong type',
-      );
-      expect(() =>
-        userNamespace.addAliases({
-          // @ts-expect-error - mock invalid argument
-          'some-label': 1234,
-        }),
-      ).toThrowError('"key: some-label" is the wrong type');
-
-      // empty values
-      expect(() => userNamespace.addAliases({})).toThrowError(
-        '"aliases" is empty',
-      );
-      expect(() => userNamespace.addAlias('', 'some-id')).toThrowError(
-        '"label" is empty',
-      );
-      expect(() => userNamespace.addAlias('some-label', '')).toThrowError(
-        '"id" is empty',
-      );
-
-      // reserved aliases
-      expect(() =>
-        userNamespace.addAlias('external_id', 'some-id'),
-      ).toThrowError('"external_id" is reserved');
-      expect(() =>
-        userNamespace.addAlias('onesignal_id', 'some-id'),
-      ).toThrowError('"onesignal_id" is reserved');
-      expect(() =>
-        userNamespace.addAliases({
-          external_id: 'some-id',
-        }),
-      ).toThrowError('"external_id" is reserved');
-      expect(() =>
-        userNamespace.addAliases({
-          onesignal_id: 'some-id',
-        }),
-      ).toThrowError('"onesignal_id" is reserved');
-    });
-
-    test('can validate remove aliases', () => {
-      // wrong types
-      // @ts-expect-error - mock invalid argument
-      expect(() => userNamespace.removeAliases(1234)).toThrowError(
-        '"aliases" is the wrong type',
-      );
-      // @ts-expect-error - mock invalid argument
-      expect(() => userNamespace.removeAlias(1234)).toThrowError(
-        '"label" is the wrong type',
-      );
-
-      // empty values
-      expect(() => userNamespace.removeAliases([])).toThrowError(
-        '"aliases" is empty',
-      );
-      expect(() => userNamespace.removeAlias('')).toThrowError(
-        '"label" is empty',
-      );
-    });
-  });
-
-  describe('Email Management', () => {
-    const getEmailSubscription = (email: string) => {
-      const subscriptionModels =
-        OneSignal.coreDirector.getEmailSubscriptionModels();
-      return subscriptionModels.find((model) => model.token === email);
+  test('can add multiple aliases', () => {
+    const userNamespace = new UserNamespace(true);
+    const aliases = {
+      someLabel: 'some-id',
+      anotherLabel: 'another-id',
     };
 
-    test('can add an email subscription', async () => {
-      const identityModel = OneSignal.coreDirector.getIdentityModel();
-      identityModel.onesignalId = IDManager.createLocalId();
+    userNamespace.addAliases(aliases);
 
-      const email = 'test@example.com';
-      const addSubscriptionSpy = vi.spyOn(
-        OneSignal.coreDirector,
-        'addSubscriptionModel',
-      );
-
-      await userNamespace.addEmail(email);
-
-      expect(addSubscriptionSpy).toHaveBeenCalled();
-      const subscription = getEmailSubscription(email);
-      expect(subscription).toBeDefined();
-      expect(subscription?.token).toBe(email);
-    });
-
-    test('should remove an email subscription', async () => {
-      const identityModel = OneSignal.coreDirector.getIdentityModel();
-      identityModel.onesignalId = IDManager.createLocalId();
-
-      const email = 'test@example.com';
-
-      // First add the email
-      await userNamespace.addEmail(email);
-      let subscription = getEmailSubscription(email);
-      expect(subscription).toBeDefined();
-
-      // Then remove it
-      const removeSubscriptionSpy = vi.spyOn(
-        OneSignal.coreDirector,
-        'removeSubscriptionModel',
-      );
-      userNamespace.removeEmail(email);
-
-      expect(removeSubscriptionSpy).toHaveBeenCalled();
-      subscription = getEmailSubscription(email);
-      expect(subscription).toBeUndefined();
-    });
+    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    expect(identityModel.getProperty('someLabel')).toBe(aliases.someLabel);
+    expect(identityModel.getProperty('anotherLabel')).toBe(
+      aliases.anotherLabel,
+    );
   });
 
-  describe('SMS Management', () => {
-    const getSmsSubscription = (smsNumber: string) => {
-      const subscriptionModels =
-        OneSignal.coreDirector.getSmsSubscriptionModels();
-      return subscriptionModels.find((model) => model.token === smsNumber);
+  test('can remove a single alias', () => {
+    const userNamespace = new UserNamespace(true);
+    const label = 'some-label';
+    const id = 'some-id';
+    const identityModel = OneSignal.coreDirector.getIdentityModel();
+
+    // First add the alias
+    userNamespace.addAlias(label, id);
+    expect(identityModel.getProperty(label)).toBe(id);
+
+    // Then remove it
+    userNamespace.removeAlias(label);
+
+    expect(identityModel.getProperty(label)).toBeUndefined();
+  });
+
+  test('can remove multiple aliases', () => {
+    const userNamespace = new UserNamespace(true);
+    const aliases = {
+      someLabel: 'some-id',
+      anotherLabel: 'another-id',
+    };
+    const identityModel = OneSignal.coreDirector.getIdentityModel();
+
+    // First add the aliases
+    userNamespace.addAliases(aliases);
+    expect(identityModel.getProperty('someLabel')).toBe(aliases.someLabel);
+    expect(identityModel.getProperty('anotherLabel')).toBe(
+      aliases.anotherLabel,
+    );
+
+    // Then remove them
+    userNamespace.removeAliases(Object.keys(aliases));
+
+    expect(identityModel.getProperty('someLabel')).toBeUndefined();
+    expect(identityModel.getProperty('anotherLabel')).toBeUndefined();
+  });
+
+  test('can validate add aliases', () => {
+    const userNamespace = new UserNamespace(true);
+    // wrong types
+    // @ts-expect-error - mock invalid argument
+    expect(() => userNamespace.addAlias(1234, '5678')).toThrowError(
+      '"label" is the wrong type',
+    );
+    // @ts-expect-error - mock invalid argument
+    expect(() => userNamespace.addAlias('some-label', 1234)).toThrowError(
+      '"id" is the wrong type',
+    );
+    // @ts-expect-error - mock invalid argument
+    expect(() => userNamespace.addAliases(['some-label'])).toThrowError(
+      '"aliases" is the wrong type',
+    );
+    expect(() =>
+      userNamespace.addAliases({
+        // @ts-expect-error - mock invalid argument
+        'some-label': 1234,
+      }),
+    ).toThrowError('"key: some-label" is the wrong type');
+
+    // empty values
+    expect(() => userNamespace.addAliases({})).toThrowError(
+      '"aliases" is empty',
+    );
+    expect(() => userNamespace.addAlias('', 'some-id')).toThrowError(
+      '"label" is empty',
+    );
+    expect(() => userNamespace.addAlias('some-label', '')).toThrowError(
+      '"id" is empty',
+    );
+
+    // reserved aliases
+    expect(() => userNamespace.addAlias('external_id', 'some-id')).toThrowError(
+      '"external_id" is reserved',
+    );
+    expect(() =>
+      userNamespace.addAlias('onesignal_id', 'some-id'),
+    ).toThrowError('"onesignal_id" is reserved');
+    expect(() =>
+      userNamespace.addAliases({
+        external_id: 'some-id',
+      }),
+    ).toThrowError('"external_id" is reserved');
+    expect(() =>
+      userNamespace.addAliases({
+        onesignal_id: 'some-id',
+      }),
+    ).toThrowError('"onesignal_id" is reserved');
+  });
+
+  test('can validate remove aliases', () => {
+    const userNamespace = new UserNamespace(true);
+    // wrong types
+    // @ts-expect-error - mock invalid argument
+    expect(() => userNamespace.removeAliases(1234)).toThrowError(
+      '"aliases" is the wrong type',
+    );
+    // @ts-expect-error - mock invalid argument
+    expect(() => userNamespace.removeAlias(1234)).toThrowError(
+      '"label" is the wrong type',
+    );
+
+    // empty values
+    expect(() => userNamespace.removeAliases([])).toThrowError(
+      '"aliases" is empty',
+    );
+    expect(() => userNamespace.removeAlias('')).toThrowError(
+      '"label" is empty',
+    );
+  });
+});
+
+describe('Email Management', () => {
+  const userNamespace = new UserNamespace(true);
+  const getEmailSubscription = (email: string) => {
+    const subscriptionModels =
+      OneSignal.coreDirector.getEmailSubscriptionModels();
+    return subscriptionModels.find((model) => model.token === email);
+  };
+
+  test('can add an email subscription', async () => {
+    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    identityModel.onesignalId = IDManager.createLocalId();
+
+    const email = 'test@example.com';
+    const addSubscriptionSpy = vi.spyOn(
+      OneSignal.coreDirector,
+      'addSubscriptionModel',
+    );
+
+    await userNamespace.addEmail(email);
+
+    expect(addSubscriptionSpy).toHaveBeenCalled();
+    const subscription = getEmailSubscription(email);
+    expect(subscription).toBeDefined();
+    expect(subscription?.token).toBe(email);
+  });
+
+  test('should remove an email subscription', async () => {
+    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    identityModel.onesignalId = IDManager.createLocalId();
+
+    const email = 'test@example.com';
+
+    // First add the email
+    await userNamespace.addEmail(email);
+    let subscription = getEmailSubscription(email);
+    expect(subscription).toBeDefined();
+
+    // Then remove it
+    const removeSubscriptionSpy = vi.spyOn(
+      OneSignal.coreDirector,
+      'removeSubscriptionModel',
+    );
+    userNamespace.removeEmail(email);
+
+    expect(removeSubscriptionSpy).toHaveBeenCalled();
+    subscription = getEmailSubscription(email);
+    expect(subscription).toBeUndefined();
+  });
+});
+
+describe('SMS Management', () => {
+  const getSmsSubscription = (smsNumber: string) => {
+    const subscriptionModels =
+      OneSignal.coreDirector.getSmsSubscriptionModels();
+    return subscriptionModels.find((model) => model.token === smsNumber);
+  };
+
+  test('should add an SMS subscription', async () => {
+    const userNamespace = new UserNamespace(true);
+    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    identityModel.onesignalId = IDManager.createLocalId();
+
+    const smsNumber = '+15551234567';
+    const addSubscriptionSpy = vi.spyOn(
+      OneSignal.coreDirector,
+      'addSubscriptionModel',
+    );
+
+    await userNamespace.addSms(smsNumber);
+
+    expect(addSubscriptionSpy).toHaveBeenCalled();
+    const subscription = getSmsSubscription(smsNumber);
+    expect(subscription).toBeDefined();
+    expect(subscription?.token).toBe(smsNumber);
+  });
+
+  test('should remove an SMS subscription', async () => {
+    const userNamespace = new UserNamespace(true);
+    const smsNumber = '+15551234567';
+
+    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    identityModel.onesignalId = IDManager.createLocalId();
+
+    // First add the SMS
+    await userNamespace.addSms(smsNumber);
+    let subscription = getSmsSubscription(smsNumber);
+    expect(subscription).toBeDefined();
+
+    // Then remove it
+    const removeSubscriptionSpy = vi.spyOn(
+      OneSignal.coreDirector,
+      'removeSubscriptionModel',
+    );
+    userNamespace.removeSms(smsNumber);
+
+    expect(removeSubscriptionSpy).toHaveBeenCalled();
+    subscription = getSmsSubscription(smsNumber);
+    expect(subscription).toBeUndefined();
+    expect(subscription?.token).toBe(undefined);
+  });
+});
+
+describe('Tag Management', () => {
+  test('should add a single tag', () => {
+    const userNamespace = new UserNamespace(true);
+    const key = 'test_tag';
+    const value = 'test_value';
+
+    userNamespace.addTag(key, value);
+
+    expect(userNamespace.getTags()).toEqual({ [key]: value });
+  });
+
+  test('should add multiple tags', () => {
+    const userNamespace = new UserNamespace(true);
+    const tags = {
+      tag1: 'value1',
+      tag2: 'value2',
     };
 
-    test('should add an SMS subscription', async () => {
-      const identityModel = OneSignal.coreDirector.getIdentityModel();
-      identityModel.onesignalId = IDManager.createLocalId();
+    userNamespace.addTags(tags);
 
-      const smsNumber = '+15551234567';
-      const addSubscriptionSpy = vi.spyOn(
-        OneSignal.coreDirector,
-        'addSubscriptionModel',
-      );
-
-      await userNamespace.addSms(smsNumber);
-
-      expect(addSubscriptionSpy).toHaveBeenCalled();
-      const subscription = getSmsSubscription(smsNumber);
-      expect(subscription).toBeDefined();
-      expect(subscription?.token).toBe(smsNumber);
-    });
-
-    test('should remove an SMS subscription', async () => {
-      const smsNumber = '+15551234567';
-
-      const identityModel = OneSignal.coreDirector.getIdentityModel();
-      identityModel.onesignalId = IDManager.createLocalId();
-
-      // First add the SMS
-      await userNamespace.addSms(smsNumber);
-      let subscription = getSmsSubscription(smsNumber);
-      expect(subscription).toBeDefined();
-
-      // Then remove it
-      const removeSubscriptionSpy = vi.spyOn(
-        OneSignal.coreDirector,
-        'removeSubscriptionModel',
-      );
-      userNamespace.removeSms(smsNumber);
-
-      expect(removeSubscriptionSpy).toHaveBeenCalled();
-      subscription = getSmsSubscription(smsNumber);
-      expect(subscription).toBeUndefined();
-      expect(subscription?.token).toBe(undefined);
-    });
+    expect(userNamespace.getTags()).toEqual(tags);
   });
 
-  describe('Tag Management', () => {
-    test('should add a single tag', () => {
-      const key = 'test_tag';
-      const value = 'test_value';
-
-      userNamespace.addTag(key, value);
-
-      expect(userNamespace.getTags()).toEqual({ [key]: value });
-    });
-
-    test('should add multiple tags', () => {
-      const tags = {
-        tag1: 'value1',
-        tag2: 'value2',
-      };
-
-      userNamespace.addTags(tags);
-
-      expect(userNamespace.getTags()).toEqual(tags);
-    });
-
-    test('should remove a single tag', () => {
-      const tags = {
-        tag1: 'value1',
-        tag2: 'value2',
-      };
-
-      // First add tags
-      userNamespace.addTags(tags);
-
-      // Then remove one
-      userNamespace.removeTag('tag1');
-
-      expect(userNamespace.getTags()).toEqual({ tag1: '', tag2: 'value2' });
-    });
-
-    test('should remove multiple tags', () => {
-      const tags = {
-        tag1: 'value1',
-        tag2: 'value2',
-        tag3: 'value3',
-      };
-
-      // First add tags
-      userNamespace.addTags(tags);
-
-      // Then remove multiple
-      userNamespace.removeTags(['tag1', 'tag3']);
-
-      expect(userNamespace.getTags()).toEqual({
-        tag1: '',
-        tag2: 'value2',
-        tag3: '',
-      });
-    });
-
-    test('should return empty object when no tags exist', () => {
-      expect(userNamespace.getTags()).toEqual({});
-    });
-  });
-
-  describe('Language Management', () => {
-    test('should set language', () => {
-      const language = 'fr';
-
-      // @ts-expect-error - mock invalid argument
-      expect(() => userNamespace.setLanguage(123)).toThrowError(
-        '"language" is the wrong type',
-      );
-
-      userNamespace.setLanguage(language);
-      expect(userNamespace.getLanguage()).toBe(language);
-    });
-
-    test('should get language', () => {
-      const language = 'es';
-      const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
-      propertiesModel.language = language;
-
-      expect(userNamespace.getLanguage()).toBe(language);
-    });
-
-    test('should return empty string if language is not set', () => {
-      const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
-      propertiesModel.language = undefined;
-
-      expect(userNamespace.getLanguage()).toBe('');
-    });
-  });
-
-  describe('Event Handling', () => {
-    test('should add and trigger event listener', () => {
-      const mockListener = vi.fn();
-      const event: UserChangeEvent = {
-        current: {
-          onesignalId: ONESIGNAL_ID,
-          externalId: undefined,
-        },
-      };
-
-      userNamespace.addEventListener('change', mockListener);
-      UserNamespace.emitter.emit('change', event);
-
-      expect(mockListener).toHaveBeenCalledWith(event);
-    });
-
-    test('should remove event listener', () => {
-      const mockListener = vi.fn();
-      const event: UserChangeEvent = {
-        current: {
-          onesignalId: ONESIGNAL_ID,
-          externalId: undefined,
-        },
-      };
-
-      userNamespace.addEventListener('change', mockListener);
-      userNamespace.removeEventListener('change', mockListener);
-      UserNamespace.emitter.emit('change', event);
-
-      expect(mockListener).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('Initialization', () => {
-    test('should initialize PushSubscription when initialize is true', () => {
-      const initializedNamespace = new UserNamespace(true);
-
-      expect(initializedNamespace.PushSubscription).toBeDefined();
-      expect(initializedNamespace['_currentUser']).toBeDefined();
-    });
-
-    test('should not initialize user when initialize is false', () => {
-      const uninitializedNamespace = new UserNamespace(false);
-
-      expect(uninitializedNamespace['_currentUser']).toBeUndefined();
-    });
-
-    test('should use provided subscription and permission when initializing', () => {
-      const subscription = new Subscription();
-      subscription.deviceId = 'device-123';
-      subscription.subscriptionToken = PUSH_TOKEN;
-      subscription.optedOut = false;
-      subscription.createdAt = Date.now();
-
-      const permission: NotificationPermission = 'granted';
-
-      const customNamespace = new UserNamespace(true, subscription, permission);
-
-      expect(customNamespace.PushSubscription).toBeDefined();
-    });
-  });
-
-  describe('Custom Events', () => {
-    test('should call track event', () => {
-      const trackEventSpy = vi.spyOn(User.prototype, 'trackEvent');
-      const name = 'test_event';
-      const properties = {
-        test_property: 'test_value',
-      };
-
-      updateIdentityModel('onesignal_id', IDManager.createLocalId());
-      userNamespace.trackEvent(name, {});
-      expect(errorSpy).toHaveBeenCalledWith('User must be logged in first.');
-      errorSpy.mockClear();
-
-      const identityModel = OneSignal.coreDirector.getIdentityModel();
-      identityModel.setProperty(
-        'onesignal_id',
-        ONESIGNAL_ID,
-        ModelChangeTags.NO_PROPAGATE,
-      );
-
-      // should validate properties
-      // @ts-expect-error - mock invalid argument
-      userNamespace.trackEvent(name, 123);
-      expect(errorSpy).toHaveBeenCalledWith(
-        'Properties must be JSON-serializable',
-      );
-
-      // big ints can't be serialized
-      userNamespace.trackEvent(name, {
-        data: 10n,
-      });
-      expect(errorSpy).toHaveBeenCalledWith(
-        'Properties must be JSON-serializable',
-      );
-
-      userNamespace.trackEvent(name, properties);
-      expect(trackEventSpy).toHaveBeenCalledWith(name, properties);
-    });
-  });
-
-  describe('Consent Required', () => {
-    beforeEach(async () => {
-      OneSignal.setConsentRequired(true);
-      await OneSignal.setConsentGiven(false);
-    });
-
-    const expectConsentRequired = () => {
-      expect(warnSpy).toHaveBeenCalledWith('Consent required but not given');
+  test('should remove a single tag', () => {
+    const userNamespace = new UserNamespace(true);
+    const tags = {
+      tag1: 'value1',
+      tag2: 'value2',
     };
 
-    test('should not add/remove email if consent is required but not given', () => {
-      const email = 'mail@mail.com';
-      const user = new UserNamespace(true);
-      user.addEmail(email);
-      expectConsentRequired();
+    // First add tags
+    userNamespace.addTags(tags);
 
-      warnSpy.mockClear();
-      user.removeEmail(email);
-      expectConsentRequired();
+    // Then remove one
+    userNamespace.removeTag('tag1');
+
+    expect(userNamespace.getTags()).toEqual({ tag1: '', tag2: 'value2' });
+  });
+
+  test('should remove multiple tags', () => {
+    const userNamespace = new UserNamespace(true);
+    const tags = {
+      tag1: 'value1',
+      tag2: 'value2',
+      tag3: 'value3',
+    };
+
+    // First add tags
+    userNamespace.addTags(tags);
+
+    // Then remove multiple
+    userNamespace.removeTags(['tag1', 'tag3']);
+
+    expect(userNamespace.getTags()).toEqual({
+      tag1: '',
+      tag2: 'value2',
+      tag3: '',
     });
+  });
 
-    test('should not add/remove SMS if consent is required but not given', () => {
-      const smsNumber = '+15551234567';
-      const user = new UserNamespace(true);
+  test('should return empty object when no tags exist', () => {
+    const userNamespace = new UserNamespace(true);
+    expect(userNamespace.getTags()).toEqual({});
+  });
+});
 
-      user.addSms(smsNumber);
-      expectConsentRequired();
+describe('Language Management', () => {
+  test('should set language', () => {
+    const userNamespace = new UserNamespace(true);
+    const language = 'fr';
 
-      warnSpy.mockClear();
-      user.removeSms(smsNumber);
-      expectConsentRequired();
+    // @ts-expect-error - mock invalid argument
+    expect(() => userNamespace.setLanguage(123)).toThrowError(
+      '"language" is the wrong type',
+    );
+
+    userNamespace.setLanguage(language);
+    expect(userNamespace.getLanguage()).toBe(language);
+  });
+
+  test('should get language', () => {
+    const userNamespace = new UserNamespace(true);
+    const language = 'es';
+    const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
+    propertiesModel.language = language;
+
+    expect(userNamespace.getLanguage()).toBe(language);
+  });
+
+  test('should return empty string if language is not set', () => {
+    const userNamespace = new UserNamespace(true);
+    const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
+    propertiesModel.language = undefined;
+
+    expect(userNamespace.getLanguage()).toBe('');
+  });
+});
+
+describe('Event Handling', () => {
+  test('should add and trigger event listener', () => {
+    const userNamespace = new UserNamespace(true);
+    const mockListener = vi.fn();
+    const event: UserChangeEvent = {
+      current: {
+        onesignalId: ONESIGNAL_ID,
+        externalId: undefined,
+      },
+    };
+
+    userNamespace.addEventListener('change', mockListener);
+    UserNamespace._emitter.emit('change', event);
+
+    expect(mockListener).toHaveBeenCalledWith(event);
+  });
+
+  test('should remove event listener', () => {
+    const userNamespace = new UserNamespace(true);
+    const mockListener = vi.fn();
+    const event: UserChangeEvent = {
+      current: {
+        onesignalId: ONESIGNAL_ID,
+        externalId: undefined,
+      },
+    };
+
+    userNamespace.addEventListener('change', mockListener);
+    userNamespace.removeEventListener('change', mockListener);
+    UserNamespace._emitter.emit('change', event);
+
+    expect(mockListener).not.toHaveBeenCalled();
+  });
+});
+
+describe('Initialization', () => {
+  test('should initialize PushSubscription when initialize is true', () => {
+    const userNamespace = new UserNamespace(true);
+
+    expect(userNamespace.PushSubscription).toBeDefined();
+    expect(userNamespace['_currentUser']).toBeDefined();
+  });
+
+  test('should not initialize user when initialize is false', () => {
+    const userNamespace = new UserNamespace(false);
+
+    expect(userNamespace['_currentUser']).toBeUndefined();
+  });
+
+  test('should use provided subscription and permission when initializing', () => {
+    const subscription = new Subscription();
+    subscription.deviceId = 'device-123';
+    subscription.subscriptionToken = PUSH_TOKEN;
+    subscription.optedOut = false;
+    subscription.createdAt = Date.now();
+
+    const permission: NotificationPermission = 'granted';
+
+    const customNamespace = new UserNamespace(true, subscription, permission);
+
+    expect(customNamespace.PushSubscription).toBeDefined();
+  });
+
+  test('properties model should have onesignalId for existing user', () => {
+    // with an existing onesignalId
+    const user = new UserNamespace(true);
+    expect(IDManager.isLocalId(user.onesignalId)).toBe(false);
+
+    // identity and properties models should have the same onesignalId
+    const onesignalId = user.onesignalId;
+
+    const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
+    expect(propertiesModel.onesignalId).toBe(onesignalId);
+  });
+
+  test('properties model should have onesignalId for new user', () => {
+    // without an existing onesignalId
+    updateIdentityModel(IdentityConstants.ONESIGNAL_ID, undefined);
+
+    const user = new UserNamespace(true);
+    expect(IDManager.isLocalId(user.onesignalId)).toBe(true);
+
+    // identity and properties models should have the same onesignalId
+    const onesignalId = user.onesignalId;
+
+    const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
+    expect(propertiesModel.onesignalId).toBe(onesignalId);
+  });
+});
+
+describe('Custom Events', () => {
+  test('should call track event', () => {
+    const userNamespace = new UserNamespace(true);
+    const trackEventSpy = vi.spyOn(User.prototype, 'trackEvent');
+    const name = 'test_event';
+    const properties = {
+      test_property: 'test_value',
+    };
+
+    updateIdentityModel('onesignal_id', IDManager.createLocalId());
+    userNamespace.trackEvent(name, {});
+    expect(errorSpy).toHaveBeenCalledWith('User must be logged in first.');
+    errorSpy.mockClear();
+
+    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    identityModel.setProperty(
+      'onesignal_id',
+      ONESIGNAL_ID,
+      ModelChangeTags.NO_PROPAGATE,
+    );
+
+    // should validate properties
+    // @ts-expect-error - mock invalid argument
+    userNamespace.trackEvent(name, 123);
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Properties must be JSON-serializable',
+    );
+
+    // big ints can't be serialized
+    userNamespace.trackEvent(name, {
+      data: 10n,
     });
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Properties must be JSON-serializable',
+    );
 
-    test('should not add/remove tag(s) if consent is required but not given', () => {
-      const user = new UserNamespace(true);
-      user.addTag('test_tag', 'test_value');
-      expectConsentRequired();
+    userNamespace.trackEvent(name, properties);
+    expect(trackEventSpy).toHaveBeenCalledWith(name, properties);
+  });
+});
 
-      warnSpy.mockClear();
-      user.removeTag('test_tag');
-      expectConsentRequired();
+describe('Consent Required', () => {
+  beforeEach(async () => {
+    OneSignal.setConsentRequired(true);
+    await OneSignal.setConsentGiven(false);
+  });
 
-      warnSpy.mockClear();
-      user.addTags({ tag1: 'value1', tag2: 'value2' });
-      expectConsentRequired();
+  const expectConsentRequired = () => {
+    expect(warnSpy).toHaveBeenCalledWith('Consent required but not given');
+  };
 
-      warnSpy.mockClear();
-      user.removeTags(['tag1', 'tag2']);
-      expectConsentRequired();
-    });
+  test('should not add/remove email if consent is required but not given', () => {
+    const email = 'mail@mail.com';
+    const user = new UserNamespace(true);
+    user.addEmail(email);
+    expectConsentRequired();
 
-    test('should not set language if consent is required but not given', () => {
-      const user = new UserNamespace(true);
-      user.setLanguage('fr');
-      expectConsentRequired();
-    });
+    warnSpy.mockClear();
+    user.removeEmail(email);
+    expectConsentRequired();
+  });
 
-    test('should not add/remove alias if consent is required but not given', () => {
-      const user = new UserNamespace(true);
-      user.addAlias('test_label', 'test_value');
-      expectConsentRequired();
+  test('should not add/remove SMS if consent is required but not given', () => {
+    const smsNumber = '+15551234567';
+    const user = new UserNamespace(true);
 
-      warnSpy.mockClear();
-      user.addAliases({ test_label: 'test_value' });
-      expectConsentRequired();
+    user.addSms(smsNumber);
+    expectConsentRequired();
 
-      warnSpy.mockClear();
-      user.removeAlias('test_label');
-      expectConsentRequired();
+    warnSpy.mockClear();
+    user.removeSms(smsNumber);
+    expectConsentRequired();
+  });
 
-      warnSpy.mockClear();
-      user.removeAliases(['test_label']);
-      expectConsentRequired();
-    });
+  test('should not add/remove tag(s) if consent is required but not given', () => {
+    const user = new UserNamespace(true);
+    user.addTag('test_tag', 'test_value');
+    expectConsentRequired();
 
-    test('should not track event if consent is required but not given', () => {
-      const user = new UserNamespace(true);
-      user.trackEvent('test_event');
-      expectConsentRequired();
-    });
+    warnSpy.mockClear();
+    user.removeTag('test_tag');
+    expectConsentRequired();
+
+    warnSpy.mockClear();
+    user.addTags({ tag1: 'value1', tag2: 'value2' });
+    expectConsentRequired();
+
+    warnSpy.mockClear();
+    user.removeTags(['tag1', 'tag2']);
+    expectConsentRequired();
+  });
+
+  test('should not set language if consent is required but not given', () => {
+    const user = new UserNamespace(true);
+    user.setLanguage('fr');
+    expectConsentRequired();
+  });
+
+  test('should not add/remove alias if consent is required but not given', () => {
+    const user = new UserNamespace(true);
+    user.addAlias('test_label', 'test_value');
+    expectConsentRequired();
+
+    warnSpy.mockClear();
+    user.addAliases({ test_label: 'test_value' });
+    expectConsentRequired();
+
+    warnSpy.mockClear();
+    user.removeAlias('test_label');
+    expectConsentRequired();
+
+    warnSpy.mockClear();
+    user.removeAliases(['test_label']);
+    expectConsentRequired();
+  });
+
+  test('should not track event if consent is required but not given', () => {
+    const user = new UserNamespace(true);
+    user.trackEvent('test_event');
+    expectConsentRequired();
   });
 });

--- a/src/onesignal/UserNamespace.ts
+++ b/src/onesignal/UserNamespace.ts
@@ -10,7 +10,7 @@ export default class UserNamespace extends EventListenerBase {
 
   readonly PushSubscription = new PushSubscriptionNamespace(false);
 
-  static emitter = new Emitter();
+  static _emitter = new Emitter();
 
   constructor(
     initialize: boolean,
@@ -113,13 +113,13 @@ export default class UserNamespace extends EventListenerBase {
     event: 'change',
     listener: (userChange: UserChangeEvent) => void,
   ): void {
-    UserNamespace.emitter.on(event, listener);
+    UserNamespace._emitter.on(event, listener);
   }
 
   removeEventListener(
     event: 'change',
     listener: (userChange: UserChangeEvent) => void,
   ): void {
-    UserNamespace.emitter.off(event, listener);
+    UserNamespace._emitter.off(event, listener);
   }
 }

--- a/src/shared/helpers/SubscriptionHelper.ts
+++ b/src/shared/helpers/SubscriptionHelper.ts
@@ -30,7 +30,9 @@ export default class SubscriptionHelper {
       );
       subscription =
         await context.subscriptionManager.registerSubscription(rawSubscription);
+
       incrementPageViewCount();
+
       await triggerNotificationPermissionChanged();
       await checkAndTriggerSubscriptionChanged();
     } catch (e) {

--- a/src/shared/listeners.ts
+++ b/src/shared/listeners.ts
@@ -151,7 +151,7 @@ function triggerUserChanged(change: UserChangeEvent) {
   OneSignalEvent.trigger(
     OneSignal.EVENTS.SUBSCRIPTION_CHANGED,
     change,
-    UserNamespace.emitter,
+    UserNamespace._emitter,
   );
 }
 

--- a/src/shared/managers/SubscriptionManager.test.ts
+++ b/src/shared/managers/SubscriptionManager.test.ts
@@ -7,28 +7,21 @@ import {
   setUpdateSubscriptionResponse,
   updateSubscriptionFn,
 } from '__test__/support/helpers/requests';
-import { updateIdentityModel } from '__test__/support/helpers/setup';
+import {
+  getRawPushSubscription,
+  updateIdentityModel,
+} from '__test__/support/helpers/setup';
 import MockNotification from '__test__/support/mocks/MockNotification';
 import {
   getSubscriptionFn,
   MockServiceWorker,
 } from '__test__/support/mocks/MockServiceWorker';
 import { setPushToken } from '../database/subscription';
-import { RawPushSubscription } from '../models/RawPushSubscription';
 import { IDManager } from './IDManager';
 import {
   SubscriptionManagerPage,
   updatePushSubscriptionModelWithRawSubscription,
 } from './subscription/page';
-
-const getRawSubscription = (): RawPushSubscription => {
-  const rawSubscription = new RawPushSubscription();
-  rawSubscription.w3cAuth = 'auth';
-  rawSubscription.w3cP256dh = 'p256dh';
-  rawSubscription.w3cEndpoint = new URL('https://example.com/endpoint');
-  rawSubscription.safariDeviceToken = 'safariDeviceToken';
-  return rawSubscription;
-};
 
 describe('SubscriptionManager', () => {
   beforeEach(() => {
@@ -38,7 +31,7 @@ describe('SubscriptionManager', () => {
   describe('updatePushSubscriptionModelWithRawSubscription', () => {
     test('should create the push subscription model if it does not exist', async () => {
       setCreateUserResponse();
-      const rawSubscription = getRawSubscription();
+      const rawSubscription = getRawPushSubscription();
 
       let subModels =
         await OneSignal.coreDirector.subscriptionModelStore.list();
@@ -84,7 +77,7 @@ describe('SubscriptionManager', () => {
         OneSignal.coreDirector,
         'generatePushSubscriptionModel',
       );
-      const rawSubscription = getRawSubscription();
+      const rawSubscription = getRawPushSubscription();
       getSubscriptionFn.mockResolvedValue({
         endpoint: rawSubscription.w3cEndpoint?.toString(),
       });
@@ -125,7 +118,7 @@ describe('SubscriptionManager', () => {
 
     test('should update the push subscription model if it already exists', async () => {
       setUpdateSubscriptionResponse({ subscriptionId: '123' });
-      const rawSubscription = getRawSubscription();
+      const rawSubscription = getRawPushSubscription();
 
       await setPushToken(rawSubscription.w3cEndpoint?.toString());
 

--- a/src/shared/managers/subscription/page.ts
+++ b/src/shared/managers/subscription/page.ts
@@ -267,7 +267,7 @@ export class SubscriptionManagerPage extends SubscriptionManagerBase<ContextInte
       }
     } else {
       rawPushSubscription =
-        await this.subscribeFcmFromPage(subscriptionStrategy);
+        await this._subscribeFcmFromPage(subscriptionStrategy);
       await updatePushSubscriptionModelWithRawSubscription(rawPushSubscription);
     }
 
@@ -351,7 +351,7 @@ export class SubscriptionManagerPage extends SubscriptionManagerBase<ContextInte
     }
   }
 
-  private async subscribeFcmFromPage(
+  async _subscribeFcmFromPage(
     subscriptionStrategy: SubscriptionStrategyKindValue,
   ): Promise<RawPushSubscription> {
     /*


### PR DESCRIPTION
# Description
## 1 Line Summary
- update properties model onesignal id to match identity model onesignal id

## Details
- Main fix to just set onesignal id to match identity onesignal when initializing usernamespace. Before the set property operation was executing early since onesignal would be undefined for properties model. Now it will wait to execute when onesignal id is created. 

https://github.com/user-attachments/assets/1d74d67f-930d-416e-bd3e-68b14600aa86

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1366)
<!-- Reviewable:end -->
