### PR TITLE
fix: [SDK-4341] populate push token from raw subscription for local-id models

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "42.28 kB",
+      "limit": "42.3 kB",
       "gzip": true
     },
     {

--- a/src/shared/managers/SubscriptionManager.test.ts
+++ b/src/shared/managers/SubscriptionManager.test.ts
@@ -112,9 +112,53 @@ describe('SubscriptionManager', () => {
             ...BASE_SUB,
             token: rawSubscription.w3cEndpoint?.toString(),
             type: 'ChromePush',
+            web_auth: rawSubscription.w3cAuth,
+            web_p256: rawSubscription.w3cP256dh,
           },
         ],
       });
+    });
+
+    test('should populate token from rawPushSubscription when model has local id and empty token (SDK-4341)', async () => {
+      const rawSubscription = getRawPushSubscription();
+      mockPushManager.getSubscription.mockResolvedValue(
+        Object.assign({}, mockPushSubscription, {
+          endpoint: rawSubscription.w3cEndpoint?.toString(),
+        }),
+      );
+      setCreateUserResponse({
+        externalId: 'some-external-id',
+      });
+
+      const onesignalId = IDManager._createLocalId();
+      updateIdentityModel('onesignal_id', onesignalId);
+      updateIdentityModel('external_id', 'some-external-id');
+
+      // Simulate what login() actually does: placeholder model with local id and EMPTY token
+      await setupSubModelStore({
+        id: IDManager._createLocalId(),
+        token: '',
+        onesignalId,
+      });
+
+      await updatePushSubscriptionModelWithRawSubscription(rawSubscription);
+
+      // The server request should include the real token from rawPushSubscription,
+      // NOT the empty string from the placeholder model
+      await vi.waitUntil(() => createUserFn.mock.calls.length > 0);
+      expect(createUserFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subscriptions: [
+            expect.objectContaining({
+              token: rawSubscription.w3cEndpoint?.toString(),
+            }),
+          ],
+        }),
+      );
+
+      // The local model should also be updated with the token
+      const pushModel = (await OneSignal._coreDirector._getPushSubscriptionModel())!;
+      expect(pushModel.token).toBe(rawSubscription.w3cEndpoint?.toString());
     });
 
     test('should update the push subscription model if it already exists', async () => {

--- a/src/shared/managers/subscription/page.ts
+++ b/src/shared/managers/subscription/page.ts
@@ -63,6 +63,17 @@ async function createSubscribedUser(pushModel: SubscriptionModel): Promise<void>
   );
 }
 
+function updateModelFromRawSubscription(
+  pushModel: SubscriptionModel,
+  rawPushSubscription: RawPushSubscription,
+): void {
+  const serialized = new FuturePushSubscriptionRecord(rawPushSubscription)._serialize();
+  for (const key in serialized) {
+    const modelKey = key as keyof typeof serialized;
+    pushModel._setProperty(modelKey, serialized[modelKey]);
+  }
+}
+
 export const updatePushSubscriptionModelWithRawSubscription = async (
   rawPushSubscription: RawPushSubscription,
 ) => {
@@ -78,17 +89,12 @@ export const updatePushSubscriptionModelWithRawSubscription = async (
   }
   // for users with data failed to create a user or user + subscription on the server
   if (IDManager._isLocalId(pushModel.id)) {
+    updateModelFromRawSubscription(pushModel, rawPushSubscription);
     return createSubscribedUser(pushModel);
   }
 
   // in case of notification state changes, we need to update its web_auth, web_p256, and other keys
-  const serializedSubscriptionRecord = new FuturePushSubscriptionRecord(
-    rawPushSubscription,
-  )._serialize();
-  for (const key in serializedSubscriptionRecord) {
-    const modelKey = key as keyof typeof serializedSubscriptionRecord;
-    pushModel._setProperty(modelKey, serializedSubscriptionRecord[modelKey]);
-  }
+  updateModelFromRawSubscription(pushModel, rawPushSubscription);
 };
 
 export class SubscriptionManagerPage extends SubscriptionManagerBase<ContextInterface> {


### PR DESCRIPTION
# Description

## 1 Line Summary

Fix subscriptions created with no push token when `login()` is called before `optIn()`.

## Details

When `login()` creates a placeholder `SubscriptionModel` with a `local-` id and empty `token: ''`, the subsequent `optIn()` flow obtains the real push token via `rawPushSubscription`. However, Branch 2 of `updatePushSubscriptionModelWithRawSubscription` was calling `createSubscribedUser(pushModel)` with the stale empty-token model, discarding the `rawPushSubscription` entirely:

```ts
// Branch 2 (before fix): rawPushSubscription is never used
if (IDManager._isLocalId(pushModel.id)) {
  return createSubscribedUser(pushModel); // pushModel.token is '' from login() placeholder
}
```

The fix extracts the model-update logic into `updateModelFromRawSubscription()` and calls it **before** `createSubscribedUser()` in the local-id branch, ensuring the token, `web_auth`, and `web_p256` fields are populated from the actual push subscription data.

# Systems Affected

- [x] WebSDK
- [ ] Backend
- [ ] Dashboard

# Validation

## Tests

### Info

- Added a new unit test `should populate token from rawPushSubscription when model has local id and empty token (SDK-4341)` that reproduces the exact bug conditions: a model with a `local-` id and `token: ''` (the realistic state produced by `login()`). This test **failed** before the fix and now passes.
- Updated the existing `should create user if push subscription model has a local id` test to expect the `web_auth` and `web_p256` fields that are now correctly populated from the raw subscription.

### Checklist

- [x] All the automated tests pass or I explained why that is not possible
- [x] I have personally tested this on my machine or explained why that is not possible
- [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:

- [x] Don't use default export
- [x] New interfaces are in model files

Functions:

- [x] Don't use default export
- [x] All function signatures have return types
- [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:

- [x] No Typescript warnings
- [x] Avoid silencing null/undefined warnings with the exclamation point

Other:

- [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
- [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots

### Info

N/A — internal logic fix with no UI changes.

### Checklist

- [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

- [SDK-4341](https://linear.app/onesignal/issue/SDK-4341/safari-subscription-created-with-no-push-token-on-custom-web-setup)

---