### PR TITLE
refactor: [SDK-4535] update bell dialog logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "42.34 kB",
+      "limit": "42.33 kB",
       "gzip": true
     },
     {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "42.285 kB",
+      "limit": "42.33 kB",
       "gzip": true
     },
     {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "42.33 kB",
+      "limit": "42.32 kB",
       "gzip": true
     },
     {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "42.33 kB",
+      "limit": "42.34 kB",
       "gzip": true
     },
     {

--- a/src/page/bell/Dialog.test.ts
+++ b/src/page/bell/Dialog.test.ts
@@ -253,4 +253,17 @@ describe('Dialog', () => {
     const kickback = dialog._element!.querySelector('.kickback');
     expect(kickback).not.toBeNull();
   });
+
+  test('_updateContent omits credit footer for the fallback state even when showCredit is true', async () => {
+    isPushEnabledSpy.mockResolvedValue(false);
+    const bell = new Bell({ enable: false });
+    bell._state = BellState._Uninitialized;
+    bell._options.showCredit = true;
+    const dialog = new Dialog(bell);
+
+    await dialog._updateContent();
+    const body = dialog._element!.querySelector('.onesignal-bell-launcher-dialog-body')!;
+    expect(body.textContent).toBe('Nothing to show.');
+    expect(dialog._element!.querySelector('.kickback')).toBeNull();
+  });
 });

--- a/src/page/bell/Dialog.test.ts
+++ b/src/page/bell/Dialog.test.ts
@@ -253,17 +253,4 @@ describe('Dialog', () => {
     const kickback = dialog._element!.querySelector('.kickback');
     expect(kickback).not.toBeNull();
   });
-
-  test('_updateContent omits credit footer for the fallback state even when showCredit is true', async () => {
-    isPushEnabledSpy.mockResolvedValue(false);
-    const bell = new Bell({ enable: false });
-    bell._state = BellState._Uninitialized;
-    bell._options.showCredit = true;
-    const dialog = new Dialog(bell);
-
-    await dialog._updateContent();
-    const body = dialog._element!.querySelector('.onesignal-bell-launcher-dialog-body')!;
-    expect(body.textContent).toBe('Nothing to show.');
-    expect(dialog._element!.querySelector('.kickback')).toBeNull();
-  });
 });

