### PR TITLE
chore(api): add `User.trackEvent` definition to API spec

### DIFF
--- a/api.json
+++ b/api.json
@@ -509,6 +509,23 @@
         "isAsync": false,
         "args": [],
         "returnType": "string"
+      },
+      {
+        "name": "trackEvent",
+        "isAsync": false,
+        "args": [
+          {
+            "name": "name",
+            "type": "string",
+            "optional": false
+          },
+          {
+            "name": "properties",
+            "type": "Record<string, unknown>",
+            "optional": true
+          }
+        ],
+        "returnType": "void"
       }
     ],
     "properties": [

--- a/src/page/managers/slidedownManager/SlidedownManager.test.ts
+++ b/src/page/managers/slidedownManager/SlidedownManager.test.ts
@@ -314,6 +314,7 @@ export const mockPhoneLibraryLoading = () => {
 
     window.intlTelInputUtils = {
       numberType: { MOBILE: 1 },
+      // @ts-expect-error - mock intl-tel-input
       numberFormat: { E164: 0 },
     };
 

--- a/src/page/managers/slidedownManager/SlidedownManager.test.ts
+++ b/src/page/managers/slidedownManager/SlidedownManager.test.ts
@@ -314,7 +314,6 @@ export const mockPhoneLibraryLoading = () => {
 
     window.intlTelInputUtils = {
       numberType: { MOBILE: 1 },
-      // @ts-expect-error - mock intl-tel-input
       numberFormat: { E164: 0 },
     };
 


### PR DESCRIPTION
# Description
## 1 Line Summary
Adds the definition for `User.trackEvent` to the API spec (see more details [on docs](https://documentation.onesignal.com/docs/web-sdk-reference#trackevent)). This will then generate and push the definitions downstream to https://github.com/OneSignal/web-shim-codegen and the web wrappers.

## Details

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [x] Don't use default export
   - [x] New interfaces are in model files

Functions:
   - [x] Don't use default export
   - [x] All function signatures have return types
   - [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [x] No Typescript warnings
   - [x] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1380)
<!-- Reviewable:end -->
