### PR TITLE
fix: [SDK-4509] guard hydration against concurrent login swap

### DIFF
--- a/__test__/support/helpers/requests.ts
+++ b/__test__/support/helpers/requests.ts
@@ -300,10 +300,12 @@ export const setCreateUserResponse = ({
   onesignalId = ONESIGNAL_ID,
   subscriptions = [],
   externalId,
+  properties,
 }: {
   onesignalId?: string;
   subscriptions?: Partial<ISubscription>[];
   externalId?: string;
+  properties?: Partial<IUserProperties>;
 } = {}) =>
   getHandler({
     uri: getCreateUserUri(),
@@ -315,6 +317,7 @@ export const setCreateUserResponse = ({
         external_id: externalId,
       },
       subscriptions,
+      properties,
     },
     callback: createUserFn,
   });

--- a/src/core/executors/LoginUserOperationExecutor.test.ts
+++ b/src/core/executors/LoginUserOperationExecutor.test.ts
@@ -26,6 +26,8 @@ import { beforeAll, beforeEach, describe, expect, test, vi } from 'vite-plus/tes
 
 import { IdentityConstants, OPERATION_NAME } from '../constants';
 import { RebuildUserService } from '../modelRepo/RebuildUserService';
+import { IdentityModel } from '../models/IdentityModel';
+import { PropertiesModel } from '../models/PropertiesModel';
 import { SubscriptionModel } from '../models/SubscriptionModel';
 import { IdentityModelStore } from '../modelStores/IdentityModelStore';
 import { PropertiesModelStore } from '../modelStores/PropertiesModelStore';
@@ -186,6 +188,54 @@ describe('LoginUserOperationExecutor', () => {
           [SUB_ID]: SUB_ID_2,
         },
       });
+    });
+
+    // Regression: SDK-4509
+    // Concurrent OneSignal.login() calls swap the PropertiesModelStore's
+    // underlying model synchronously at login() invocation time. If a
+    // createNewUser request for User A is in flight when User B's login
+    // replaces the model, A's response handler must not hydrate A's
+    // server-returned properties (tags/language/timezone_id/country) onto
+    // B's freshly-replaced model.
+    test('does not hydrate properties onto a model that was swapped mid-request', async () => {
+      updateIdentityModel('onesignal_id', ONESIGNAL_ID);
+      updatePropertiesModel('onesignalId', ONESIGNAL_ID);
+
+      // Server returns User A's properties for the in-flight createNewUser.
+      setCreateUserResponse({
+        onesignalId: ONESIGNAL_ID,
+        properties: {
+          tags: { from: 'userA' },
+          language: 'fr',
+          timezone_id: 'Europe/Paris',
+          country: 'FR',
+        },
+      });
+
+      const executor = getExecutor();
+      const loginOpA = new LoginUserOperation(APP_ID, ONESIGNAL_ID);
+      const createSubOp = new CreateSubscriptionOperation(mockSubscriptionOpInfo);
+
+      // Kick off A's createNewUser; do NOT await yet. While the request is in
+      // flight, simulate User B's login replacing the underlying models.
+      const resultPromise = executor._execute([loginOpA, createSubOp]);
+
+      const newIdentityModel = new IdentityModel();
+      newIdentityModel._onesignalId = ONESIGNAL_ID_2;
+      const newPropertiesModel = new PropertiesModel();
+      newPropertiesModel._onesignalId = ONESIGNAL_ID_2;
+      identityModelStore._replace(newIdentityModel);
+      propertiesModelStore._replace(newPropertiesModel);
+
+      await resultPromise;
+
+      // The post-swap model should belong to User B and must not be
+      // contaminated with User A's tags/language/timezone/country.
+      expect(propertiesModelStore._model._getProperty('onesignalId')).toEqual(ONESIGNAL_ID_2);
+      expect(propertiesModelStore._model._getProperty('tags')).toBeUndefined();
+      expect(propertiesModelStore._model._getProperty('language')).toBeUndefined();
+      expect(propertiesModelStore._model._getProperty('timezone_id')).toBeUndefined();
+      expect(propertiesModelStore._model._getProperty('country')).toBeUndefined();
     });
 
     test('should handle network errors', async () => {

--- a/src/core/executors/LoginUserOperationExecutor.test.ts
+++ b/src/core/executors/LoginUserOperationExecutor.test.ts
@@ -190,18 +190,12 @@ describe('LoginUserOperationExecutor', () => {
       });
     });
 