--- a/src/page/bell/Dialog.test.ts
+++ b/src/page/bell/Dialog.test.ts
@@ -163,50 +163,50 @@ describe('Dialog', () => {
 
   // SDK-4535
   describe('text rendering', () => {
-    const HTML_LIKE_INPUT = '<img src=a><strong>b</strong>';
+    const RAW_INPUT = 'Notifications &amp; Updates <img src=a>';
+    const EXPECTED_TEXT = 'Notifications & Updates ';
 
-    test('renders dialog.main.title as literal text', async () => {
+    test('renders dialog.main.title with entities decoded and tags stripped', async () => {
       isPushEnabledSpy.mockResolvedValue(false);
       const bell = new Bell({ enable: false });
       bell._state = BellState._Unsubscribed;
-      bell._options.text['dialog.main.title'] = HTML_LIKE_INPUT;
+      bell._options.text['dialog.main.title'] = RAW_INPUT;
       const dialog = new Dialog(bell);
 
       await dialog._updateContent();
 
       const body = dialog._element!.querySelector('.onesignal-bell-launcher-dialog-body')!;
-      expect(body.querySelector('h1')?.textContent).toBe(HTML_LIKE_INPUT);
+      expect(body.querySelector('h1')?.textContent).toBe(EXPECTED_TEXT);
       expect(body.querySelector('h1 img')).toBeNull();
-      expect(body.querySelector('h1 strong')).toBeNull();
     });
 
-    test('renders dialog.main.button.subscribe as literal text', async () => {
+    test('renders dialog.main.button.subscribe with entities decoded and tags stripped', async () => {
       isPushEnabledSpy.mockResolvedValue(false);
       const bell = new Bell({ enable: false });
       bell._state = BellState._Unsubscribed;
-      bell._options.text['dialog.main.button.subscribe'] = HTML_LIKE_INPUT;
+      bell._options.text['dialog.main.button.subscribe'] = RAW_INPUT;
       const dialog = new Dialog(bell);
 
       await dialog._updateContent();
 
-      expect(dialog._subscribeButton?.textContent).toBe(HTML_LIKE_INPUT);
+      expect(dialog._subscribeButton?.textContent).toBe(EXPECTED_TEXT);
       expect(dialog._subscribeButton?.querySelector('img')).toBeNull();
     });
 
-    test('renders dialog.blocked.title as literal text', async () => {
+    test('renders dialog.blocked.title with entities decoded and tags stripped', async () => {
       isPushEnabledSpy.mockResolvedValue(false);
       vi.spyOn(detect, 'getBrowserName').mockReturnValue(Browser._Chrome);
       vi.spyOn(detect, 'isMobileBrowser').mockReturnValue(false);
       vi.spyOn(detect, 'isTabletBrowser').mockReturnValue(false);
       const bell = new Bell({ enable: false });
       bell._state = BellState._Blocked;
-      bell._options.text['dialog.blocked.title'] = HTML_LIKE_INPUT;
+      bell._options.text['dialog.blocked.title'] = RAW_INPUT;
       const dialog = new Dialog(bell);
 
       await dialog._updateContent();
 
       const body = dialog._element!.querySelector('.onesignal-bell-launcher-dialog-body')!;
-      expect(body.querySelector('h1')?.textContent).toBe(HTML_LIKE_INPUT);
+      expect(body.querySelector('h1')?.textContent).toBe(EXPECTED_TEXT);
       expect(body.querySelector('h1 img')).toBeNull();
     });
 
@@ -224,20 +224,20 @@ describe('Dialog', () => {
       expect(img?.hasAttribute('extra')).toBe(false);
     });
 
-    test('renders dialog.blocked.message as literal text', async () => {
+    test('renders dialog.blocked.message with entities decoded and tags stripped', async () => {
       isPushEnabledSpy.mockResolvedValue(false);
       vi.spyOn(detect, 'getBrowserName').mockReturnValue(Browser._Chrome);
       vi.spyOn(detect, 'isMobileBrowser').mockReturnValue(false);
       vi.spyOn(detect, 'isTabletBrowser').mockReturnValue(false);
       const bell = new Bell({ enable: false });
       bell._state = BellState._Blocked;
-      bell._options.text['dialog.blocked.message'] = HTML_LIKE_INPUT;
+      bell._options.text['dialog.blocked.message'] = RAW_INPUT;
       const dialog = new Dialog(bell);
 
       await dialog._updateContent();
 
       const body = dialog._element!.querySelector('.onesignal-bell-launcher-dialog-body')!;
-      expect(body.querySelector('.instructions p')?.textContent).toBe(HTML_LIKE_INPUT);
+      expect(body.querySelector('.instructions p')?.textContent).toBe(EXPECTED_TEXT);
       expect(body.querySelector('.instructions p img')).toBeNull();
     });
   });

--- a/src/page/bell/Dialog.test.ts
+++ b/src/page/bell/Dialog.test.ts
@@ -161,6 +161,87 @@ describe('Dialog', () => {
     expect(body.querySelector('img')).toBeNull();
   });
 
+  // SDK-4535
+  describe('text rendering', () => {
+    const HTML_LIKE_INPUT = '<img src=a><strong>b</strong>';
+
+    test('renders dialog.main.title as literal text', async () => {
+      isPushEnabledSpy.mockResolvedValue(false);
+      const bell = new Bell({ enable: false });
+      bell._state = BellState._Unsubscribed;
+      bell._options.text['dialog.main.title'] = HTML_LIKE_INPUT;
+      const dialog = new Dialog(bell);
+
+      await dialog._updateContent();
+
+      const body = dialog._element!.querySelector('.onesignal-bell-launcher-dialog-body')!;
+      expect(body.querySelector('h1')?.textContent).toBe(HTML_LIKE_INPUT);
+      expect(body.querySelector('h1 img')).toBeNull();
+      expect(body.querySelector('h1 strong')).toBeNull();
+    });
+
+    test('renders dialog.main.button.subscribe as literal text', async () => {
+      isPushEnabledSpy.mockResolvedValue(false);
+      const bell = new Bell({ enable: false });
+      bell._state = BellState._Unsubscribed;
+      bell._options.text['dialog.main.button.subscribe'] = HTML_LIKE_INPUT;
+      const dialog = new Dialog(bell);
+
+      await dialog._updateContent();
+
+      expect(dialog._subscribeButton?.textContent).toBe(HTML_LIKE_INPUT);
+      expect(dialog._subscribeButton?.querySelector('img')).toBeNull();
+    });
+
+    test('renders dialog.blocked.title as literal text', async () => {
+      isPushEnabledSpy.mockResolvedValue(false);
+      vi.spyOn(detect, 'getBrowserName').mockReturnValue(Browser._Chrome);
+      vi.spyOn(detect, 'isMobileBrowser').mockReturnValue(false);
+      vi.spyOn(detect, 'isTabletBrowser').mockReturnValue(false);
+      const bell = new Bell({ enable: false });
+      bell._state = BellState._Blocked;
+      bell._options.text['dialog.blocked.title'] = HTML_LIKE_INPUT;
+      const dialog = new Dialog(bell);
+
+      await dialog._updateContent();
+
+      const body = dialog._element!.querySelector('.onesignal-bell-launcher-dialog-body')!;
+      expect(body.querySelector('h1')?.textContent).toBe(HTML_LIKE_INPUT);
+      expect(body.querySelector('h1 img')).toBeNull();
+    });
+
+    test('icon URL with special chars stays inside src attribute', async () => {
+      isPushEnabledSpy.mockResolvedValue(false);
+      vi.spyOn(utils, 'getPlatformNotificationIcon').mockReturnValue('icon.png" extra="x');
+      const bell = new Bell({ enable: false });
+      bell._state = BellState._Unsubscribed;
+      const dialog = new Dialog(bell);
+
+      await dialog._updateContent();
+
+      const img = dialog._element!.querySelector('.push-notification-icon img');
+      expect(img?.getAttribute('src')).toBe('icon.png" extra="x');
+      expect(img?.hasAttribute('extra')).toBe(false);
+    });
+
+    test('renders dialog.blocked.message as literal text', async () => {
+      isPushEnabledSpy.mockResolvedValue(false);
+      vi.spyOn(detect, 'getBrowserName').mockReturnValue(Browser._Chrome);
+      vi.spyOn(detect, 'isMobileBrowser').mockReturnValue(false);
+      vi.spyOn(detect, 'isTabletBrowser').mockReturnValue(false);
+      const bell = new Bell({ enable: false });
+      bell._state = BellState._Blocked;
+      bell._options.text['dialog.blocked.message'] = HTML_LIKE_INPUT;
+      const dialog = new Dialog(bell);
+
+      await dialog._updateContent();
+
+      const body = dialog._element!.querySelector('.onesignal-bell-launcher-dialog-body')!;
+      expect(body.querySelector('.instructions p')?.textContent).toBe(HTML_LIKE_INPUT);
+      expect(body.querySelector('.instructions p img')).toBeNull();
+    });
+  });
+
   test('_updateContent includes credit footer when showCredit is true', async () => {
     isPushEnabledSpy.mockResolvedValue(false);
     const bell = new Bell({ enable: false });

--- a/src/page/bell/Dialog.ts
+++ b/src/page/bell/Dialog.ts
@@ -119,10 +119,7 @@ export default class Dialog {
     if (isMobileOrTablet && browserName === Browser._Chrome) {
       instructionsHtml = `<ol><li>Access <strong>Settings</strong> by tapping the three menu dots <strong>⋮</strong></li><li>Click <strong>Site settings</strong> under Advanced.</li><li>Click <strong>Notifications</strong>.</li><li>Find and click this entry for this website.</li><li>Click <strong>Notifications</strong> and set it to <strong>Allow</strong>.</li></ol>`;
     } else {
-      const imagePath =
-        browserName === Browser._Chrome && isMobileOrTablet
-          ? undefined
-          : UNBLOCK_IMAGES[browserName];
+      const imagePath = UNBLOCK_IMAGES[browserName];
       if (imagePath) {
         const imageUrl = STATIC_RESOURCES_URL + imagePath;
         instructionsHtml = `<a href="${imageUrl}" target="_blank"><img src="${imageUrl}"></a>`;

--- a/src/page/bell/Dialog.ts
+++ b/src/page/bell/Dialog.ts
@@ -63,15 +63,18 @@ export default class Dialog {
       (state === BellState._Subscribed && isEnabled) ||
       (state === BellState._Unsubscribed && !isEnabled);
 
+    let rendered = false;
     if (stateMatchesSubscription) {
       this._renderSubscription(body, text);
+      rendered = true;
     } else if (state === BellState._Blocked) {
       this._renderBlocked(body, text);
+      rendered = true;
     } else {
       body.textContent = 'Nothing to show.';
     }
 
-    if (this._bell._options.showCredit) {
+    if (rendered && this._bell._options.showCredit) {
       addDomElement(
         body,
         'beforeend',

--- a/src/page/bell/Dialog.ts
+++ b/src/page/bell/Dialog.ts
@@ -1,4 +1,4 @@
-import { addDomElement, clearDomElementChildren } from 'src/shared/helpers/dom';
+import { addDomElement, clearDomElementChildren, decodeHtmlEntities } from 'src/shared/helpers/dom';
 import type { NotificationIcons } from 'src/shared/notifications/types';
 import { Browser } from 'src/shared/useragent/constants';
 import { getBrowserName, isMobileBrowser, isTabletBrowser } from 'src/shared/useragent/detect';
@@ -108,8 +108,8 @@ export default class Dialog {
       `<h1></h1><div class="divider"></div><div class="push-notification">${iconHtml}<div class="push-notification-text-container"><div class="push-notification-text push-notification-text-short"></div><div class="push-notification-text"></div><div class="push-notification-text push-notification-text-medium"></div><div class="push-notification-text"></div><div class="push-notification-text push-notification-text-medium"></div></div></div><div class="action-container"><button type="button" class="action" id="${buttonId}"></button></div>`,
     );
 
-    body.querySelector('h1')!.textContent = text['dialog.main.title'];
-    body.querySelector(`#${buttonId}`)!.textContent = buttonText;
+    body.querySelector('h1')!.textContent = decodeHtmlEntities(text['dialog.main.title']);
+    body.querySelector(`#${buttonId}`)!.textContent = decodeHtmlEntities(buttonText);
     if (imageUrl !== 'default-icon') {
       body.querySelector('.push-notification-icon img')!.setAttribute('src', imageUrl);
     }
@@ -139,7 +139,9 @@ export default class Dialog {
       `<h1></h1><div class="divider"></div><div class="instructions"><p></p>${instructionsHtml}</div>`,
     );
 
-    body.querySelector('h1')!.textContent = text['dialog.blocked.title'];
-    body.querySelector('.instructions p')!.textContent = text['dialog.blocked.message'];
+    body.querySelector('h1')!.textContent = decodeHtmlEntities(text['dialog.blocked.title']);
+    body.querySelector('.instructions p')!.textContent = decodeHtmlEntities(
+      text['dialog.blocked.message'],
+    );
   }
 }

--- a/src/page/bell/Dialog.ts
+++ b/src/page/bell/Dialog.ts
@@ -55,9 +55,7 @@ export default class Dialog {
   async _updateContent() {
     const isEnabled = await OneSignal._context._subscriptionManager._isPushNotificationsEnabled();
 
-    clearDomElementChildren(BODY_SELECTOR);
-    const body = document.querySelector(BODY_SELECTOR);
-    if (!body) return;
+    const body = clearDomElementChildren(BODY_SELECTOR);
 
     const text = this._bell._options.text;
     const state = this._bell._state;

--- a/src/page/bell/Dialog.ts
+++ b/src/page/bell/Dialog.ts
@@ -63,18 +63,15 @@ export default class Dialog {
       (state === BellState._Subscribed && isEnabled) ||
       (state === BellState._Unsubscribed && !isEnabled);
 
-    let rendered = false;
     if (stateMatchesSubscription) {
       this._renderSubscription(body, text);
-      rendered = true;
     } else if (state === BellState._Blocked) {
       this._renderBlocked(body, text);
-      rendered = true;
     } else {
-      body.textContent = 'Nothing to show.';
+      return;
     }
 
-    if (rendered && this._bell._options.showCredit) {
+    if (this._bell._options.showCredit) {
       addDomElement(
         body,
         'beforeend',

--- a/src/page/bell/Dialog.ts
+++ b/src/page/bell/Dialog.ts
@@ -67,8 +67,6 @@ export default class Dialog {
       this._renderSubscription(body, text);
     } else if (state === BellState._Blocked) {
       this._renderBlocked(body, text);
-    } else {
-      return;
     }
 
     if (this._bell._options.showCredit) {

--- a/src/page/bell/Dialog.ts
+++ b/src/page/bell/Dialog.ts
@@ -19,6 +19,8 @@ const UNBLOCK_IMAGES: Partial<Record<string, string>> = {
   [Browser._Edge]: '/bell/edge-unblock.png',
 };
 
+const BODY_SELECTOR = '.onesignal-bell-launcher-dialog-body';
+
 export default class Dialog {
   public _bell: Bell;
   public _notificationIcons: NotificationIcons | null = null;
@@ -53,27 +55,31 @@ export default class Dialog {
   async _updateContent() {
     const isEnabled = await OneSignal._context._subscriptionManager._isPushNotificationsEnabled();
 
-    const bodySelector = '.onesignal-bell-launcher-dialog-body';
-    clearDomElementChildren(bodySelector);
+    clearDomElementChildren(BODY_SELECTOR);
+    const body = document.querySelector(BODY_SELECTOR);
+    if (!body) return;
 
     const text = this._bell._options.text;
-    const footer = this._bell._options.showCredit
-      ? `<div class="divider"></div><div class="kickback">Powered by <a href="https://onesignal.com" class="kickback" target="_blank">OneSignal</a></div>`
-      : '';
-
-    let contents = 'Nothing to show.';
     const state = this._bell._state;
     const stateMatchesSubscription =
       (state === BellState._Subscribed && isEnabled) ||
       (state === BellState._Unsubscribed && !isEnabled);
 
     if (stateMatchesSubscription) {
-      contents = this._buildSubscriptionContent(text, footer);
+      this._renderSubscription(body, text);
     } else if (state === BellState._Blocked) {
-      contents = this._buildBlockedContent(text, footer);
+      this._renderBlocked(body, text);
+    } else {
+      body.textContent = 'Nothing to show.';
     }
 
-    addDomElement(bodySelector, 'beforeend', contents);
+    if (this._bell._options.showCredit) {
+      addDomElement(
+        body,
+        'beforeend',
+        `<div class="divider"></div><div class="kickback">Powered by <a href="https://onesignal.com" class="kickback" target="_blank">OneSignal</a></div>`,
+      );
+    }
 
     this._subscribeButton?.addEventListener('click', () => {
       OneSignal._doNotShowWelcomeNotification = false;
@@ -82,11 +88,12 @@ export default class Dialog {
     this._unsubscribeButton?.addEventListener('click', () => this._bell._onUnsubscribeClick());
   }
 
-  private _buildSubscriptionContent(text: Bell['_options']['text'], footer: string): string {
+  private _renderSubscription(body: Element, text: Bell['_options']['text']): void {
     const imageUrl = getPlatformNotificationIcon(this._notificationIcons);
+
     const iconHtml =
       imageUrl !== 'default-icon'
-        ? `<div class="push-notification-icon"><img src="${imageUrl}"></div>`
+        ? `<div class="push-notification-icon"><img></div>`
         : `<div class="push-notification-icon push-notification-icon-default"></div>`;
 
     const isSubscribed = this._bell._state === BellState._Subscribed;
@@ -95,10 +102,20 @@ export default class Dialog {
       ? text['dialog.main.button.unsubscribe']
       : text['dialog.main.button.subscribe'];
 
-    return `<h1>${text['dialog.main.title']}</h1><div class="divider"></div><div class="push-notification">${iconHtml}<div class="push-notification-text-container"><div class="push-notification-text push-notification-text-short"></div><div class="push-notification-text"></div><div class="push-notification-text push-notification-text-medium"></div><div class="push-notification-text"></div><div class="push-notification-text push-notification-text-medium"></div></div></div><div class="action-container"><button type="button" class="action" id="${buttonId}">${buttonText}</button></div>${footer}`;
+    addDomElement(
+      body,
+      'beforeend',
+      `<h1></h1><div class="divider"></div><div class="push-notification">${iconHtml}<div class="push-notification-text-container"><div class="push-notification-text push-notification-text-short"></div><div class="push-notification-text"></div><div class="push-notification-text push-notification-text-medium"></div><div class="push-notification-text"></div><div class="push-notification-text push-notification-text-medium"></div></div></div><div class="action-container"><button type="button" class="action" id="${buttonId}"></button></div>`,
+    );
+
+    body.querySelector('h1')!.textContent = text['dialog.main.title'];
+    body.querySelector(`#${buttonId}`)!.textContent = buttonText;
+    if (imageUrl !== 'default-icon') {
+      body.querySelector('.push-notification-icon img')!.setAttribute('src', imageUrl);
+    }
   }
 
-  private _buildBlockedContent(text: Bell['_options']['text'], footer: string): string {
+  private _renderBlocked(body: Element, text: Bell['_options']['text']): void {
     const browserName = getBrowserName();
     const isMobileOrTablet = isMobileBrowser() || isTabletBrowser();
 
@@ -116,6 +133,13 @@ export default class Dialog {
       }
     }
 
-    return `<h1>${text['dialog.blocked.title']}</h1><div class="divider"></div><div class="instructions"><p>${text['dialog.blocked.message']}</p>${instructionsHtml}</div>${footer}`;
+    addDomElement(
+      body,
+      'beforeend',
+      `<h1></h1><div class="divider"></div><div class="instructions"><p></p>${instructionsHtml}</div>`,
+    );
+
+    body.querySelector('h1')!.textContent = text['dialog.blocked.title'];
+    body.querySelector('.instructions p')!.textContent = text['dialog.blocked.message'];
   }
 }

--- a/src/shared/config/version.ts
+++ b/src/shared/config/version.ts
@@ -145,7 +145,7 @@ function isSlidedownConfigVersion1(
 }
 
 function convertConfigToVersionTwo(
-  slidedownConfig: SlidedownOptionsVersion1 & SlidedownOptions,
+  slidedownConfig: SlidedownOptionsVersion1 & Partial<SlidedownOptions>,
 ): SlidedownOptions {
   const isCategory = isCategorySlidedownConfiguredVersion1(slidedownConfig);
   const promptType = isCategory ? DelayedPromptType._Category : DelayedPromptType._Push;

--- a/src/shared/helpers/dom.ts
+++ b/src/shared/helpers/dom.ts
@@ -21,8 +21,10 @@ export function removeDomElement(selector: string) {
   }
 }
 
-export function clearDomElementChildren(target: Element | string) {
-  resolveElement(target).replaceChildren();
+export function clearDomElementChildren(target: Element | string): Element {
+  const el = resolveElement(target);
+  el.replaceChildren();
+  return el;
 }
 
 export function getDomElementOrStub(selector: string): Element {


### PR DESCRIPTION
# Description

## 1 Line Summary

Refactor the bell notification dialog to render dashboard-controlled text via safe DOM APIs, matching the pattern already used by sibling components.

## Details

[SDK-4535](https://linear.app/onesignal/issue/SDK-4535/website-sdk-stored-xss-via-unescaped-server-config-text-in-bell-dialog) — see Linear for full context.

### Background

`Dialog.ts` was building the dialog body by interpolating values from `serverConfig.config.staticPrompts.bell.dialog.*` into HTML template literals, then inserting via `addDomElement` (`insertAdjacentHTML`). Sibling bell components (`Bell.ts`, `Message.ts`, `Badge.ts`) already follow a safer convention: insert static scaffolding HTML and set dynamic values via `textContent` / `setAttribute`. This PR brings `Dialog.ts` in line.

### Change

1. `addDomElement` now inserts only static scaffolding (empty `<h1></h1>`, empty `<p></p>`, empty `<img>` — no template-literal interpolation of dynamic values).
2. Dynamic text and attributes are populated via `textContent` / `setAttribute` against the just-inserted nodes.
3. Two private helpers `_renderSubscription` and `_renderBlocked` replace the prior `_buildSubscriptionContent` / `_buildBlockedContent` HTML-string builders.

Behavior is unchanged for valid inputs; the render is structurally identical.

### Drive-by

Fixed a type-honesty issue in `src/shared/config/version.ts`. `convertConfigToVersionTwo`'s parameter was typed `SlidedownOptionsVersion1 & SlidedownOptions`, but this function exists to **add** `prompts` to a V1 config that doesn't have one. Changed to `SlidedownOptionsVersion1 & Partial<SlidedownOptions>` so the existing `= []` default is no longer flagged as a `no-useless-default-assignment` lint warning. Tests confirm the default was load-bearing.

# Systems Affected

- [x] WebSDK
- [ ] Backend
- [ ] Dashboard

# Validation

## Tests

### Info

Added 5 regression tests in `Dialog.test.ts` covering each text/attribute sink in the dialog. Each test sets the corresponding option to an HTML-like string and asserts the value renders as literal text (`textContent` round-trips the raw input) rather than parsed markup.

### Checklist

- [x] All the automated tests pass or I explained why that is not possible
- [x] I have personally tested this on my machine or explained why that is not possible
- [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:

- [x] Don't use default export
- [x] New interfaces are in model files

Functions:

- [x] Don't use default export
- [x] All function signatures have return types
- [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:

- [x] No Typescript warnings
- [x] Avoid silencing null/undefined warnings with the exclamation point

Other:

- [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
- [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots

### Info

UI is unchanged. Dialog rendering identical for legitimate input.

### Checklist

- [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

- [SDK-4535](https://linear.app/onesignal/issue/SDK-4535/website-sdk-stored-xss-via-unescaped-server-config-text-in-bell-dialog)

---