### PR TITLE
ci: drop missing .nvmrc reference from CD and release workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1
         with:
-          node-version-file: '.nvmrc'
           cache: true
 
       - name: Build for Staging

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -23,8 +23,6 @@ jobs:
 
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1
-        with:
-          node-version-file: '.nvmrc'
 
       - name: Get current SDK version
         id: current_version


### PR DESCRIPTION
## One Line Summary

Remove stale `node-version-file: '.nvmrc'` from `cd.yml` and `create-release-pr.yml` so `setup-vp` stops failing.

## Motivation

The `Create Release PR` workflow is currently broken at the `Setup Vite+` step with:

```
Error: node-version-file not found: /home/runner/work/OneSignal-Website-SDK/OneSignal-Website-SDK/.nvmrc
```

`.nvmrc` was deleted in #1458 when the project switched to bun, and `ci.yml` was updated to drop the `node-version-file` input — but `cd.yml` and `create-release-pr.yml` still reference the missing file. This blocks both the release PR workflow and any future `cd.yml` runs.

## Scope

- Removes `node-version-file: '.nvmrc'` from `.github/workflows/cd.yml` (keeps `cache: true`).
- Removes the same line (and the now-empty `with:` block) from `.github/workflows/create-release-pr.yml`.
- No source code, dependency, or runtime behavior changes.

## Testing

- Manual: verified `ci.yml` (which already omits the input) is green on `main`, confirming `setup-vp` works without `node-version-file`.
- Will validate end-to-end by re-running `Create Release PR` after merge.

## Affected code

- [x] CI / build workflows
- [ ] SDK runtime
- [ ] Tests

## Checklist

- [x] Mirrors the same change already shipped in `ci.yml` via #1458
- [x] No `.nvmrc` reintroduced (project is on bun)