### PR TITLE
Return undefined for local onesignal id

### DIFF
--- a/__test__/setupTests.ts
+++ b/__test__/setupTests.ts
@@ -18,7 +18,7 @@ beforeEach(async () => {
 afterEach(() => {
   server.resetHandlers();
   if (typeof OneSignal !== 'undefined') {
-    OneSignal.coreDirector?.operationRepo._clear();
+    OneSignal._coreDirector?.operationRepo._clear();
     OneSignal.emitter?.removeAllListeners();
   }
 });

--- a/__test__/support/environment/TestEnvironment.ts
+++ b/__test__/support/environment/TestEnvironment.ts
@@ -32,7 +32,7 @@ export class TestEnvironment {
   ) {
     mockJsonp();
     const oneSignal = initOSGlobals(config);
-    OneSignal.coreDirector.operationRepo.queue = [];
+    OneSignal._coreDirector.operationRepo.queue = [];
 
     if (config.initOneSignalId) {
       updateIdentityModel('onesignal_id', ONESIGNAL_ID);

--- a/__test__/support/environment/TestEnvironmentHelpers.ts
+++ b/__test__/support/environment/TestEnvironmentHelpers.ts
@@ -26,7 +26,7 @@ export function initOSGlobals(config: TestEnvironmentConfig = {}) {
   global.OneSignal.initialized = true;
   global.OneSignal.emitter = new Emitter();
   const core = new CoreModule();
-  global.OneSignal.coreDirector = new CoreModuleDirector(core);
+  global.OneSignal._coreDirector = new CoreModuleDirector(core);
 
   // Clear the User singleton before creating new instance
   User.singletonInstance = undefined;
@@ -92,7 +92,7 @@ export const setupSubModelStore = async ({
     pushModel.web_p256 = web_p256;
   }
   await setPushToken(pushModel.token);
-  OneSignal.coreDirector.subscriptionModelStore.replaceAll(
+  OneSignal._coreDirector.subscriptionModelStore.replaceAll(
     [pushModel],
     ModelChangeTags.NO_PROPAGATE,
   );

--- a/__test__/support/helpers/setup.ts
+++ b/__test__/support/helpers/setup.ts
@@ -64,7 +64,7 @@ export const setupIdentityModel = async (
 ) => {
   const newIdentityModel = new IdentityModel();
   newIdentityModel.onesignalId = onesignalID;
-  OneSignal.coreDirector.identityModelStore.replace(
+  OneSignal._coreDirector.identityModelStore.replace(
     newIdentityModel,
     ModelChangeTags.NO_PROPAGATE,
   );
@@ -78,7 +78,7 @@ export const setupPropertiesModel = async (
 ) => {
   const newPropertiesModel = new PropertiesModel();
   newPropertiesModel.onesignalId = onesignalID;
-  OneSignal.coreDirector.propertiesModelStore.replace(
+  OneSignal._coreDirector.propertiesModelStore.replace(
     newPropertiesModel,
     ModelChangeTags.NO_PROPAGATE,
   );
@@ -96,7 +96,7 @@ export const updateIdentityModel = async <
   property: T,
   value?: IdentitySchema[T],
 ) => {
-  const identityModel = OneSignal.coreDirector.getIdentityModel();
+  const identityModel = OneSignal._coreDirector._getIdentityModel();
   identityModel.setProperty(property, value, ModelChangeTags.NO_PROPAGATE);
 };
 
@@ -112,7 +112,7 @@ export const updatePropertiesModel = async <
   property: T,
   value?: PropertiesSchema[T],
 ) => {
-  const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
+  const propertiesModel = OneSignal._coreDirector._getPropertiesModel();
   propertiesModel.setProperty(property, value, ModelChangeTags.NO_PROPAGATE);
 };
 
@@ -126,7 +126,7 @@ export const setupSubscriptionModel = async (
   const subscriptionModel = new SubscriptionModel();
   subscriptionModel.id = id || '';
   subscriptionModel.token = token || '';
-  OneSignal.coreDirector.subscriptionModelStore.replaceAll(
+  OneSignal._coreDirector.subscriptionModelStore.replaceAll(
     [subscriptionModel],
     ModelChangeTags.NO_PROPAGATE,
   );

--- a/__test__/unit/pushSubscription/nativePermissionChange.test.ts
+++ b/__test__/unit/pushSubscription/nativePermissionChange.test.ts
@@ -112,7 +112,7 @@ describe('Notification Types are set correctly on subscription change', () => {
         lastKnownPushToken: PUSH_TOKEN,
         lastKnownPushId: SUB_ID,
       });
-      OneSignal.coreDirector.addSubscriptionModel(pushModel);
+      OneSignal._coreDirector.addSubscriptionModel(pushModel);
 
       await checkAndTriggerSubscriptionChanged();
       expect(changeListener).not.toHaveBeenCalled();
@@ -130,7 +130,7 @@ describe('Notification Types are set correctly on subscription change', () => {
         lastKnownPushToken: PUSH_TOKEN_2,
         lastKnownPushId: SUB_ID_3,
       });
-      OneSignal.coreDirector.subscriptionModelStore.add(pushModel);
+      OneSignal._coreDirector.subscriptionModelStore.add(pushModel);
 
       await checkAndTriggerSubscriptionChanged();
       expect(changeListener).toHaveBeenCalledWith({

--- a/__test__/unit/user/user.test.ts
+++ b/__test__/unit/user/user.test.ts
@@ -27,7 +27,7 @@ describe('User tests', () => {
     TestEnvironment.initialize();
 
     const tagsSample = { key1: 'value1' };
-    const propModel = OneSignal.coreDirector.getPropertiesModel();
+    const propModel = OneSignal._coreDirector._getPropertiesModel();
     propModel.tags = tagsSample;
 
     const user = User.createOrGetInstance();
@@ -41,7 +41,7 @@ describe('User tests', () => {
 
     const languageSample = 'fr';
 
-    const propModel = OneSignal.coreDirector.getPropertiesModel();
+    const propModel = OneSignal._coreDirector._getPropertiesModel();
     propModel.language = languageSample;
 
     const user = User.createOrGetInstance();
@@ -58,7 +58,7 @@ describe('User tests', () => {
     const user = User.createOrGetInstance();
     user.setLanguage(languageSample);
 
-    const propModel = OneSignal.coreDirector.getPropertiesModel();
+    const propModel = OneSignal._coreDirector._getPropertiesModel();
     expect(propModel.language).toBe(languageSample);
   });
 });

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "52.18 kB",
+      "limit": "52.13 kB",
       "gzip": true
     },
     {

--- a/src/core/CoreModuleDirector.ts
+++ b/src/core/CoreModuleDirector.ts
@@ -64,7 +64,7 @@ export class CoreModuleDirector {
     model.initializeFromJson(
       new FuturePushSubscriptionRecord(rawPushSubscription).serialize(),
     );
-    model.id = IDManager.createLocalId();
+    model.id = IDManager._createLocalId();
 
     // we enqueue a login operation w/ a create subscription operation the first time we generate/save a push subscription model
     this.core.subscriptionModelStore.add(model, ModelChangeTags.HYDRATE);
@@ -159,12 +159,12 @@ export class CoreModuleDirector {
     );
   }
 
-  public getIdentityModel(): IdentityModel {
+  public _getIdentityModel(): IdentityModel {
     logMethodCall('CoreModuleDirector.getIdentityModel');
     return this.core.identityModelStore.model;
   }
 
-  public getPropertiesModel(): PropertiesModel {
+  public _getPropertiesModel(): PropertiesModel {
     logMethodCall('CoreModuleDirector.getPropertiesModel');
     return this.core.propertiesModelStore.model;
   }

--- a/src/core/executors/IdentityOperationExecutor.test.ts
+++ b/src/core/executors/IdentityOperationExecutor.test.ts
@@ -49,10 +49,10 @@ describe('IdentityOperationExecutor', () => {
     setAddAliasResponse();
     setDeleteAliasResponse();
 
-    identityModelStore = OneSignal.coreDirector.identityModelStore;
-    newRecordsState = OneSignal.coreDirector.newRecordsState;
-    propertiesModelStore = OneSignal.coreDirector.propertiesModelStore;
-    subscriptionModelStore = OneSignal.coreDirector.subscriptionModelStore;
+    identityModelStore = OneSignal._coreDirector.identityModelStore;
+    newRecordsState = OneSignal._coreDirector.newRecordsState;
+    propertiesModelStore = OneSignal._coreDirector.propertiesModelStore;
+    subscriptionModelStore = OneSignal._coreDirector.subscriptionModelStore;
 
     rebuildUserService = new RebuildUserService(
       identityModelStore,

--- a/src/core/executors/LoginUserOperationExecutor.test.ts
+++ b/src/core/executors/LoginUserOperationExecutor.test.ts
@@ -60,9 +60,9 @@ describe('LoginUserOperationExecutor', () => {
   });
 
   beforeEach(() => {
-    identityModelStore = OneSignal.coreDirector.identityModelStore;
-    propertiesModelStore = OneSignal.coreDirector.propertiesModelStore;
-    subscriptionModelStore = OneSignal.coreDirector.subscriptionModelStore;
+    identityModelStore = OneSignal._coreDirector.identityModelStore;
+    propertiesModelStore = OneSignal._coreDirector.propertiesModelStore;
+    subscriptionModelStore = OneSignal._coreDirector.subscriptionModelStore;
     rebuildUserService = new RebuildUserService(
       identityModelStore,
       propertiesModelStore,

--- a/src/core/executors/RefreshUserOperationExecutor.test.ts
+++ b/src/core/executors/RefreshUserOperationExecutor.test.ts
@@ -47,10 +47,10 @@ describe('RefreshUserOperationExecutor', () => {
   });
 
   beforeEach(() => {
-    identityModelStore = OneSignal.coreDirector.identityModelStore;
-    propertiesModelStore = OneSignal.coreDirector.propertiesModelStore;
-    subscriptionModelStore = OneSignal.coreDirector.subscriptionModelStore;
-    newRecordsState = OneSignal.coreDirector.newRecordsState;
+    identityModelStore = OneSignal._coreDirector.identityModelStore;
+    propertiesModelStore = OneSignal._coreDirector.propertiesModelStore;
+    subscriptionModelStore = OneSignal._coreDirector.subscriptionModelStore;
+    newRecordsState = OneSignal._coreDirector.newRecordsState;
     buildUserService = new RebuildUserService(
       identityModelStore,
       propertiesModelStore,

--- a/src/core/executors/RefreshUserOperationExecutor.ts
+++ b/src/core/executors/RefreshUserOperationExecutor.ts
@@ -119,7 +119,8 @@ export class RefreshUserOperationExecutor implements IOperationExecutor {
         }
       }
 
-      const pushModel = await OneSignal.coreDirector.getPushSubscriptionModel();
+      const pushModel =
+        await OneSignal._coreDirector.getPushSubscriptionModel();
       if (pushModel) {
         pushModel.onesignalId = op.onesignalId;
         subscriptionModels.push(pushModel);

--- a/src/core/executors/SubscriptionOperationExecutor.test.ts
+++ b/src/core/executors/SubscriptionOperationExecutor.test.ts
@@ -55,13 +55,13 @@ describe('SubscriptionOperationExecutor', () => {
   });
 
   beforeEach(() => {
-    subscriptionModelStore = OneSignal.coreDirector.subscriptionModelStore;
-    newRecordsState = OneSignal.coreDirector.newRecordsState;
+    subscriptionModelStore = OneSignal._coreDirector.subscriptionModelStore;
+    newRecordsState = OneSignal._coreDirector.newRecordsState;
     newRecordsState._records.clear();
 
-    identityModelStore = OneSignal.coreDirector.identityModelStore;
-    propertiesModelStore = OneSignal.coreDirector.propertiesModelStore;
-    subscriptionsModelStore = OneSignal.coreDirector.subscriptionModelStore;
+    identityModelStore = OneSignal._coreDirector.identityModelStore;
+    propertiesModelStore = OneSignal._coreDirector.propertiesModelStore;
+    subscriptionsModelStore = OneSignal._coreDirector.subscriptionModelStore;
 
     buildUserService = new RebuildUserService(
       identityModelStore,

--- a/src/core/executors/UpdateUserOperationExecutor.test.ts
+++ b/src/core/executors/UpdateUserOperationExecutor.test.ts
@@ -32,10 +32,10 @@ describe('UpdateUserOperationExecutor', () => {
   });
 
   beforeEach(() => {
-    identityModelStore = OneSignal.coreDirector.identityModelStore;
-    propertiesModelStore = OneSignal.coreDirector.propertiesModelStore;
-    newRecordsState = OneSignal.coreDirector.newRecordsState;
-    subscriptionsModelStore = OneSignal.coreDirector.subscriptionModelStore;
+    identityModelStore = OneSignal._coreDirector.identityModelStore;
+    propertiesModelStore = OneSignal._coreDirector.propertiesModelStore;
+    newRecordsState = OneSignal._coreDirector.newRecordsState;
+    subscriptionsModelStore = OneSignal._coreDirector.subscriptionModelStore;
     buildUserService = new RebuildUserService(
       identityModelStore,
       propertiesModelStore,

--- a/src/core/modelRepo/RebuildUserService.ts
+++ b/src/core/modelRepo/RebuildUserService.ts
@@ -54,7 +54,7 @@ export class RebuildUserService implements IRebuildUserService {
     );
 
     const pushSubscription =
-      await OneSignal.coreDirector.getPushSubscriptionModel();
+      await OneSignal._coreDirector.getPushSubscriptionModel();
     if (pushSubscription) {
       operations.push(
         new CreateSubscriptionOperation({

--- a/src/core/operations/BaseSubscriptionOperation.ts
+++ b/src/core/operations/BaseSubscriptionOperation.ts
@@ -43,8 +43,8 @@ export abstract class BaseSubscriptionOperation<
 
   override get canStartExecute(): boolean {
     return (
-      !IDManager.isLocalId(this.onesignalId) &&
-      !IDManager.isLocalId(this.subscriptionId)
+      !IDManager._isLocalId(this.onesignalId) &&
+      !IDManager._isLocalId(this.subscriptionId)
     );
   }
 

--- a/src/core/operations/CreateSubscriptionOperation.ts
+++ b/src/core/operations/CreateSubscriptionOperation.ts
@@ -20,7 +20,7 @@ export class CreateSubscriptionOperation extends BaseFullSubscriptionOperation {
   }
 
   override get canStartExecute(): boolean {
-    return !IDManager.isLocalId(this.onesignalId);
+    return !IDManager._isLocalId(this.onesignalId);
   }
 
   override get applyToRecordId(): string {

--- a/src/core/operations/LoginUserOperation.ts
+++ b/src/core/operations/LoginUserOperation.ts
@@ -74,7 +74,7 @@ export class LoginUserOperation extends Operation<ILoginOp> {
   override get canStartExecute(): boolean {
     return (
       !this.existingOnesignalId ||
-      !IDManager.isLocalId(this.existingOnesignalId)
+      !IDManager._isLocalId(this.existingOnesignalId)
     );
   }
 

--- a/src/core/operations/Operation.ts
+++ b/src/core/operations/Operation.ts
@@ -85,7 +85,7 @@ export abstract class Operation<
    * Whether the operation can currently execute given its current state.
    */
   get canStartExecute(): boolean {
-    return !IDManager.isLocalId(this.onesignalId);
+    return !IDManager._isLocalId(this.onesignalId);
   }
 
   /**

--- a/src/core/operations/TrackCustomEventOperation.ts
+++ b/src/core/operations/TrackCustomEventOperation.ts
@@ -78,7 +78,7 @@ export class TrackCustomEventOperation extends Operation<ITrackEventOp> {
     return GroupComparisonType.NONE;
   }
   override get canStartExecute(): boolean {
-    return !IDManager.isLocalId(this.onesignalId);
+    return !IDManager._isLocalId(this.onesignalId);
   }
   override get applyToRecordId(): string {
     return this.onesignalId;

--- a/src/entries/pageSdkInit.test.ts
+++ b/src/entries/pageSdkInit.test.ts
@@ -38,7 +38,7 @@ describe('pageSdkInit', () => {
     await vi.waitUntil(async () => {
       return logoutSpy.mock.calls.length > 0;
     });
-    expect(window.OneSignal.coreDirector).toBeDefined();
+    expect(window.OneSignal._coreDirector).toBeDefined();
   });
 
   test('can process deferred items long after page init', async () => {

--- a/src/entries/pageSdkInit2.test.ts
+++ b/src/entries/pageSdkInit2.test.ts
@@ -28,7 +28,7 @@ describe('pageSdkInit 2', () => {
   });
 
   test('can login and addEmail', async () => {
-    const onesignalId = IDManager.createLocalId();
+    const onesignalId = IDManager._createLocalId();
     updateIdentityModel('onesignal_id', onesignalId);
 
     const email = 'joe@example.com';
@@ -74,7 +74,7 @@ describe('pageSdkInit 2', () => {
       OneSignal.User.addEmail(email);
 
       // waiting for indexedb to update, addEmail should add a new subscription item with temporary id
-      const subModels = OneSignal.coreDirector.subscriptionModelStore
+      const subModels = OneSignal._coreDirector.subscriptionModelStore
         .list()
         .map((m) => m.toJSON());
       subModels.sort((a, b) => a.type.localeCompare(b.type));
@@ -92,7 +92,7 @@ describe('pageSdkInit 2', () => {
           type: 'Email',
         },
       ]);
-      expect(IDManager.isLocalId(subModels[1].id)).toBe(true);
+      expect(IDManager._isLocalId(subModels[1].id)).toBe(true);
     });
 
     // wait user subscriptions to be refresh/replaced

--- a/src/onesignal/OneSignal.test.ts
+++ b/src/onesignal/OneSignal.test.ts
@@ -63,7 +63,7 @@ const setupEnv = (consentRequired: boolean) => {
       requiresUserPrivacyConsent: consentRequired,
     },
   });
-  OneSignal.coreDirector.subscriptionModelStore.replaceAll(
+  OneSignal._coreDirector.subscriptionModelStore.replaceAll(
     [],
     ModelChangeTags.NO_PROPAGATE,
   );
@@ -84,7 +84,7 @@ describe('OneSignal - No Consent Required', () => {
 
       test('can add an alias to the current user', async () => {
         OneSignal.User.addAlias('someLabel', 'someId');
-        const identityModel = OneSignal.coreDirector.getIdentityModel();
+        const identityModel = OneSignal._coreDirector._getIdentityModel();
         expect(identityModel.getProperty('someLabel')).toBe('someId');
 
         // should make a request to the backend
@@ -100,7 +100,7 @@ describe('OneSignal - No Consent Required', () => {
         OneSignal.User.addAlias('someLabel', 'someId');
         OneSignal.User.addAlias('someLabel2', 'someId2');
 
-        const identityModel = OneSignal.coreDirector.getIdentityModel();
+        const identityModel = OneSignal._coreDirector._getIdentityModel();
         expect(identityModel.getProperty('someLabel')).toBe('someId');
         expect(identityModel.getProperty('someLabel2')).toBe('someId2');
 
@@ -124,7 +124,7 @@ describe('OneSignal - No Consent Required', () => {
         await vi.waitUntil(() => addAliasFn.mock.calls.length === 1);
         OneSignal.User.removeAlias('someLabel');
 
-        const identityModel = OneSignal.coreDirector.getIdentityModel();
+        const identityModel = OneSignal._coreDirector._getIdentityModel();
         expect(identityModel.getProperty('someLabel')).toBeUndefined();
 
         await vi.waitUntil(() => deleteAliasFn.mock.calls.length === 1);
@@ -136,7 +136,7 @@ describe('OneSignal - No Consent Required', () => {
         OneSignal.User.addAlias('someLabel', 'someId');
         OneSignal.User.addAlias('someLabel2', 'someId2');
 
-        let identityModel = OneSignal.coreDirector.getIdentityModel();
+        let identityModel = OneSignal._coreDirector._getIdentityModel();
         expect(identityModel.getProperty('someLabel')).toBe('someId');
         expect(identityModel.getProperty('someLabel2')).toBe('someId2');
 
@@ -147,7 +147,7 @@ describe('OneSignal - No Consent Required', () => {
 
         await vi.waitUntil(async () => deleteAliasFn.mock.calls.length === 2);
 
-        identityModel = OneSignal.coreDirector.getIdentityModel();
+        identityModel = OneSignal._coreDirector._getIdentityModel();
         expect(identityModel.getProperty('someLabel')).toBeUndefined();
         expect(identityModel.getProperty('someLabel2')).toBeUndefined();
       });
@@ -402,7 +402,7 @@ describe('OneSignal - No Consent Required', () => {
             onesignal_id: ONESIGNAL_ID,
           });
 
-          const identityModel = OneSignal.coreDirector.getIdentityModel();
+          const identityModel = OneSignal._coreDirector._getIdentityModel();
           expect(identityModel.externalId).toBe(externalId);
 
           await vi.waitUntil(
@@ -464,7 +464,7 @@ describe('OneSignal - No Consent Required', () => {
             onesignal_id: ONESIGNAL_ID,
           });
 
-          const identityModel = OneSignal.coreDirector.getIdentityModel();
+          const identityModel = OneSignal._coreDirector._getIdentityModel();
           expect(identityModel.externalId).toBe(newExternalId);
         });
 
@@ -607,10 +607,10 @@ describe('OneSignal - No Consent Required', () => {
           });
           setCreateUserResponse({});
 
-          const localId = IDManager.createLocalId();
+          const localId = IDManager._createLocalId();
           setupIdentityModel(localId);
 
-          OneSignal.coreDirector.subscriptionModelStore.replaceAll(
+          OneSignal._coreDirector.subscriptionModelStore.replaceAll(
             [],
             ModelChangeTags.NO_PROPAGATE,
           );
@@ -688,7 +688,7 @@ describe('OneSignal - No Consent Required', () => {
             ],
           });
 
-          OneSignal.coreDirector.subscriptionModelStore.replaceAll(
+          OneSignal._coreDirector.subscriptionModelStore.replaceAll(
             [],
             ModelChangeTags.NO_PROPAGATE,
           );
@@ -698,7 +698,7 @@ describe('OneSignal - No Consent Required', () => {
           );
 
           // new/empty user
-          setupIdentityModel(IDManager.createLocalId());
+          setupIdentityModel(IDManager._createLocalId());
 
           // calling login before accept permissions
           OneSignal.login(externalId);
@@ -744,7 +744,7 @@ describe('OneSignal - No Consent Required', () => {
           let pushSub: SubscriptionSchema | undefined;
           await vi.waitUntil(async () => {
             pushSub = (await db.getAll('subscriptions'))[0];
-            return pushSub && !IDManager.isLocalId(pushSub.id);
+            return pushSub && !IDManager._isLocalId(pushSub.id);
           });
         });
       });
@@ -752,7 +752,7 @@ describe('OneSignal - No Consent Required', () => {
 
     describe('logout', () => {
       test('should not do anything if user has no external id', async () => {
-        const identityModel = OneSignal.coreDirector.getIdentityModel();
+        const identityModel = OneSignal._coreDirector._getIdentityModel();
         expect(identityModel.externalId).toBeUndefined();
 
         OneSignal.logout();
@@ -768,7 +768,7 @@ describe('OneSignal - No Consent Required', () => {
         });
 
         // existing user
-        let identityModel = OneSignal.coreDirector.getIdentityModel();
+        let identityModel = OneSignal._coreDirector._getIdentityModel();
         updateIdentityModel('external_id', 'jd-1');
 
         setCreateUserResponse({});
@@ -776,12 +776,12 @@ describe('OneSignal - No Consent Required', () => {
         OneSignal.logout();
 
         // identity model should be reset
-        identityModel = OneSignal.coreDirector.getIdentityModel();
+        identityModel = OneSignal._coreDirector._getIdentityModel();
         const onesignalId = identityModel.onesignalId;
         expect(identityModel.toJSON()).toEqual({
           onesignal_id: expect.any(String),
         });
-        expect(IDManager.isLocalId(onesignalId)).toBe(true);
+        expect(IDManager._isLocalId(onesignalId)).toBe(true);
 
         let identityData = await getIdentityItem();
         expect(identityData).toEqual({
@@ -791,7 +791,7 @@ describe('OneSignal - No Consent Required', () => {
         });
 
         // properties model should be reset
-        const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
+        const propertiesModel = OneSignal._coreDirector._getPropertiesModel();
         expect(propertiesModel.toJSON()).toEqual({
           onesignalId,
         });
@@ -806,7 +806,7 @@ describe('OneSignal - No Consent Required', () => {
         await vi.waitUntil(() => createUserFn.mock.calls.length === 1);
 
         // should update models and db
-        identityModel = OneSignal.coreDirector.getIdentityModel();
+        identityModel = OneSignal._coreDirector._getIdentityModel();
         expect(identityModel.toJSON()).toEqual({
           onesignal_id: ONESIGNAL_ID,
         });
@@ -856,7 +856,7 @@ describe('OneSignal - No Consent Required', () => {
     const getQueue = async (length: number) => {
       const queue = await vi.waitUntil(
         () => {
-          const _queue = OneSignal.coreDirector.operationRepo.queue;
+          const _queue = OneSignal._coreDirector.operationRepo.queue;
           return _queue.length === length ? _queue : null;
         },
         { interval: 0 },
@@ -894,7 +894,7 @@ describe('OneSignal - No Consent Required', () => {
       });
       setSendCustomEventResponse();
 
-      updateIdentityModel('onesignal_id', IDManager.createLocalId());
+      updateIdentityModel('onesignal_id', IDManager._createLocalId());
       updateIdentityModel('external_id', 'some-id');
 
       OneSignal.login('some-id-2');
@@ -1115,7 +1115,7 @@ describe('OneSignal - No Consent Required', () => {
     let queue: OperationQueueItem[] = [];
     await vi.waitUntil(
       () => {
-        queue = OneSignal.coreDirector.operationRepo.queue;
+        queue = OneSignal._coreDirector.operationRepo.queue;
         return queue.length === 3;
       },
       { interval: 1 },

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -56,7 +56,7 @@ export default class OneSignal {
   private static async _initializeCoreModuleAndOSNamespaces() {
     const core = new CoreModule();
     await core.init();
-    OneSignal.coreDirector = new CoreModuleDirector(core);
+    OneSignal._coreDirector = new CoreModuleDirector(core);
     const subscription = await getSubscription();
     const permission =
       await OneSignal.context.permissionManager.getPermissionStatus();
@@ -285,7 +285,7 @@ export default class OneSignal {
   static context: Context;
 
   /* NEW USER MODEL CHANGES */
-  static coreDirector: CoreModuleDirector;
+  static _coreDirector: CoreModuleDirector;
 
   static Notifications = new NotificationsNamespace();
   static Slidedown = new SlidedownNamespace();

--- a/src/onesignal/PushSubscriptionNamespace.ts
+++ b/src/onesignal/PushSubscriptionNamespace.ts
@@ -11,6 +11,7 @@ import {
   checkAndTriggerSubscriptionChanged,
   onInternalSubscriptionSet,
 } from 'src/shared/listeners';
+import { IDManager } from 'src/shared/managers/IDManager';
 import { isCompleteSubscriptionObject } from '../core/utils/typePredicates';
 import type { SubscriptionChangeEvent } from '../page/models/SubscriptionChangeEvent';
 import { EventListenerBase } from '../page/userModel/EventListenerBase';
@@ -48,7 +49,6 @@ export default class PushSubscriptionNamespace extends EventListenerBase {
       .getPushSubscriptionModel()
       .then((pushModel) => {
         if (isCompleteSubscriptionObject(pushModel)) {
-          pushModel;
           this._id = pushModel.id;
         }
       })
@@ -73,7 +73,7 @@ export default class PushSubscriptionNamespace extends EventListenerBase {
   }
 
   get id(): string | null | undefined {
-    return this._id;
+    return IDManager._isLocalId(this._id) ? undefined : this._id;
   }
 
   get token(): string | null | undefined {

--- a/src/onesignal/PushSubscriptionNamespace.ts
+++ b/src/onesignal/PushSubscriptionNamespace.ts
@@ -44,7 +44,7 @@ export default class PushSubscriptionNamespace extends EventListenerBase {
     this._permission = permission;
     this._token = subscription.subscriptionToken;
 
-    OneSignal.coreDirector
+    OneSignal._coreDirector
       .getPushSubscriptionModel()
       .then((pushModel) => {
         if (isCompleteSubscriptionObject(pushModel)) {

--- a/src/onesignal/UserDirector.ts
+++ b/src/onesignal/UserDirector.ts
@@ -8,11 +8,11 @@ import MainHelper from '../shared/helpers/MainHelper';
 
 export default class UserDirector {
   static async createUserOnServer(): Promise<void> {
-    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    const identityModel = OneSignal._coreDirector._getIdentityModel();
     const appId = MainHelper.getAppId();
 
     const hasAnySubscription =
-      OneSignal.coreDirector.subscriptionModelStore.list().length > 0;
+      OneSignal._coreDirector.subscriptionModelStore.list().length > 0;
 
     const hasExternalId = !!identityModel.externalId;
 
@@ -23,18 +23,18 @@ export default class UserDirector {
       return;
     }
 
-    const pushOp = await OneSignal.coreDirector.getPushSubscriptionModel();
+    const pushOp = await OneSignal._coreDirector.getPushSubscriptionModel();
     if (pushOp) {
       const subData = pushOp.toJSON();
 
-      OneSignal.coreDirector.operationRepo.enqueue(
+      OneSignal._coreDirector.operationRepo.enqueue(
         new LoginUserOperation(
           appId,
           identityModel.onesignalId,
           identityModel.externalId,
         ),
       );
-      await OneSignal.coreDirector.operationRepo.enqueueAndWait(
+      await OneSignal._coreDirector.operationRepo.enqueueAndWait(
         new CreateSubscriptionOperation({
           ...subData,
           appId,
@@ -43,7 +43,7 @@ export default class UserDirector {
         }),
       );
     } else {
-      OneSignal.coreDirector.operationRepo.enqueue(
+      OneSignal._coreDirector.operationRepo.enqueue(
         new LoginUserOperation(
           appId,
           identityModel.onesignalId,
@@ -60,11 +60,11 @@ export default class UserDirector {
     const newIdentityModel = new IdentityModel();
     const newPropertiesModel = new PropertiesModel();
 
-    const sdkId = IDManager.createLocalId();
+    const sdkId = IDManager._createLocalId();
     newIdentityModel.onesignalId = sdkId;
     newPropertiesModel.onesignalId = sdkId;
 
-    OneSignal.coreDirector.identityModelStore.replace(newIdentityModel);
-    OneSignal.coreDirector.propertiesModelStore.replace(newPropertiesModel);
+    OneSignal._coreDirector.identityModelStore.replace(newIdentityModel);
+    OneSignal._coreDirector.propertiesModelStore.replace(newPropertiesModel);
   }
 }

--- a/src/onesignal/UserNamespace.test.ts
+++ b/src/onesignal/UserNamespace.test.ts
@@ -31,9 +31,9 @@ describe('User Identity Properties', () => {
     updateIdentityModel('onesignal_id', undefined);
     expect(userNamespace.onesignalId).toBe(undefined);
 
-    const localId = IDManager.createLocalId();
+    const localId = IDManager._createLocalId();
     updateIdentityModel('onesignal_id', localId);
-    expect(userNamespace.onesignalId).toBe(localId);
+    expect(userNamespace.onesignalId).toBe(undefined);
 
     updateIdentityModel('onesignal_id', ONESIGNAL_ID);
     expect(userNamespace.onesignalId).toBe(ONESIGNAL_ID);
@@ -56,7 +56,7 @@ describe('Alias Management', () => {
 
     userNamespace.addAlias(label, id);
 
-    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    const identityModel = OneSignal._coreDirector._getIdentityModel();
     expect(identityModel.getProperty(label)).toBe(id);
   });
 
@@ -69,7 +69,7 @@ describe('Alias Management', () => {
 
     userNamespace.addAliases(aliases);
 
-    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    const identityModel = OneSignal._coreDirector._getIdentityModel();
     expect(identityModel.getProperty('someLabel')).toBe(aliases.someLabel);
     expect(identityModel.getProperty('anotherLabel')).toBe(
       aliases.anotherLabel,
@@ -80,7 +80,7 @@ describe('Alias Management', () => {
     const userNamespace = new UserNamespace(true);
     const label = 'some-label';
     const id = 'some-id';
-    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    const identityModel = OneSignal._coreDirector._getIdentityModel();
 
     // First add the alias
     userNamespace.addAlias(label, id);
@@ -98,7 +98,7 @@ describe('Alias Management', () => {
       someLabel: 'some-id',
       anotherLabel: 'another-id',
     };
-    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    const identityModel = OneSignal._coreDirector._getIdentityModel();
 
     // First add the aliases
     userNamespace.addAliases(aliases);
@@ -192,17 +192,17 @@ describe('Email Management', () => {
   const userNamespace = new UserNamespace(true);
   const getEmailSubscription = (email: string) => {
     const subscriptionModels =
-      OneSignal.coreDirector.getEmailSubscriptionModels();
+      OneSignal._coreDirector.getEmailSubscriptionModels();
     return subscriptionModels.find((model) => model.token === email);
   };
 
   test('can add an email subscription', async () => {
-    const identityModel = OneSignal.coreDirector.getIdentityModel();
-    identityModel.onesignalId = IDManager.createLocalId();
+    const identityModel = OneSignal._coreDirector._getIdentityModel();
+    identityModel.onesignalId = IDManager._createLocalId();
 
     const email = 'test@example.com';
     const addSubscriptionSpy = vi.spyOn(
-      OneSignal.coreDirector,
+      OneSignal._coreDirector,
       'addSubscriptionModel',
     );
 
@@ -215,8 +215,8 @@ describe('Email Management', () => {
   });
 
   test('should remove an email subscription', async () => {
-    const identityModel = OneSignal.coreDirector.getIdentityModel();
-    identityModel.onesignalId = IDManager.createLocalId();
+    const identityModel = OneSignal._coreDirector._getIdentityModel();
+    identityModel.onesignalId = IDManager._createLocalId();
 
     const email = 'test@example.com';
 
@@ -227,7 +227,7 @@ describe('Email Management', () => {
 
     // Then remove it
     const removeSubscriptionSpy = vi.spyOn(
-      OneSignal.coreDirector,
+      OneSignal._coreDirector,
       'removeSubscriptionModel',
     );
     userNamespace.removeEmail(email);
@@ -241,18 +241,18 @@ describe('Email Management', () => {
 describe('SMS Management', () => {
   const getSmsSubscription = (smsNumber: string) => {
     const subscriptionModels =
-      OneSignal.coreDirector.getSmsSubscriptionModels();
+      OneSignal._coreDirector.getSmsSubscriptionModels();
     return subscriptionModels.find((model) => model.token === smsNumber);
   };
 
   test('should add an SMS subscription', async () => {
     const userNamespace = new UserNamespace(true);
-    const identityModel = OneSignal.coreDirector.getIdentityModel();
-    identityModel.onesignalId = IDManager.createLocalId();
+    const identityModel = OneSignal._coreDirector._getIdentityModel();
+    identityModel.onesignalId = IDManager._createLocalId();
 
     const smsNumber = '+15551234567';
     const addSubscriptionSpy = vi.spyOn(
-      OneSignal.coreDirector,
+      OneSignal._coreDirector,
       'addSubscriptionModel',
     );
 
@@ -268,8 +268,8 @@ describe('SMS Management', () => {
     const userNamespace = new UserNamespace(true);
     const smsNumber = '+15551234567';
 
-    const identityModel = OneSignal.coreDirector.getIdentityModel();
-    identityModel.onesignalId = IDManager.createLocalId();
+    const identityModel = OneSignal._coreDirector._getIdentityModel();
+    identityModel.onesignalId = IDManager._createLocalId();
 
     // First add the SMS
     await userNamespace.addSms(smsNumber);
@@ -278,7 +278,7 @@ describe('SMS Management', () => {
 
     // Then remove it
     const removeSubscriptionSpy = vi.spyOn(
-      OneSignal.coreDirector,
+      OneSignal._coreDirector,
       'removeSubscriptionModel',
     );
     userNamespace.removeSms(smsNumber);
@@ -373,7 +373,7 @@ describe('Language Management', () => {
   test('should get language', () => {
     const userNamespace = new UserNamespace(true);
     const language = 'es';
-    const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
+    const propertiesModel = OneSignal._coreDirector._getPropertiesModel();
     propertiesModel.language = language;
 
     expect(userNamespace.getLanguage()).toBe(language);
@@ -381,7 +381,7 @@ describe('Language Management', () => {
 
   test('should return empty string if language is not set', () => {
     const userNamespace = new UserNamespace(true);
-    const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
+    const propertiesModel = OneSignal._coreDirector._getPropertiesModel();
     propertiesModel.language = undefined;
 
     expect(userNamespace.getLanguage()).toBe('');
@@ -455,12 +455,12 @@ describe('Initialization', () => {
     // with an existing onesignalId
     updateIdentityModel('onesignal_id', ONESIGNAL_ID);
     const user = new UserNamespace(true);
-    expect(IDManager.isLocalId(user.onesignalId)).toBe(false);
+    expect(IDManager._isLocalId(user.onesignalId)).toBe(false);
 
     // identity and properties models should have the same onesignalId
     const onesignalId = user.onesignalId;
 
-    const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
+    const propertiesModel = OneSignal._coreDirector._getPropertiesModel();
     expect(propertiesModel.onesignalId).toBe(onesignalId);
   });
 
@@ -469,12 +469,12 @@ describe('Initialization', () => {
     updateIdentityModel(IdentityConstants.ONESIGNAL_ID, undefined);
 
     const user = new UserNamespace(true);
-    expect(IDManager.isLocalId(user.onesignalId)).toBe(true);
+    expect(user.onesignalId).toBe(undefined); // since its local
+    const onesignalId = OneSignal._coreDirector._getIdentityModel().onesignalId;
+    expect(IDManager._isLocalId(onesignalId)).toBe(true);
 
     // identity and properties models should have the same onesignalId
-    const onesignalId = user.onesignalId;
-
-    const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
+    const propertiesModel = OneSignal._coreDirector._getPropertiesModel();
     expect(propertiesModel.onesignalId).toBe(onesignalId);
   });
 });
@@ -488,12 +488,12 @@ describe('Custom Events', () => {
       test_property: 'test_value',
     };
 
-    updateIdentityModel('onesignal_id', IDManager.createLocalId());
+    updateIdentityModel('onesignal_id', IDManager._createLocalId());
     userNamespace.trackEvent(name, {});
     expect(errorSpy).toHaveBeenCalledWith('User must be logged in first.');
     errorSpy.mockClear();
 
-    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    const identityModel = OneSignal._coreDirector._getIdentityModel();
     identityModel.setProperty(
       'onesignal_id',
       ONESIGNAL_ID,

--- a/src/onesignal/UserNamespace.ts
+++ b/src/onesignal/UserNamespace.ts
@@ -35,7 +35,7 @@ export default class UserNamespace extends EventListenerBase {
   }
 
   get externalId(): string | undefined {
-    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    const identityModel = OneSignal._coreDirector._getIdentityModel();
     return identityModel?.externalId;
   }
 

--- a/src/page/managers/LoginManager.ts
+++ b/src/page/managers/LoginManager.ts
@@ -24,8 +24,8 @@ export default class LoginManager {
       db.put('Ids', { id: token, type: 'jwtToken' });
     }
 
-    let identityModel = OneSignal.coreDirector.getIdentityModel();
-    const currentOneSignalId = !IDManager.isLocalId(identityModel.onesignalId)
+    let identityModel = OneSignal._coreDirector._getIdentityModel();
+    const currentOneSignalId = !IDManager._isLocalId(identityModel.onesignalId)
       ? identityModel.onesignalId
       : undefined;
     const currentExternalId = identityModel.externalId;
@@ -37,7 +37,7 @@ export default class LoginManager {
     }
 
     UserDirector.resetUserModels();
-    identityModel = OneSignal.coreDirector.getIdentityModel();
+    identityModel = OneSignal._coreDirector._getIdentityModel();
 
     // avoid duplicate identity requests, this is needed if dev calls init and login in quick succession e.g.
     // e.g. OneSignalDeferred.push(OneSignal) => OneSignal.init({...})); OneSignalDeferred.push(OneSignal) => OneSignal.login('some-external-id'));
@@ -50,9 +50,9 @@ export default class LoginManager {
     const appId = MainHelper.getAppId();
 
     const promises: Promise<void>[] = [
-      OneSignal.coreDirector.getPushSubscriptionModel().then((pushOp) => {
+      OneSignal._coreDirector.getPushSubscriptionModel().then((pushOp) => {
         if (pushOp) {
-          OneSignal.coreDirector.operationRepo.enqueue(
+          OneSignal._coreDirector.operationRepo.enqueue(
             new TransferSubscriptionOperation(
               appId,
               newIdentityOneSignalId,
@@ -61,7 +61,7 @@ export default class LoginManager {
           );
         }
       }),
-      OneSignal.coreDirector.operationRepo.enqueueAndWait(
+      OneSignal._coreDirector.operationRepo.enqueueAndWait(
         new LoginUserOperation(
           appId,
           newIdentityOneSignalId,
@@ -80,7 +80,7 @@ export default class LoginManager {
 
   private static async _logout(): Promise<void> {
     // check if user is already logged out
-    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    const identityModel = OneSignal._coreDirector._getIdentityModel();
 
     if (!identityModel.externalId)
       return Log.debug('Logout: User is not logged in, skipping logout');

--- a/src/page/managers/slidedownManager/SlidedownManager.ts
+++ b/src/page/managers/slidedownManager/SlidedownManager.ts
@@ -92,10 +92,10 @@ export class SlidedownManager {
     } else {
       if (!options.force) {
         const smsSubscribed = await (
-          OneSignal.coreDirector as CoreModuleDirector
+          OneSignal._coreDirector as CoreModuleDirector
         ).hasSms();
         const emailSubscribed = await (
-          OneSignal.coreDirector as CoreModuleDirector
+          OneSignal._coreDirector as CoreModuleDirector
         ).hasEmail();
         const bothSubscribed = smsSubscribed && emailSubscribed;
 
@@ -295,7 +295,7 @@ export class SlidedownManager {
         throw new Error('Categories not defined');
       }
 
-      const propertiesModel = OneSignal.coreDirector.getPropertiesModel();
+      const propertiesModel = OneSignal._coreDirector._getPropertiesModel();
       const existingTags = propertiesModel.tags;
 
       if (options.isInUpdateMode && existingTags) {

--- a/src/shared/listeners.test.ts
+++ b/src/shared/listeners.test.ts
@@ -91,7 +91,7 @@ describe('checkAndTriggerSubscriptionChanged', () => {
       token,
     });
     await setPushToken(token);
-    OneSignal.coreDirector.subscriptionModelStore.add(pushModel);
+    OneSignal._coreDirector.subscriptionModelStore.add(pushModel);
     getSubscriptionFn.mockResolvedValue({
       endpoint: token,
     });

--- a/src/shared/listeners.ts
+++ b/src/shared/listeners.ts
@@ -36,7 +36,7 @@ export async function checkAndTriggerSubscriptionChanged() {
   } = appState;
   const currentPushToken = await MainHelper.getCurrentPushToken();
 
-  const pushModel = await OneSignal.coreDirector.getPushSubscriptionModel();
+  const pushModel = await OneSignal._coreDirector.getPushSubscriptionModel();
   const pushSubscriptionId = pushModel?.id;
 
   const didStateChange =
@@ -122,7 +122,7 @@ export async function checkAndTriggerUserChanged() {
   const userState = await getUserState();
   const { previousOneSignalId, previousExternalId } = userState;
 
-  const identityModel = await OneSignal.coreDirector.getIdentityModel();
+  const identityModel = await OneSignal._coreDirector._getIdentityModel();
   const currentOneSignalId = identityModel?.onesignalId;
   const currentExternalId = identityModel?.externalId;
 

--- a/src/shared/managers/IDManager.ts
+++ b/src/shared/managers/IDManager.ts
@@ -21,7 +21,7 @@ export const IDManager = {
    * @param id - The ID to test.
    * @returns True if the ID was created via createLocalId.
    */
-  _isLocalId(id: string | undefined): boolean {
+  _isLocalId(id: string | undefined | null): boolean {
     return id?.startsWith(this.LOCAL_PREFIX) ?? false;
   },
 };

--- a/src/shared/managers/IDManager.ts
+++ b/src/shared/managers/IDManager.ts
@@ -11,7 +11,7 @@ export const IDManager = {
    *
    * @returns A new locally generated ID.
    */
-  createLocalId(): string {
+  _createLocalId(): string {
     return `${this.LOCAL_PREFIX}${crypto.randomUUID()}`;
   },
 
@@ -21,7 +21,7 @@ export const IDManager = {
    * @param id - The ID to test.
    * @returns True if the ID was created via createLocalId.
    */
-  isLocalId(id: string | undefined): boolean {
+  _isLocalId(id: string | undefined): boolean {
     return id?.startsWith(this.LOCAL_PREFIX) ?? false;
   },
 };

--- a/src/shared/managers/SubscriptionManager.test.ts
+++ b/src/shared/managers/SubscriptionManager.test.ts
@@ -34,7 +34,7 @@ describe('SubscriptionManager', () => {
       const rawSubscription = getRawPushSubscription();
 
       let subModels =
-        await OneSignal.coreDirector.subscriptionModelStore.list();
+        await OneSignal._coreDirector.subscriptionModelStore.list();
       expect(subModels.length).toBe(0);
 
       // mimicing the event helper checkAndTriggerSubscriptionChanged
@@ -42,11 +42,11 @@ describe('SubscriptionManager', () => {
 
       await updatePushSubscriptionModelWithRawSubscription(rawSubscription);
 
-      subModels = await OneSignal.coreDirector.subscriptionModelStore.list();
+      subModels = await OneSignal._coreDirector.subscriptionModelStore.list();
       expect(subModels.length).toBe(1);
 
       const id = subModels[0].id;
-      expect(IDManager.isLocalId(id)).toBe(true);
+      expect(IDManager._isLocalId(id)).toBe(true);
       expect(subModels[0].toJSON()).toEqual({
         id,
         ...BASE_SUB,
@@ -74,7 +74,7 @@ describe('SubscriptionManager', () => {
 
     test('should create user if push subscription model has a local id', async () => {
       const generatePushSubscriptionModelSpy = vi.spyOn(
-        OneSignal.coreDirector,
+        OneSignal._coreDirector,
         'generatePushSubscriptionModel',
       );
       const rawSubscription = getRawPushSubscription();
@@ -86,12 +86,12 @@ describe('SubscriptionManager', () => {
       });
 
       // create push sub with no id
-      const onesignalId = IDManager.createLocalId();
+      const onesignalId = IDManager._createLocalId();
       updateIdentityModel('onesignal_id', onesignalId);
       updateIdentityModel('external_id', 'some-external-id');
 
       await setupSubModelStore({
-        id: IDManager.createLocalId(),
+        id: IDManager._createLocalId(),
         token: rawSubscription.w3cEndpoint?.toString(),
         onesignalId,
       });
@@ -133,7 +133,7 @@ describe('SubscriptionManager', () => {
       await updatePushSubscriptionModelWithRawSubscription(rawSubscription);
 
       const updatedPushModel =
-        (await OneSignal.coreDirector.getPushSubscriptionModel())!;
+        (await OneSignal._coreDirector.getPushSubscriptionModel())!;
       expect(updatedPushModel.token).toBe(
         rawSubscription.w3cEndpoint?.toString(),
       );

--- a/src/shared/managers/UpdateManager.ts
+++ b/src/shared/managers/UpdateManager.ts
@@ -52,7 +52,7 @@ export class UpdateManager {
     }
 
     const subscriptionModel =
-      await OneSignal.coreDirector.getPushSubscriptionModel();
+      await OneSignal._coreDirector.getPushSubscriptionModel();
 
     if (
       subscriptionModel?.notification_types !== NotificationType.Subscribed &&
@@ -84,7 +84,7 @@ export class UpdateManager {
   ) {
     logMethodCall('sendOutcomeDirect');
     const pushSubscriptionModel =
-      await OneSignal.coreDirector.getPushSubscriptionModel();
+      await OneSignal._coreDirector.getPushSubscriptionModel();
 
     if (
       pushSubscriptionModel &&
@@ -119,7 +119,7 @@ export class UpdateManager {
   ) {
     logMethodCall('sendOutcomeInfluenced');
     const pushSubscriptionModel =
-      await OneSignal.coreDirector.getPushSubscriptionModel();
+      await OneSignal._coreDirector.getPushSubscriptionModel();
 
     if (
       pushSubscriptionModel &&
@@ -153,7 +153,7 @@ export class UpdateManager {
   ) {
     logMethodCall('sendOutcomeUnattributed');
     const pushSubscriptionModel =
-      await OneSignal.coreDirector.getPushSubscriptionModel();
+      await OneSignal._coreDirector.getPushSubscriptionModel();
 
     if (
       pushSubscriptionModel &&

--- a/src/shared/managers/sessionManager/SessionManager.ts
+++ b/src/shared/managers/sessionManager/SessionManager.ts
@@ -90,9 +90,9 @@ export class SessionManager implements ISessionManager {
     onesignalId: string;
     subscriptionId: string;
   }> {
-    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    const identityModel = OneSignal._coreDirector._getIdentityModel();
     const pushSubscriptionModel =
-      await OneSignal.coreDirector.getPushSubscriptionModel();
+      await OneSignal._coreDirector.getPushSubscriptionModel();
 
     if (!identityModel || !identityModel.onesignalId) {
       throw new Error('No identity');
@@ -353,7 +353,7 @@ export class SessionManager implements ISessionManager {
       return;
     }
 
-    const identityModel = OneSignal.coreDirector.getIdentityModel();
+    const identityModel = OneSignal._coreDirector._getIdentityModel();
     const onesignalId = identityModel.onesignalId;
 
     if (!onesignalId) {
@@ -364,7 +364,7 @@ export class SessionManager implements ISessionManager {
     }
 
     const pushSubscription =
-      await OneSignal.coreDirector.getPushSubscriptionModel();
+      await OneSignal._coreDirector.getPushSubscriptionModel();
     if (
       pushSubscription?.notification_types !== NotificationType.Subscribed &&
       OneSignal.config?.enableOnSession !== true

--- a/src/shared/managers/subscription/page.ts
+++ b/src/shared/managers/subscription/page.ts
@@ -55,15 +55,17 @@ export const updatePushSubscriptionModelWithRawSubscription = async (
   // otherwise there would be two login ops in the same bucket for LoginOperationExecutor which would error
   await LoginManager.switchingUsersPromise;
 
-  let pushModel = await OneSignal.coreDirector.getPushSubscriptionModel();
+  let pushModel = await OneSignal._coreDirector.getPushSubscriptionModel();
   // for new users, we need to create a new push subscription model and also save its push id to IndexedDB
   if (!pushModel) {
     pushModel =
-      OneSignal.coreDirector.generatePushSubscriptionModel(rawPushSubscription);
+      OneSignal._coreDirector.generatePushSubscriptionModel(
+        rawPushSubscription,
+      );
     return UserDirector.createUserOnServer();
   }
   // for users with data failed to create a user or user + subscription on the server
-  if (IDManager.isLocalId(pushModel.id)) {
+  if (IDManager._isLocalId(pushModel.id)) {
     return UserDirector.createUserOnServer();
   }
 
@@ -93,7 +95,7 @@ export class SubscriptionManagerPage extends SubscriptionManagerBase<ContextInte
   async updatePushSubscriptionNotificationTypes(
     notificationTypes: NotificationTypeValue,
   ): Promise<void> {
-    const pushModel = await OneSignal.coreDirector.getPushSubscriptionModel();
+    const pushModel = await OneSignal._coreDirector.getPushSubscriptionModel();
     if (!pushModel) {
       Log.info('No Push Subscription yet to update notification_types.');
       return;
@@ -167,7 +169,7 @@ export class SubscriptionManagerPage extends SubscriptionManagerBase<ContextInte
     const { optedOut, subscriptionToken } = await getSubscription();
 
     const pushSubscriptionModel =
-      await OneSignal.coreDirector.getPushSubscriptionModel();
+      await OneSignal._coreDirector.getPushSubscriptionModel();
     const isValidPushSubscription = isCompleteSubscriptionObject(
       pushSubscriptionModel,
     );


### PR DESCRIPTION
# Description
## 1 Line Summary
- Return undefined for local onesignal id and push subscription id

## Details
- Update User and PushSubscription class to return undefined if id is local

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1370)
<!-- Reviewable:end -->