-    // Regression: SDK-4509
-    // Concurrent OneSignal.login() calls swap the PropertiesModelStore's
-    // underlying model synchronously at login() invocation time. If a
-    // createNewUser request for User A is in flight when User B's login
-    // replaces the model, A's response handler must not hydrate A's
-    // server-returned properties (tags/language/timezone_id/country) onto
-    // B's freshly-replaced model.
+    // A concurrent login() can swap the properties model while createNewUser
+    // is in flight; the response must not hydrate onto the new user's model.
     test('does not hydrate properties onto a model that was swapped mid-request', async () => {
       updateIdentityModel('onesignal_id', ONESIGNAL_ID);
       updatePropertiesModel('onesignalId', ONESIGNAL_ID);
 
-      // Server returns User A's properties for the in-flight createNewUser.
       setCreateUserResponse({
         onesignalId: ONESIGNAL_ID,
         properties: {
@@ -216,8 +210,6 @@ describe('LoginUserOperationExecutor', () => {
       const loginOpA = new LoginUserOperation(APP_ID, ONESIGNAL_ID);
       const createSubOp = new CreateSubscriptionOperation(mockSubscriptionOpInfo);
 
-      // Kick off A's createNewUser; do NOT await yet. While the request is in
-      // flight, simulate User B's login replacing the underlying models.
       const resultPromise = executor._execute([loginOpA, createSubOp]);
 
       const newIdentityModel = new IdentityModel();
@@ -229,8 +221,6 @@ describe('LoginUserOperationExecutor', () => {
 
       await resultPromise;
 
-      // The post-swap model should belong to User B and must not be
-      // contaminated with User A's tags/language/timezone/country.
       expect(propertiesModelStore._model._getProperty('onesignalId')).toEqual(ONESIGNAL_ID_2);
       expect(propertiesModelStore._model._getProperty('tags')).toBeUndefined();
       expect(propertiesModelStore._model._getProperty('language')).toBeUndefined();
@@ -238,12 +228,10 @@ describe('LoginUserOperationExecutor', () => {
       expect(propertiesModelStore._model._getProperty('country')).toBeUndefined();
     });
 
-    // Same race as above, but for the subscription hydration loop. The
-    // SubscriptionModelStore is not swapped by _resetAndGetIdentityModel
-    // (only identity + properties are), so subscription models persist across
-    // logins. A's response handler must not stamp A's backend ids onto a
-    // model that user B is now sharing. idTranslations must still be returned
-    // so the op-repo can rewrite local ids on B's pending subscription ops.
+    // Subscription models persist across logins (only identity + properties
+    // are swapped), so a stale response must not stamp the prior user's
+    // backend ids onto a subscription the new user is now sharing.
+    // idTranslations must still be returned so pending ops can be rewritten.
     test('does not hydrate subscription onto a model after a mid-request user swap', async () => {
       updateIdentityModel('onesignal_id', ONESIGNAL_ID);
       updatePropertiesModel('onesignalId', ONESIGNAL_ID);
@@ -273,12 +261,9 @@ describe('LoginUserOperationExecutor', () => {
 
       const res = await resultPromise;
 
-      // The persistent subscription model must not be stamped with A's
-      // backend ids while user B is the active user.
       expect(subscriptionModel._getProperty('id')).toEqual(SUB_ID);
       expect(subscriptionModel._getProperty('onesignalId')).toEqual(ONESIGNAL_ID);
 
-      // idTranslations must still be returned so pending ops can be rewritten.
       expect(res._idTranslations).toEqual({
         [ONESIGNAL_ID]: ONESIGNAL_ID_2,
         [SUB_ID]: SUB_ID_2,

--- a/src/core/executors/LoginUserOperationExecutor.test.ts
+++ b/src/core/executors/LoginUserOperationExecutor.test.ts
@@ -238,6 +238,53 @@ describe('LoginUserOperationExecutor', () => {
       expect(propertiesModelStore._model._getProperty('country')).toBeUndefined();
     });
 
+    // Same race as above, but for the subscription hydration loop. The
+    // SubscriptionModelStore is not swapped by _resetAndGetIdentityModel
+    // (only identity + properties are), so subscription models persist across
+    // logins. A's response handler must not stamp A's backend ids onto a
+    // model that user B is now sharing. idTranslations must still be returned
+    // so the op-repo can rewrite local ids on B's pending subscription ops.
+    test('does not hydrate subscription onto a model after a mid-request user swap', async () => {
+      updateIdentityModel('onesignal_id', ONESIGNAL_ID);
+      updatePropertiesModel('onesignalId', ONESIGNAL_ID);
+
+      const subscriptionModel = new SubscriptionModel();
+      subscriptionModel._setProperty('id', SUB_ID, ModelChangeTags._NoPropogate);
+      subscriptionModel._setProperty('onesignalId', ONESIGNAL_ID, ModelChangeTags._NoPropogate);
+      subscriptionModelStore._add(subscriptionModel, ModelChangeTags._NoPropogate);
+
+      setCreateUserResponse({
+        onesignalId: ONESIGNAL_ID_2,
+        subscriptions: [{ id: SUB_ID_2 }],
+      });
+
+      const executor = getExecutor();
+      const loginOpA = new LoginUserOperation(APP_ID, ONESIGNAL_ID);
+      const createSubOp = new CreateSubscriptionOperation(mockSubscriptionOpInfo);
+
+      const resultPromise = executor._execute([loginOpA, createSubOp]);
+
+      const newIdentityModel = new IdentityModel();
+      newIdentityModel._onesignalId = ONESIGNAL_ID_2;
+      const newPropertiesModel = new PropertiesModel();
+      newPropertiesModel._onesignalId = ONESIGNAL_ID_2;
+      identityModelStore._replace(newIdentityModel);
+      propertiesModelStore._replace(newPropertiesModel);
+
+      const res = await resultPromise;
+
+      // The persistent subscription model must not be stamped with A's
+      // backend ids while user B is the active user.
+      expect(subscriptionModel._getProperty('id')).toEqual(SUB_ID);
+      expect(subscriptionModel._getProperty('onesignalId')).toEqual(ONESIGNAL_ID);
+
+      // idTranslations must still be returned so pending ops can be rewritten.
+      expect(res._idTranslations).toEqual({
+        [ONESIGNAL_ID]: ONESIGNAL_ID_2,
+        [SUB_ID]: SUB_ID_2,
+      });
+    });
+
     test('should handle network errors', async () => {
       const executor = getExecutor();
 

--- a/src/core/executors/LoginUserOperationExecutor.ts
+++ b/src/core/executors/LoginUserOperationExecutor.ts
@@ -165,32 +165,39 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
         [createUserOperation._onesignalId]: backendOneSignalId,
       };
 
-      if (this._identityModelStore._model._onesignalId === opOneSignalId) {
+      // Capture this BEFORE any local writes mutate the model stores. A
+      // concurrent OneSignal.login(...) may have replaced the identity and
+      // properties stores while this createNewUser was in flight; if so we
+      // must not hydrate any of this response onto the new user's models.
+      // Subscriptions persist across logins (the SubscriptionModelStore is
+      // not swapped), so this guard also prevents stamping A's backend
+      // onesignalId onto a subscription model that user B is now sharing.
+      // idTranslations is populated unconditionally so the op-repo can still
+      // rewrite local ids on any pending ops that referenced this user.
+      const stillCurrent = this._identityModelStore._model._onesignalId === opOneSignalId;
+
+      if (stillCurrent) {
         this._identityModelStore._model._setProperty(
           IdentityConstants._OneSignalID,
           backendOneSignalId,
           ModelChangeTags._Hydrate,
         );
-      }
 
-      if (this._propertiesModelStore._model._onesignalId === opOneSignalId) {
         this._propertiesModelStore._model._setProperty(
           'onesignalId',
           backendOneSignalId,
           ModelChangeTags._Hydrate,
         );
-      }
 
-      // Guarded so a concurrent login() that swapped the model store mid-request
-      // doesn't hydrate this response onto the new user's properties model.
-      const resultProperties = response.result.properties;
-      if (resultProperties && this._propertiesModelStore._model._onesignalId === opOneSignalId) {
-        for (const [key, value] of Object.entries(resultProperties)) {
-          this._propertiesModelStore._model._setProperty(
-            key as IPropertiesModelKeys,
-            value,
-            ModelChangeTags._Hydrate,
-          );
+        const resultProperties = response.result.properties;
+        if (resultProperties) {
+          for (const [key, value] of Object.entries(resultProperties)) {
+            this._propertiesModelStore._model._setProperty(
+              key as IPropertiesModelKeys,
+              value,
+              ModelChangeTags._Hydrate,
+            );
+          }
         }
       }
 
@@ -200,6 +207,8 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
 
         if (!backendSub || !('id' in backendSub)) continue;
         idTranslations[localId] = backendSub.id;
+
+        if (!stillCurrent) continue;
 
         const model = this._subscriptionsModelStore._getBySubscriptionId(localId);
         model?._setProperty('id', backendSub.id, ModelChangeTags._Hydrate);

--- a/src/core/executors/LoginUserOperationExecutor.ts
+++ b/src/core/executors/LoginUserOperationExecutor.ts
@@ -165,15 +165,10 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
         [createUserOperation._onesignalId]: backendOneSignalId,
       };
 
-      // Capture this BEFORE any local writes mutate the model stores. A
-      // concurrent OneSignal.login(...) may have replaced the identity and
-      // properties stores while this createNewUser was in flight; if so we
-      // must not hydrate any of this response onto the new user's models.
-      // Subscriptions persist across logins (the SubscriptionModelStore is
-      // not swapped), so this guard also prevents stamping A's backend
-      // onesignalId onto a subscription model that user B is now sharing.
-      // idTranslations is populated unconditionally so the op-repo can still
-      // rewrite local ids on any pending ops that referenced this user.
+      // Checked once before any writes so a concurrent login() that swapped
+      // the stores mid-request doesn't hydrate this response onto the new
+      // user. idTranslations is populated unconditionally so pending ops can
+      // still be rewritten.
       const stillCurrent = this._identityModelStore._model._onesignalId === opOneSignalId;
 
       if (stillCurrent) {

--- a/src/core/executors/LoginUserOperationExecutor.ts
+++ b/src/core/executors/LoginUserOperationExecutor.ts
@@ -181,9 +181,10 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
         );
       }
 
-      // update other properties
+      // Guarded so a concurrent login() that swapped the model store mid-request
+      // doesn't hydrate this response onto the new user's properties model.
       const resultProperties = response.result.properties;
-      if (resultProperties) {
+      if (resultProperties && this._propertiesModelStore._model._onesignalId === opOneSignalId) {
         for (const [key, value] of Object.entries(resultProperties)) {
           this._propertiesModelStore._model._setProperty(
             key as IPropertiesModelKeys,


### PR DESCRIPTION
# Description

## 1 Line Summary

Prevents User A's server-returned properties and subscription ids from leaking onto User B's local models when `OneSignal.login()` is called twice without an `await` between calls.

## Details

### Root cause

In `LoginUserOperationExecutor._createUser`, the `onesignal_id` writes at the top of the success branch were guarded by `_onesignalId === opOneSignalId`, but the rest of the response-handling code was not:

1. The loop that hydrates the rest of the server-returned properties (`tags`, `language`, `timezone_id`, `country`) was **not** guarded.
2. The loop that hydrates each subscription model (`id`, `onesignalId`) was **not** guarded. The `SubscriptionModelStore` is not swapped by `LoginManager._resetAndGetIdentityModel` (only identity + properties are), so subscription models persist across logins and can be stamped with the prior user's backend ids.

`LoginManager._resetAndGetIdentityModel` swaps the underlying `IdentityModelStore` and `PropertiesModelStore` models **synchronously** at `login()` invocation time — well before the op-repo executor runs. `LoginManager._switchingUsersPromise` is a "latest wins" reference that doesn't chain, so back-to-back `login('A'); login('B')` (without an `await`) gives this timeline:

| t | event | model store points to |
|---|---|---|
| t0 | `login('A')` enqueues op A | A's models |
| t0+ε | `login('B')` swaps identity + properties stores synchronously, enqueues op B. SubscriptionModelStore is **not** swapped. | **B's identity/properties; A's subscription models still in store** |
| t1 | op repo runs op A; `createNewUser` request fires | as above |
| t2 | A's response arrives. `onesignal_id` writes are correctly skipped by the existing guards. The unguarded properties loop **hydrates A's tags/language/timezone/country onto B's properties model**. The unguarded subscription loop **stamps A's backend ids onto subscription models user B is now sharing.** | **B's models, contaminated** |

Subsequent property syncs may then push the contaminated state to the server tied to User B's identity.

### Fix

Refactor the success branch to capture `stillCurrent = identityStore._model._onesignalId === opOneSignalId` once, **before any local writes mutate the stores**, and gate identity, properties, properties-loop, and subscription-loop hydration on it. `idTranslations` is populated unconditionally so the op-repo can still rewrite local ids on any pending ops queued for this user (B's `TransferSubscriptionOperation` needs A's backend subscription id to know what to PATCH).

This also fixes a self-inflicted bug found while addressing the subscription gap: the original properties-loop guard read `_propertiesModelStore._model._onesignalId` **after** the preceding line had already overwritten that field with `backendOneSignalId`, so the loop never ran in the non-swap path. The bug went undetected because no existing test passed a `properties` field in the `createNewUser` response. Caught by widening the test fixture to populate `properties`.

### Out of scope

The structural fix — chaining `LoginManager._switchingUsersPromise` so `login('B')` waits for `login('A')`'s `_switchUser` to settle — is potentially load-bearing for callers that rely on synchronous read-after-`login()` semantics. The ticket explicitly leaves it as a separate consideration. The guard alone closes the reported window.

# Systems Affected

- [x] WebSDK
- [ ] Backend
- [ ] Dashboard

# Validation

## Tests

### Info

Added two regression tests to `LoginUserOperationExecutor.test.ts`, both mid-request swap scenarios:

1. **`does not hydrate properties onto a model that was swapped mid-request`** — mocks `createNewUser` to return User A's `tags`/`language`/`timezone_id`/`country`; kicks off A's executor without awaiting; synchronously replaces both `IdentityModelStore` and `PropertiesModelStore` with User B's models (mirroring `LoginManager._resetAndGetIdentityModel`); awaits A's response handler and asserts B's properties model has no leaked fields.
2. **`does not hydrate subscription onto a model after a mid-request user swap`** — pre-seeds a `SubscriptionModel` representing User A's subscription; kicks off A's executor without awaiting; performs the same identity/properties swap mid-flight; asserts the subscription model retains its original `id` and `onesignalId` (no backend ids stamped onto it) **and** that `idTranslations` is still returned so the op-repo can rewrite pending ops.

Both tests verified to **fail before the fix** and **pass after**. Also extended `setCreateUserResponse` in `__test__/support/helpers/requests.ts` to accept a `properties` payload so other tests can use the same mock shape.

Full suite: 512/512 pass. Lint clean. Prod build green, bundle within size limits.

### Checklist

- [x] All the automated tests pass or I explained why that is not possible
- [x] I have personally tested this on my machine or explained why that is not possible
- [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:

- [x] Don't use default export
- [x] New interfaces are in model files

Functions:

- [x] Don't use default export
- [x] All function signatures have return types
- [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:

- [x] No Typescript warnings
- [x] Avoid silencing null/undefined warnings with the exclamation point

Other:

- [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
- [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots

### Info

N/A — internal correctness fix, no UI changes.

### Checklist

- [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

[SDK-4509](https://linear.app/onesignal/issue/SDK-4509/race-condition-leaks-cross-user-properties-during-concurrent-logins)