### PR TITLE
fix create release on github permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,22 +11,29 @@ on:
 jobs:
   check_release:
     runs-on: ubuntu-22.04
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
     steps:
       - name: Check if release merge or workflow dispatch
-        id: check_release
+        id: check
         uses: actions/github-script@v8
         with:
           script: |
-            // Allow workflow_dispatch and release PR merges
-            if (context.eventName !== 'push') return;
+            let shouldRun = false;
 
-            // For push events, check if it's a release merge
-            const isReleaseMerge = /Release \d{6}/.test(context.payload.head_commit.message);
-            if (!isReleaseMerge) core.setFailed('Not a release merge - skipping workflow');
+            if (context.eventName === 'workflow_dispatch') {
+              shouldRun = true;
+            } else if (context.eventName === 'push') {
+              const isReleaseMerge = /Release \d{6}/.test(context.payload.head_commit.message);
+              shouldRun = isReleaseMerge;
+            }
+
+            core.setOutput('should_run', shouldRun);
 
   test_build_deploy:
     runs-on: ubuntu-22.04
     needs: check_release
+    if: needs.check_release.outputs.should_run == 'true'
     steps:
       - uses: actions/checkout@v5
       - name: Use Node.js

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,15 +19,8 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            let shouldRun = false;
-
-            if (context.eventName === 'workflow_dispatch') {
-              shouldRun = true;
-            } else if (context.eventName === 'push') {
-              const isReleaseMerge = /Release \d{6}/.test(context.payload.head_commit.message);
-              shouldRun = isReleaseMerge;
-            }
-
+            const shouldRun = context.eventName === 'workflow_dispatch' ||
+                             /Release \d{6}/.test(context.payload.head_commit.message);
             core.setOutput('should_run', shouldRun);
 
   test_build_deploy:

--- a/.github/workflows/create-release-on-github.yml
+++ b/.github/workflows/create-release-on-github.yml
@@ -7,9 +7,6 @@ jobs:
   create-release-notes:
     runs-on: ubuntu-latest
 
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     steps:
       - uses: actions/checkout@v5
         with:
@@ -59,17 +56,23 @@ jobs:
               return;
             }
 
-            core.setOutput('notes', releasePr.body);
+            const releaseNotes = releasePr.body.split('<!--')[0].trim();
+            core.setOutput('notes', releaseNotes);
+
       - name: Create GitHub Release
         uses: actions/github-script@v8
+        env:
+          RELEASE_NOTES: ${{ steps.release_notes.outputs.notes }}
         with:
           script: |
+            const notes = process.env.RELEASE_NOTES;
+
             await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: '${{ steps.get_version.outputs.version }}',
               name: 'Release ${{ steps.get_version.outputs.version }}',
-              body: '${{ steps.release_notes.outputs.notes }}',
+              body: notes,
               draft: false,
               prerelease: false
             });

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -103,7 +103,11 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const prs = JSON.parse('${{ steps.get_prs.outputs.prs }}');
+            // Trim whitespace from PR titles
+            const prs = JSON.parse('${{ steps.get_prs.outputs.prs }}').map(pr => ({
+              ...pr,
+              title: pr.title.trim()
+            }));
 
             // Categorize PRs
             const features = prs.filter(pr => /^feat/i.test(pr.title));


### PR DESCRIPTION
# Description
## 1 Line Summary
Clean up create release notes workflow

## Details
- update create release notes workflow to clean up pr body notes (to remove reviewable section)
- update cd workflow to not error for pushes on main

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [ ] All the automated tests pass or I explained why that is not possible
   - [ ] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1392)
<!-- Reviewable:end -->
