### PR TITLE
SDK-1846 Add roepen db when transaction is closing/terminating

### DIFF
--- a/__test__/unit/pushSubscription/nativePermissionChange.test.ts
+++ b/__test__/unit/pushSubscription/nativePermissionChange.test.ts
@@ -8,7 +8,7 @@ import {
 import { TestEnvironment } from '__test__/support/environment/TestEnvironment';
 import { createPushSub } from '__test__/support/environment/TestEnvironmentHelpers';
 import { MockServiceWorker } from '__test__/support/mocks/MockServiceWorker';
-import { db, getOptionsValue } from 'src/shared/database/client';
+import { clearStore, db, getOptionsValue } from 'src/shared/database/client';
 import { setAppState as setDBAppState } from 'src/shared/database/config';
 import * as PermissionUtils from 'src/shared/helpers/permissions';
 import Emitter from 'src/shared/libraries/Emitter';
@@ -31,8 +31,8 @@ describe('Notification Types are set correctly on subscription change', () => {
   });
 
   afterEach(async () => {
-    await db.clear('subscriptions');
-    await db.clear('Options');
+    await clearStore('subscriptions');
+    await clearStore('Options');
   });
 
   const setDbPermission = async (permission: NotificationPermission) => {

--- a/package.json
+++ b/package.json
@@ -84,12 +84,12 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "52.13 kB",
+      "limit": "52.153 kB",
       "gzip": true
     },
     {
       "path": "./build/releases/OneSignalSDK.sw.js",
-      "limit": "14.54 kB",
+      "limit": "14.564 kB",
       "gzip": true
     },
     {

--- a/src/shared/database/client.ts
+++ b/src/shared/database/client.ts
@@ -117,12 +117,10 @@ export const db = {
   ) {
     return (await dbPromise).delete(storeName, key);
   },
-  async clear<K extends IDBStoreName>(storeName: K) {
-    return (await dbPromise).clear(storeName);
-  },
-  async close() {
-    return (await dbPromise).close();
-  },
+};
+
+export const clearStore = async <K extends IDBStoreName>(storeName: K) => {
+  return (await dbPromise).clear(storeName);
 };
 
 export const getObjectStoreNames = async () => {
@@ -154,7 +152,7 @@ export const cleanupCurrentSession = async () => {
 export const clearAll = async () => {
   const objectStoreNames = await getObjectStoreNames();
   for (const storeName of objectStoreNames) {
-    await db.clear(storeName);
+    await clearStore(storeName);
   }
 };
 

--- a/src/shared/helpers/service-worker.ts
+++ b/src/shared/helpers/service-worker.ts
@@ -6,6 +6,7 @@ import OneSignalApiSW from '../api/OneSignalApiSW';
 import { encodeHashAsUriComponent } from '../context/helpers';
 import {
   cleanupCurrentSession,
+  clearStore,
   db,
   getCurrentSession,
 } from '../database/client';
@@ -243,7 +244,7 @@ async function finalizeSession(
 
   await Promise.all([
     cleanupCurrentSession(),
-    db.clear('Outcomes.NotificationClicked'),
+    clearStore('Outcomes.NotificationClicked'),
   ]);
   Log.debug(
     'Finalize session finished',


### PR DESCRIPTION
# Description
## 1 Line Summary
- Address (#503) by reopening db when db is terminated 

## Details
- Adds getDb/reopen call to the terminated callback from idb. This would create a new db 
Before this would happen if a user were to deleteDB which would lead to an unhandled rejection.

https://github.com/user-attachments/assets/aa03aca0-11f8-4b3c-819e-15bc52ade05d

Now:

https://github.com/user-attachments/assets/23310b8a-e682-45ad-a220-aee31cc5cd76

The errors will be related to missing data which would use Log class.




# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1368)
<!-- Reviewable:end -->
