### PR TITLE
ci: [SDK-4482] use GH_PUSH_TOKEN for release and project workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,7 +78,7 @@ jobs:
         if: steps.get_version.outputs.version != ''
         run: ./build/scripts/turbine.sh
         env:
-          GH_TURBINE_TOKEN: ${{ secrets.GH_TURBINE_TOKEN }}
+          GH_PUSH_TOKEN: ${{ secrets.GH_PUSH_TOKEN }}
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_RUN_ID: ${{ github.run_id }}
           SDK_VERSION: ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           # SDK Web Project
           project-url: https://github.com/orgs/OneSignal/projects/9
-          github-token: ${{ secrets.GH_PROJECTS_TOKEN }}
+          github-token: ${{ secrets.GH_PUSH_TOKEN }}

--- a/build/scripts/turbine.sh
+++ b/build/scripts/turbine.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-git clone "https://${GH_TURBINE_TOKEN}@github.com/OneSignal/turbine.git" turbine
+git clone "https://${GH_PUSH_TOKEN}@github.com/OneSignal/turbine.git" turbine
 cd turbine
 
 # Configure git identity
@@ -13,12 +13,12 @@ BRANCH_NAME="web-sdk-${SDK_VERSION}-release"
 
 # Close any existing PRs for this branch
 curl -s \
-  -H "Authorization: Bearer $GH_TURBINE_TOKEN" \
+  -H "Authorization: Bearer $GH_PUSH_TOKEN" \
   "https://api.github.com/repos/OneSignal/turbine/pulls?head=OneSignal:$BRANCH_NAME&state=open" |
   jq -r '.[].number' | while read PR_NUM; do
     echo "Closing existing PR #$PR_NUM"
     curl -sS -X PATCH \
-      -H "Authorization: Bearer $GH_TURBINE_TOKEN" \
+      -H "Authorization: Bearer $GH_PUSH_TOKEN" \
       -H "Content-Type: application/json" \
       -d '{"state": "closed"}' \
       "https://api.github.com/repos/OneSignal/turbine/pulls/$PR_NUM"
@@ -48,7 +48,7 @@ git push --force origin "$BRANCH_NAME"
 # Create pull request
 PR_NUMBER=$(
   curl -sS -X POST \
-    -H "Authorization: Bearer $GH_TURBINE_TOKEN" \
+    -H "Authorization: Bearer $GH_PUSH_TOKEN" \
     -H "Content-Type: application/json" \
     -d "{
       \"title\": \"$RELEASE_MESSAGE\",
@@ -62,7 +62,7 @@ PR_NUMBER=$(
 
 # Request team reviewers
 curl -sS -X POST \
-  -H "Authorization: Bearer $GH_TURBINE_TOKEN" \
+  -H "Authorization: Bearer $GH_PUSH_TOKEN" \
   -H "Content-Type: application/json" \
   -d "{
     \"team_reviewers\": [\"eng-sdk-platform\"]


### PR DESCRIPTION
# Description

## 1 Line Summary

Switch the CD release workflow and project automation to use the unified `GH_PUSH_TOKEN` secret in place of `GH_TURBINE_TOKEN` and `GH_PROJECTS_TOKEN`.

## Details

- `cd.yml`: pass `GH_PUSH_TOKEN` to `turbine.sh` so it can clone, push, and open PRs against the turbine repo.
- `project.yml`: use `GH_PUSH_TOKEN` for the SDK Web project automation token.
- `build/scripts/turbine.sh`: read from `GH_PUSH_TOKEN` instead of `GH_TURBINE_TOKEN` for the clone URL, PR listing/closing, PR creation, and team reviewer requests.

This consolidates the per-purpose tokens onto a single org-managed token used across SDK CI workflows.

# Systems Affected

- [x] WebSDK
- [ ] Backend
- [ ] Dashboard

# Validation

## Tests

### Info

CI-only change. Will be validated on the next release run that triggers `cd.yml` and on subsequent issue/PR events that trigger `project.yml`. The `GH_PUSH_TOKEN` secret must be configured at the repo or org level before merging.

### Checklist

- [x] All the automated tests pass or I explained why that is not possible
- [x] I have personally tested this on my machine or explained why that is not possible
- [x] I have included test coverage for these changes or explained why they are not needed

## Screenshots

### Info

N/A — workflow/script changes only.

### Checklist

- [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

[SDK-4482](https://linear.app/onesignal/issue/SDK-4482)

---

Made with [Cursor](https://cursor.com)