### PR TITLE
SDK-2932 Denied permission should trigger notifications listener

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,10 +46,15 @@
 
       // // uncomment to test push subscription change listener
       // OneSignalDeferred.push(function (OneSignal) {
-      //   OneSignal.User.PushSubscription.addEventListener(
-      //     'change',
-      //     pushSubscriptionChangeListener,
-      //   );
+      //   OneSignal.User.PushSubscription.addEventListener('change', (e) => {
+      //     console.log('PushSubscription.addEventListener', e);
+      //   });
+      //   OneSignal.Notifications.addEventListener('change', (e) => {
+      //     console.log('Notifications.addEventListener', e);
+      //   });
+      //   OneSignal.Notifications.addEventListener('permissionChange', (e) => {
+      //     console.log('permissionChange', e);
+      //   });
       // });
 
       // uncomment to test login

--- a/src/shared/helpers/permissions.ts
+++ b/src/shared/helpers/permissions.ts
@@ -51,12 +51,10 @@ const triggerBooleanPermissionChangeEvent = (
   force: boolean,
 ): void => {
   const newPermissionBoolean = newPermission === 'granted';
-  const previousPermissionBoolean = previousPermission === 'granted';
-  const triggerEvent =
-    newPermissionBoolean !== previousPermissionBoolean || force;
-  if (!triggerEvent) {
-    return;
-  }
+
+  const triggerEvent = newPermission !== previousPermission || force;
+  if (!triggerEvent) return;
+
   OneSignalEvent.trigger(
     OneSignal.EVENTS.NOTIFICATION_PERMISSION_CHANGED_AS_BOOLEAN,
     newPermissionBoolean,


### PR DESCRIPTION
# Description
## 1 Line Summary
- Addresses #1092 .Denied permission should still trigger notification permission change listeners

Before:

https://github.com/user-attachments/assets/124f2cf6-d544-4e9d-9530-13cc17694f2f

After:

https://github.com/user-attachments/assets/eac00061-3299-4ebe-ab9c-89714b7838e2


## Details
- Updates permission change handler to emit when permission is denied

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1374)
<!-- Reviewable:end -->
