### PR TITLE
SDK-2937 Automate portion of web cd pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,52 +43,9 @@ jobs:
           path: turbine
 
       - name: '[Deploy] Create turbine pr'
-        run: |
-          # Create new branch
-          BRANCH_NAME="web-sdk-${GITHUB_SHA::6}-release"
-
-          # Check if PR already exists
-          EXISTING_PR=$(curl -s \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/OneSignal/turbine/pulls?head=OneSignal:$BRANCH_NAME&state=open" \
-            | jq length)
-
-          if [ "$EXISTING_PR" -gt 0 ]; then
-            echo "PR already exists for branch $BRANCH_NAME"
-            exit 0
-          fi
-
-          git checkout -b "$BRANCH_NAME"
-
-          # Update only USERMODEL_WEB_SDK_VERSION
-          sed -i "s/USERMODEL_WEB_SDK_VERSION: [a-f0-9]\{40\}/USERMODEL_WEB_SDK_VERSION: ${GITHUB_SHA}/" .circleci/config.yml
-
-          # Check if changes were made
-          if git diff --exit-code; then
-            echo "No changes to commit"
-            exit 0
-          fi
-
-          # Commit changes
-          git add .circleci/config.yml
-          git commit -m "Update commit hash for ${GITHUB_SHA::6} web release" \
-                     -m "Job that successfully built the artifacts: https://github.com/OneSignal/OneSignal-Website-SDK/actions/runs/${GITHUB_RUN_ID}"
-
-          # Push to origin (you'll need to set up a fork)
-          git remote set-url origin https://x-access-token:${{ secrets.GH_TURBINE_TOKEN }}@github.com/OneSignal/turbine.git
-          git push origin "$BRANCH_NAME"
-
-          # Create pull request
-          curl -X POST \
-            -H "Authorization: Bearer ${{ secrets.GH_TURBINE_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"title\": \"Update commit hash for ${GITHUB_SHA::6} web release\",
-              \"body\": \"Job that successfully built the artifacts: https://github.com/OneSignal/OneSignal-Website-SDK/actions/runs/${GITHUB_RUN_ID}\",
-              \"head\": \"$BRANCH_NAME\",
-              \"base\": \"main\"
-            }" \
-            https://api.github.com/repos/OneSignal/turbine/pulls
-
+        run: ./build/scripts/turbine.sh
         env:
           GH_TURBINE_TOKEN: ${{ secrets.GH_TURBINE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,14 +3,18 @@ name: Build SDK Files & GCS Upload
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   test_build_deploy:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version-file: '.nvmrc'
 
@@ -35,17 +39,23 @@ jobs:
           destination: 'sdk-builds-persistence-onesignal/web-sdk/${{ github.sha }}'
           parent: false
 
+      - name: '[Deploy] Get SDK Version'
+        id: get_version
+        run: echo "SDK_VERSION=$(node -p "require('./package.json').config.sdkVersion")" >> $GITHUB_OUTPUT
+
       - name: '[Deploy] Checkout turbine repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           repository: OneSignal/turbine
           token: ${{ secrets.GH_TURBINE_TOKEN }}
           path: turbine
-
       - name: '[Deploy] Create turbine pr'
-        run: ./build/scripts/turbine.sh
+        run: |
+          cp ./build/scripts/turbine.sh ./turbine/
+          cd turbine
+          ./turbine.sh
         env:
           GH_TURBINE_TOKEN: ${{ secrets.GH_TURBINE_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_RUN_ID: ${{ github.run_id }}
+          SDK_VERSION: ${{ steps.get_version.outputs.SDK_VERSION }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,19 +13,82 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
+
       - name: '[Setup] Install dependencies'
         run: npm ci
+
       - name: '[Build] Staging'
         run: npm run build:staging
+
       - name: '[Build] Production'
         run: npm run build:prod
+
       - name: 'Authenticate to Google Cloud'
         uses: 'google-github-actions/auth@v1'
         with:
           credentials_json: '${{ secrets.GOOGLE_CREDENTIALS }}'
+
       - name: '[Deploy] Upload SDK Files to GCS'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
           path: 'build/releases'
           destination: 'sdk-builds-persistence-onesignal/web-sdk/${{ github.sha }}'
           parent: false
+
+      - name: '[Deploy] Checkout turbine repository'
+        uses: actions/checkout@v3
+        with:
+          repository: OneSignal/turbine
+          token: ${{ secrets.GH_TURBINE_TOKEN }}
+          path: turbine
+
+      - name: '[Deploy] Create turbine pr'
+        run: |
+          # Create new branch
+          BRANCH_NAME="web-sdk-${GITHUB_SHA::6}-release"
+
+          # Check if PR already exists
+          EXISTING_PR=$(curl -s \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/OneSignal/turbine/pulls?head=OneSignal:$BRANCH_NAME&state=open" \
+            | jq length)
+
+          if [ "$EXISTING_PR" -gt 0 ]; then
+            echo "PR already exists for branch $BRANCH_NAME"
+            exit 0
+          fi
+
+          git checkout -b "$BRANCH_NAME"
+
+          # Update only USERMODEL_WEB_SDK_VERSION
+          sed -i "s/USERMODEL_WEB_SDK_VERSION: [a-f0-9]\{40\}/USERMODEL_WEB_SDK_VERSION: ${GITHUB_SHA}/" .circleci/config.yml
+
+          # Check if changes were made
+          if git diff --exit-code; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          # Commit changes
+          git add .circleci/config.yml
+          git commit -m "Update commit hash for ${GITHUB_SHA::6} web release" \
+                     -m "Job that successfully built the artifacts: https://github.com/OneSignal/OneSignal-Website-SDK/actions/runs/${GITHUB_RUN_ID}"
+
+          # Push to origin (you'll need to set up a fork)
+          git remote set-url origin https://x-access-token:${{ secrets.GH_TURBINE_TOKEN }}@github.com/OneSignal/turbine.git
+          git push origin "$BRANCH_NAME"
+
+          # Create pull request
+          curl -X POST \
+            -H "Authorization: Bearer ${{ secrets.GH_TURBINE_TOKEN }}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"title\": \"Update commit hash for ${GITHUB_SHA::6} web release\",
+              \"body\": \"Job that successfully built the artifacts: https://github.com/OneSignal/OneSignal-Website-SDK/actions/runs/${GITHUB_RUN_ID}\",
+              \"head\": \"$BRANCH_NAME\",
+              \"base\": \"main\"
+            }" \
+            https://api.github.com/repos/OneSignal/turbine/pulls
+
+        env:
+          GH_TURBINE_TOKEN: ${{ secrets.GH_TURBINE_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,17 +43,8 @@ jobs:
         id: get_version
         run: echo "SDK_VERSION=$(node -p "require('./package.json').config.sdkVersion")" >> $GITHUB_OUTPUT
 
-      - name: '[Deploy] Checkout turbine repository'
-        uses: actions/checkout@v5
-        with:
-          repository: OneSignal/turbine
-          token: ${{ secrets.GH_TURBINE_TOKEN }}
-          path: turbine
       - name: '[Deploy] Create turbine pr'
-        run: |
-          cp ./build/scripts/turbine.sh ./turbine/
-          cd turbine
-          ./turbine.sh
+        run: ./build/scripts/turbine.sh
         env:
           GH_TURBINE_TOKEN: ${{ secrets.GH_TURBINE_TOKEN }}
           GITHUB_SHA: ${{ github.sha }}

--- a/build/scripts/turbine.sh
+++ b/build/scripts/turbine.sh
@@ -40,19 +40,17 @@ JOB_MESSAGE="Job that successfully built the artifacts: https://github.com/OneSi
 git add .circleci/config.yml
 git commit -m "$RELEASE_MESSAGE" -m "$JOB_MESSAGE"
 
-# Push to origin
-git push -u origin "$BRANCH_NAME"
+# Push to origin (override any existing branch)
+git push --force origin "$BRANCH_NAME"
 
-exit 0
-
-# Create pull request - use full owner:branch format for head
+# Create pull request
 curl -sS -X POST \
   -H "Authorization: Bearer $GH_TURBINE_TOKEN" \
   -H "Content-Type: application/json" \
   -d "{
-\"title\": \"$RELEASE_MESSAGE\",
-\"body\": \"$JOB_MESSAGE\",
-\"head\": \"OneSignal:$BRANCH_NAME\",
-\"base\": \"main\"
-}" \
+    \"title\": \"$RELEASE_MESSAGE\",
+    \"body\": \"$JOB_MESSAGE\",
+    \"head\": \"OneSignal:$BRANCH_NAME\",
+    \"base\": \"main\"
+  }" \
   https://api.github.com/repos/OneSignal/turbine/pulls

--- a/build/scripts/turbine.sh
+++ b/build/scripts/turbine.sh
@@ -44,13 +44,25 @@ git commit -m "$RELEASE_MESSAGE" -m "$JOB_MESSAGE"
 git push --force origin "$BRANCH_NAME"
 
 # Create pull request
+PR_NUMBER=$(
+  curl -sS -X POST \
+    -H "Authorization: Bearer $GH_TURBINE_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"title\": \"$RELEASE_MESSAGE\",
+      \"body\": \"$JOB_MESSAGE\",
+      \"head\": \"$BRANCH_NAME\",
+      \"base\": \"main\"
+    }" \
+    https://api.github.com/repos/OneSignal/turbine/pulls |
+    jq -r '.number'
+)
+
+# Request team reviewers
 curl -sS -X POST \
   -H "Authorization: Bearer $GH_TURBINE_TOKEN" \
   -H "Content-Type: application/json" \
   -d "{
-    \"title\": \"$RELEASE_MESSAGE\",
-    \"body\": \"$JOB_MESSAGE\",
-    \"head\": \"OneSignal:$BRANCH_NAME\",
-    \"base\": \"main\"
+    \"team_reviewers\": [\"eng-sdk-platform\"]
   }" \
-  https://api.github.com/repos/OneSignal/turbine/pulls
+  "https://api.github.com/repos/OneSignal/turbine/pulls/${PR_NUMBER}/requested_reviewers"

--- a/build/scripts/turbine.sh
+++ b/build/scripts/turbine.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -euo pipefail
 
+git clone "https://${GH_TURBINE_TOKEN}@github.com/OneSignal/turbine.git" turbine
+cd turbine
+
 # Configure git identity
 git config user.name "github-actions[bot]"
 git config user.email "github-actions[bot]@users.noreply.github.com"
-
-# ensure origin has auth for push (actions/checkout sets this, but we make it explicit)
-git remote set-url origin "https://x-access-token:${GH_TURBINE_TOKEN}@github.com/OneSignal/turbine.git"
 
 # Create new branch
 BRANCH_NAME="web-sdk-${SDK_VERSION}-release"
@@ -22,7 +22,7 @@ if [ "$EXISTING_PR" -gt 0 ]; then
   exit 0
 fi
 
-git checkout -b "$BRANCH_NAME"
+git checkout -B "$BRANCH_NAME"
 
 # Update only USERMODEL_WEB_SDK_VERSION
 sed -i "s/USERMODEL_WEB_SDK_VERSION: [a-f0-9]\{40\}/USERMODEL_WEB_SDK_VERSION: ${GITHUB_SHA}/" .circleci/config.yml
@@ -41,7 +41,7 @@ git add .circleci/config.yml
 git commit -m "$RELEASE_MESSAGE" -m "$JOB_MESSAGE"
 
 # Push to origin
-git push origin "$BRANCH_NAME"
+git push -u origin "$BRANCH_NAME"
 
 exit 0
 

--- a/build/scripts/turbine.sh
+++ b/build/scripts/turbine.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# For creating a pr to turbine to update the web sdk version target commit
+# Get the SDK version
+SDK_VERSION=$(node -p "require('./package.json').config.sdkVersion")
+
+cd turbine
+
+# Create new branch
+BRANCH_NAME="web-sdk-${SDK_VERSION}-release"
+
+# Check if PR already exists
+EXISTING_PR=$(curl -s \
+  -H "Authorization: Bearer $GH_TURBINE_TOKEN" \
+  "https://api.github.com/repos/OneSignal/turbine/pulls?head=OneSignal:$BRANCH_NAME&state=open" |
+  jq length)
+
+if [ "$EXISTING_PR" -gt 0 ]; then
+  echo "PR already exists for branch $BRANCH_NAME"
+  exit 0
+fi
+
+git checkout -b "$BRANCH_NAME"
+
+# Update only USERMODEL_WEB_SDK_VERSION
+sed -i "s/USERMODEL_WEB_SDK_VERSION: [a-f0-9]\{40\}/USERMODEL_WEB_SDK_VERSION: ${GITHUB_SHA}/" .circleci/config.yml
+
+# Check if changes were made
+if git diff --exit-code; then
+  echo "No changes to commit"
+  exit 0
+fi
+
+# Commit changes
+RELEASE_MESSAGE="Update SDK version to ${SDK_VERSION} for web release"
+JOB_MESSAGE="Job that successfully built the artifacts: https://github.com/OneSignal/OneSignal-Website-SDK/actions/runs/${GITHUB_RUN_ID}"
+
+git add .circleci/config.yml
+git commit -m "$RELEASE_MESSAGE" -m "$JOB_MESSAGE"
+
+# Push to origin (you'll need to set up a fork)
+git remote set-url origin https://x-access-token:${GH_TURBINE_TOKEN}@github.com/OneSignal/turbine.git
+git push origin "$BRANCH_NAME"
+
+# Create pull request
+curl -X POST \
+  -H "Authorization: Bearer $GH_TURBINE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{
+\"title\": \"$RELEASE_MESSAGE\",
+\"body\": \"$JOB_MESSAGE\",
+\"head\": \"$BRANCH_NAME\",
+\"base\": \"main\"
+}" \
+  https://api.github.com/repos/OneSignal/turbine/pulls

--- a/build/scripts/turbine.sh
+++ b/build/scripts/turbine.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
-
-# For creating a pr to turbine to update the web sdk version target commit
-# Get the SDK version
-SDK_VERSION=$(node -p "require('./package.json').config.sdkVersion")
-
-cd turbine
+set -euo pipefail
 
 # Configure git identity
-git config user.email "github-actions[bot]@users.noreply.github.com"
 git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+# ensure origin has auth for push (actions/checkout sets this, but we make it explicit)
+git remote set-url origin "https://x-access-token:${GH_TURBINE_TOKEN}@github.com/OneSignal/turbine.git"
 
 # Create new branch
 BRANCH_NAME="web-sdk-${SDK_VERSION}-release"
@@ -42,18 +40,19 @@ JOB_MESSAGE="Job that successfully built the artifacts: https://github.com/OneSi
 git add .circleci/config.yml
 git commit -m "$RELEASE_MESSAGE" -m "$JOB_MESSAGE"
 
-# Push to origin (you'll need to set up a fork)
-git remote set-url origin https://x-access-token:${GH_TURBINE_TOKEN}@github.com/OneSignal/turbine.git
+# Push to origin
 git push origin "$BRANCH_NAME"
 
-# Create pull request
-curl -X POST \
+exit 0
+
+# Create pull request - use full owner:branch format for head
+curl -sS -X POST \
   -H "Authorization: Bearer $GH_TURBINE_TOKEN" \
   -H "Content-Type: application/json" \
   -d "{
 \"title\": \"$RELEASE_MESSAGE\",
 \"body\": \"$JOB_MESSAGE\",
-\"head\": \"$BRANCH_NAME\",
+\"head\": \"OneSignal:$BRANCH_NAME\",
 \"base\": \"main\"
 }" \
   https://api.github.com/repos/OneSignal/turbine/pulls

--- a/build/scripts/turbine.sh
+++ b/build/scripts/turbine.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
+
 # For creating a pr to turbine to update the web sdk version target commit
 # Get the SDK version
 SDK_VERSION=$(node -p "require('./package.json').config.sdkVersion")
 
 cd turbine
+
+# Configure git identity
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git config user.name "github-actions[bot]"
 
 # Create new branch
 BRANCH_NAME="web-sdk-${SDK_VERSION}-release"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx; prettylint 'src/**/*' 'test/**/*' '__test__/**/*' --no-editorconfig"
   },
   "config": {
-    "sdkVersion": "160508"
+    "sdkVersion": "160509"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description
## 1 Line Summary
- automate creation of turbine pr
<img width="1179" height="679" alt="Screenshot 2025-09-10 at 4 08 41 PM" src="https://github.com/user-attachments/assets/ba0cec3a-6849-4684-8e93-a90d95eed8c3" />

## Details
- adds script to the cd workflow to automate creating turbine pr:
  - clones turbine repo and creates/update the sdk release branch
  - creates the pr diff with the updated commit sha for user model field

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---
