### PR TITLE
refactor: replace `.toReversed()` with `[...arr].reverse()` for compatibility

### DIFF
--- a/src/core/executors/SubscriptionOperationExecutor.ts
+++ b/src/core/executors/SubscriptionOperationExecutor.ts
@@ -89,8 +89,8 @@ export class SubscriptionOperationExecutor implements IOperationExecutor {
     if (operations.some((op) => op instanceof DeleteSubscriptionOperation))
       return new ExecutionResponse(ExecutionResult.SUCCESS);
 
-    const lastUpdateOperation = operations
-      .toReversed()
+    const lastUpdateOperation = [...operations]
+      .reverse()
       .find((op) => op instanceof UpdateSubscriptionOperation);
     const enabled = lastUpdateOperation?.enabled ?? createOperation.enabled;
     const token = lastUpdateOperation?.token ?? createOperation.token;

--- a/src/core/operationRepo/OperationRepo.ts
+++ b/src/core/operationRepo/OperationRepo.ts
@@ -234,7 +234,7 @@ export class OperationRepo implements IOperationRepo, IStartableService {
         case ExecutionResult.FAIL_RETRY:
           Log._error(`Operation execution failed, retrying: ${operations}`);
           // Add back all operations to front of queue
-          ops.toReversed().forEach((op) => {
+          [...ops].reverse().forEach((op) => {
             removeOpFromDB(op.operation);
             op.retries++;
             if (op.retries > highestRetries) {
@@ -248,7 +248,7 @@ export class OperationRepo implements IOperationRepo, IStartableService {
           Log._error(`Operation failed, pausing ops:${operations}`);
           this._pause();
           ops.forEach((op) => op.resolver?.(false));
-          ops.toReversed().forEach((op) => {
+          [...ops].reverse().forEach((op) => {
             removeOpFromDB(op.operation);
             this.queue.unshift(op);
           });
@@ -257,7 +257,7 @@ export class OperationRepo implements IOperationRepo, IStartableService {
 
       // Handle additional operations from the response
       if (response.operations) {
-        for (const op of response.operations.toReversed()) {
+        for (const op of [...response.operations].reverse()) {
           const queueItem = new OperationQueueItem({
             operation: op,
             bucket: 0,
@@ -360,7 +360,7 @@ export class OperationRepo implements IOperationRepo, IStartableService {
 
   public async _loadSavedOperations(): Promise<void> {
     await this._operationModelStore.loadOperations();
-    const operations = this._operationModelStore.list().toReversed();
+    const operations = [...this._operationModelStore.list()].reverse();
 
     for (const operation of operations) {
       this._internalEnqueue(


### PR DESCRIPTION
# Description
## 1 Line Summary

Resolves https://github.com/OneSignal/react-onesignal/issues/188, which seems to be a possible compatibility issue with versions of Chrome older than v110. To be safe, this PR replaces instances of `toReversed()` with a more backwards-compatible syntax.

## Details

# Systems Affected
   - [x] WebSDK
   - [ ] Backend
   - [ ] Dashboard

# Validation
## Tests
### Info

### Checklist
   - [x] All the automated tests pass or I explained why that is not possible
   - [x] I have personally tested this on my machine or explained why that is not possible
   - [ ] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:
   - [ ] Don't use default export
   - [ ] New interfaces are in model files

Functions:
   - [ ] Don't use default export
   - [ ] All function signatures have return types
   - [ ] Helpers should not access any data but rather be given the data to operate on.

Typescript:
   - [ ] No Typescript warnings
   - [ ] Avoid silencing null/undefined warnings with the exclamation point

Other:
   - [ ] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
   - [ ] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots
### Info

### Checklist
   - [ ] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

---

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/OneSignal/OneSignal-Website-SDK/1394)
<!-- Reviewable:end -->
