### PR TITLE
fix: [SDK-4336] guard IndexedDB Options writes from iOS Safari PWA wedge

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,12 +77,12 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "42.4 kB",
+      "limit": "42.7 kB",
       "gzip": true
     },
     {
       "path": "./build/releases/OneSignalSDK.sw.js",
-      "limit": "12.354 kB",
+      "limit": "12.65 kB",
       "gzip": true
     },
     {

--- a/preview/OneSignalSDKWorker.js
+++ b/preview/OneSignalSDKWorker.js
@@ -1,4 +1,9 @@
-importScripts('https://localhost:4001/sdks/web/v16/Dev-OneSignalSDK.sw.js');
+// Use self.location.origin so the worker imports from whichever origin
+// served it (localhost during local dev, an ngrok/Cloudflare tunnel during
+// device testing, etc.). Hardcoding localhost:4001 breaks any test that
+// loads this worker from a non-localhost origin (the inner script is
+// fetched as part of registration and produces a NetworkError otherwise).
+importScripts(`${self.location.origin}/sdks/web/v16/Dev-OneSignalSDK.sw.js`);
 
 // For testing on staging
 // importScripts(

--- a/preview/pageA.html
+++ b/preview/pageA.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SDK-4336 Repro: Page A</title>
+    <link rel="shortcut icon" href="#" />
+    <link rel="manifest" href="manifest.json" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="SDK4336" />
+
+    <script src="sdks/web/v16/Dev-OneSignalSDK.page.js" defer></script>
+
+    <script>
+      console.log('!!!! [SDK-4336 PAGE A] OneSignal initialize');
+
+      function getUrlQueryParam(name) {
+        const urlParams = new URLSearchParams(window.location.search);
+        return urlParams.get(name);
+      }
+
+      // Resolve the app_id robustly. The in-page links to Page B/Page A don't
+      // carry the query string, and on an iOS standalone (home-screen) PWA the
+      // localStorage fallback isn't reliable across A->B->A navigations because
+      // storage is partitioned per context. Without a hardcoded fallback, the
+      // B->A load calls OneSignal.init with appId=null -> InvalidAppIdError.
+      const DEFAULT_APP_ID = 'b79087eb-8531-4d2d-a6f5-726f797891c7';
+      let appId = getUrlQueryParam('app_id');
+      try {
+        if (appId) localStorage.setItem('sdk4336_app_id', appId);
+        else appId = localStorage.getItem('sdk4336_app_id');
+      } catch (e) {}
+      appId = appId || DEFAULT_APP_ID;
+
+      const SERVICE_WORKER_PATH = 'push/onesignal/';
+
+      var OneSignalDeferred = window.OneSignalDeferred || [];
+      OneSignalDeferred.push(async function (OneSignal) {
+        const t0 = performance.now();
+        await OneSignal.init({
+          appId,
+          serviceWorkerParam: { scope: '/' + SERVICE_WORKER_PATH },
+          serviceWorkerPath: SERVICE_WORKER_PATH + 'OneSignalSDKWorker.js',
+        });
+        const elapsed = Math.round(performance.now() - t0);
+        console.log(`!!!! [SDK-4336 PAGE A] OneSignal initialized (${elapsed}ms)`);
+      });
+
+      async function requestNotificationPermission() {
+        window.OneSignalDeferred = window.OneSignalDeferred || [];
+        OneSignalDeferred.push(async function (OneSignal) {
+          await OneSignal.Notifications.requestPermission();
+        });
+      }
+    </script>
+  </head>
+  <body>
+    <h1>SDK-4336 Repro: Page A</h1>
+    <p>
+      <a href="./pageB.html">Go to Page B</a>
+    </p>
+    <p>
+      <button onclick="requestNotificationPermission()">Register</button>
+    </p>
+    <p>Repro steps (per the ticket):</p>
+    <ol>
+      <li>Add to Home Screen and open Page A.</li>
+      <li>Tap "Go to Page B".</li>
+      <li>Tap "Go to Page A".</li>
+      <li>Tap "Register" and accept the prompt.</li>
+      <li>Tap "Go to Page B".</li>
+      <li>Tap "Go to Page A" &mdash; <code>init()</code> should hang.</li>
+    </ol>
+  </body>
+</html>

--- a/preview/pageB.html
+++ b/preview/pageB.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SDK-4336 Repro: Page B</title>
+    <link rel="shortcut icon" href="#" />
+    <link rel="manifest" href="manifest.json" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="SDK4336" />
+  </head>
+  <body>
+    <h1>SDK-4336 Repro: Page B</h1>
+    <p>
+      <a href="./pageA.html">Go to Page A</a>
+    </p>
+    <p>
+      This page intentionally does <em>not</em> initialize the SDK. It just navigates back to Page A
+      so we can exercise the multi-page navigation flow described in SDK-4336.
+    </p>
+  </body>
+</html>

--- a/preview/push/onesignal/OneSignalSDKWorker.js
+++ b/preview/push/onesignal/OneSignalSDKWorker.js
@@ -1,4 +1,4 @@
-importScripts('https://localhost:4001/sdks/web/v16/Dev-OneSignalSDK.sw.js');
+importScripts(`${self.location.origin}/sdks/web/v16/Dev-OneSignalSDK.sw.js`);
 
 // For testing on staging
 // importScripts(

--- a/preview/vite.config.ts
+++ b/preview/vite.config.ts
@@ -43,8 +43,25 @@ export default defineConfig({
     // SDK fetch URL (e.g. `http://localhost:4000/...` in HTTP mode) lands here.
     port: useHttps ? 4001 : 4000,
     strictPort: true,
+    // HMR's WebSocket targets `wss://localhost:<port>`, which iOS devices on a
+    // tunnel (ngrok, etc.) can't reach. Disabling stops the runaway
+    // reconnect loop that floods the console with `ws.send` rejections.
+    hmr: false,
   },
   plugins: [
+    {
+      // Vite's dev server injects `<script src="/@vite/client">` into every
+      // HTML response, even when `server.hmr` is false. That client then
+      // retries a WebSocket forever, which on a tunneled iOS device floods
+      // the console with `ws.send` rejections and is heavy enough to
+      // skew our SDK timing. Strip it out for the preview server, where
+      // we don't need HMR.
+      name: 'strip-vite-client',
+      enforce: 'post',
+      transformIndexHtml(html) {
+        return html.replace(/<script[^>]*src="\/@vite\/client"[^>]*><\/script>\s*/g, '');
+      },
+    },
     ...(useHttps
       ? [
           mkcert({
@@ -87,7 +104,29 @@ export default defineConfig({
           if (contentType) {
             res.setHeader('Content-Type', contentType);
           }
+          // Avoid stale SDK bundles being served from the browser HTTP cache,
+          // which is especially aggressive on iOS Safari/PWA. Without this,
+          // rebuilding the SDK during a debug session won't take effect on the
+          // device until you fully wipe website data.
+          res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+          res.setHeader('Pragma', 'no-cache');
           fs.createReadStream(filePath).pipe(res);
+        });
+      },
+    },
+    {
+      // Same hygiene for the sandbox HTML (pageA/pageB/index) and root SW
+      // file. Vite's default dev-server cache policy is fine for source files
+      // but our HTML directly references the SDK and embeds repro state.
+      name: 'no-store-html',
+      configureServer(server) {
+        server.middlewares.use((req, res, next) => {
+          const url = req.url ?? '';
+          if (/\.(html|json|js)(\?|$)/.test(url) && !url.startsWith('/sdks/')) {
+            res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate');
+            res.setHeader('Pragma', 'no-cache');
+          }
+          next();
         });
       },
     },

--- a/src/shared/database/client.test.ts
+++ b/src/shared/database/client.test.ts
@@ -1,8 +1,8 @@
 import { APP_ID, EXTERNAL_ID, ONESIGNAL_ID } from '__test__/constants';
-import { beforeEach, describe, expect, test, vi } from 'vite-plus/test';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vite-plus/test';
 
 import { SubscriptionType } from '../subscriptions/constants';
-import { closeDb, getDb } from './client';
+import { closeDb, db, getDb, isOptionsWriteWedged } from './client';
 import { DATABASE_NAME } from './constants';
 import type * as idbLite from './idb-lite';
 import { wrapRequest } from './idb-lite';
@@ -320,6 +320,42 @@ describe('migrations', () => {
         },
       ]);
     });
+  });
+});
+
+describe('Options write timeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('clears the timeout when an Options put resolves before it fires', async () => {
+    await getDb();
+    await db.put('Options', { key: 'userConsent', value: true });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test('trips circuit breaker on Options put timeout, short-circuits subsequent writes', async () => {
+    expect(isOptionsWriteWedged()).toBe(false);
+
+    const _db = await getDb();
+    const realPut = _db.put.bind(_db);
+    vi.spyOn(_db, 'put').mockImplementation(((s: string, v: unknown) => {
+      if (s === 'Options') return new Promise(() => {});
+      return realPut(s as Parameters<typeof realPut>[0], v as never);
+    }) as typeof _db.put);
+
+    const first = db.put('Options', { key: 'isPushEnabled', value: true });
+    await vi.advanceTimersByTimeAsync(2001);
+    expect(await first).toBeUndefined();
+    expect(isOptionsWriteWedged()).toBe(true);
+
+    expect(await db.put('Options', { key: 'lastPushId', value: 'x' })).toBeUndefined();
+    await db.put('Ids', { type: 'appId', id: 'A' });
+    expect((await db.get('Ids', 'appId'))?.id).toBe('A');
   });
 });
 

--- a/src/shared/database/client.ts
+++ b/src/shared/database/client.ts
@@ -105,6 +105,12 @@ export const getDb = (version = VERSION) => {
 const OPTIONS_WRITE_TIMEOUT_MS = 1500;
 let optionsWriteWedged = false;
 
+export const isOptionsWriteWedged = () => optionsWriteWedged;
+
+// `op` is invoked synchronously so the timeout scopes only to the readwrite
+// request itself — DB open/upgrade time is awaited by callers before they
+// hand us a sync closure, so a slow `open()` (e.g. cross-tab `blocked` event,
+// schema migration on a slow device) won't false-trip the breaker.
 function guardOptionsWrite<T>(
   storeName: IDBStoreName,
   label: string,
@@ -152,13 +158,13 @@ export const db = {
     return (await dbPromise).getAll(storeName);
   },
   async put<K extends IDBStoreName>(storeName: K, value: IndexedDBSchema[K]['value']) {
-    return guardOptionsWrite(storeName, `put(${storeName})`, async () =>
-      (await dbPromise).put(storeName, value),
-    );
+    const _db = await dbPromise;
+    return guardOptionsWrite(storeName, `put(${storeName})`, () => _db.put(storeName, value));
   },
   async delete<K extends IDBStoreName>(storeName: K, key: IndexedDBSchema[K]['key']) {
-    return guardOptionsWrite(storeName, `delete(${storeName}/${String(key)})`, async () =>
-      (await dbPromise).delete(storeName, key),
+    const _db = await dbPromise;
+    return guardOptionsWrite(storeName, `delete(${storeName}/${String(key)})`, () =>
+      _db.delete(storeName, key),
     );
   },
 };

--- a/src/shared/database/client.ts
+++ b/src/shared/database/client.ts
@@ -93,35 +93,26 @@ export const getDb = (version = VERSION) => {
   return dbPromise;
 };
 
-// SDK-4336: iOS 26 Safari PWA, on the navigation back to a page after the
-// user has subscribed to push, leaves the `ONE_SIGNAL_SDK_DB` database in
-// a state where every `readwrite` request on the `Options` object store
-// stalls indefinitely (no `success`, no `error`, no transaction lifecycle
-// event). Fresh connections inherit the same per-store WebKit lock state,
-// so reopening doesn't help. Reads work, and `readwrite` on other stores
-// works — only `readwrite` on `Options` is poisoned.
-//
-// Without this guard, `OneSignal.init()` blocks on the very first Options
-// `put` in `initSaveState`/`saveInitOptions` and never returns, which the
-// support team has observed as init "hanging for ~30 minutes" (the time
-// it eventually takes WebKit's internal watchdog to abort the wedged
-// transaction).
-//
-// Workaround: cap `readwrite` operations on the `Options` store with a
-// short timeout. On timeout, we log a warning, trip a circuit breaker
-// for the rest of the page's lifetime so subsequent Options writes
-// short-circuit instead of each paying the timeout, and resolve the
-// promise as a no-op so init proceeds. The values that didn't get
-// persisted are session metadata (`pageTitle`, `persistNotification`,
-// webhook URLs, click-handler config, `lastPushToken`, `isPushEnabled`,
-// etc.) that the service worker reads with sensible fallbacks if
-// missing or stale.
+// On iOS Safari PWA after a push subscription, `readwrite` requests on the
+// `Options` object store can stall indefinitely (no success/error/abort).
+// Other stores and reads are unaffected, and reopening the DB doesn't help.
+// Without this guard, `OneSignal.init()` hangs until WebKit's watchdog
+// eventually aborts the transaction (~30 minutes). Workaround: cap Options
+// writes with a short timeout, then trip a page-scoped circuit breaker so
+// subsequent writes short-circuit. The values that fail to persist are
+// session metadata the SW reads with sensible fallbacks. Remove if WebKit
+// ever fixes the underlying bug.
 const OPTIONS_WRITE_TIMEOUT_MS = 1500;
 let optionsWriteWedged = false;
 
-function withOptionsWriteTimeout<T>(label: string, op: () => Promise<T>): Promise<T | undefined> {
+function guardOptionsWrite<T>(
+  storeName: IDBStoreName,
+  label: string,
+  op: () => Promise<T>,
+): Promise<T | undefined> {
+  if (storeName !== 'Options') return op();
   if (optionsWriteWedged) {
-    Log._warn(`[SDK-4336] db.${label} skipped (wedged)`);
+    Log._warn(`db.${label} skipped (Options store wedged)`);
     return Promise.resolve(undefined);
   }
   return new Promise<T | undefined>((resolve, reject) => {
@@ -130,7 +121,7 @@ function withOptionsWriteTimeout<T>(label: string, op: () => Promise<T>): Promis
       if (settled) return;
       settled = true;
       optionsWriteWedged = true;
-      Log._warn(`[SDK-4336] db.${label} timed out; tripping circuit breaker`);
+      Log._warn(`db.${label} timed out; tripping Options-write circuit breaker`);
       resolve(undefined);
     }, OPTIONS_WRITE_TIMEOUT_MS);
     op().then(
@@ -161,18 +152,14 @@ export const db = {
     return (await dbPromise).getAll(storeName);
   },
   async put<K extends IDBStoreName>(storeName: K, value: IndexedDBSchema[K]['value']) {
-    const op = async () => (await dbPromise).put(storeName, value);
-    if (storeName === 'Options') {
-      return withOptionsWriteTimeout(`put(${storeName})`, op);
-    }
-    return op();
+    return guardOptionsWrite(storeName, `put(${storeName})`, async () =>
+      (await dbPromise).put(storeName, value),
+    );
   },
   async delete<K extends IDBStoreName>(storeName: K, key: IndexedDBSchema[K]['key']) {
-    const op = async () => (await dbPromise).delete(storeName, key);
-    if (storeName === 'Options') {
-      return withOptionsWriteTimeout(`delete(${storeName}/${String(key)})`, op);
-    }
-    return op();
+    return guardOptionsWrite(storeName, `delete(${storeName}/${String(key)})`, async () =>
+      (await dbPromise).delete(storeName, key),
+    );
   },
 };
 

--- a/src/shared/database/client.ts
+++ b/src/shared/database/client.ts
@@ -121,7 +121,7 @@ let optionsWriteWedged = false;
 
 function withOptionsWriteTimeout<T>(label: string, op: () => Promise<T>): Promise<T | undefined> {
   if (optionsWriteWedged) {
-    Log._warn(`[SDK-4336] db.${label} skipped; Options store is known wedged for this page.`);
+    Log._warn(`[SDK-4336] db.${label} skipped (wedged)`);
     return Promise.resolve(undefined);
   }
   return new Promise<T | undefined>((resolve, reject) => {
@@ -130,12 +130,7 @@ function withOptionsWriteTimeout<T>(label: string, op: () => Promise<T>): Promis
       if (settled) return;
       settled = true;
       optionsWriteWedged = true;
-      Log._warn(
-        `[SDK-4336] db.${label} timed out after ${OPTIONS_WRITE_TIMEOUT_MS}ms; ` +
-          `IndexedDB Options store is wedged (likely iOS Safari PWA after push ` +
-          `subscription). Tripping circuit breaker; subsequent Options writes ` +
-          `on this page will be skipped immediately.`,
-      );
+      Log._warn(`[SDK-4336] db.${label} timed out; tripping circuit breaker`);
       resolve(undefined);
     }, OPTIONS_WRITE_TIMEOUT_MS);
     op().then(

--- a/src/shared/database/client.ts
+++ b/src/shared/database/client.ts
@@ -93,7 +93,58 @@ export const getDb = (version = VERSION) => {
   return dbPromise;
 };
 
-// Export db object with the same API as before
+// SDK-4336: iOS 26 Safari PWA, on the navigation back to a page after the
+// user has subscribed to push, leaves the `ONE_SIGNAL_SDK_DB` database in
+// a state where every `readwrite` request on the `Options` object store
+// stalls indefinitely (no `success`, no `error`, no transaction lifecycle
+// event). Fresh connections inherit the same per-store WebKit lock state,
+// so reopening doesn't help. Reads work, and `readwrite` on other stores
+// works — only `readwrite` on `Options` is poisoned.
+//
+// Without this guard, `OneSignal.init()` blocks on the very first Options
+// `put` in `initSaveState`/`saveInitOptions` and never returns, which the
+// support team has observed as init "hanging for ~30 minutes" (the time
+// it eventually takes WebKit's internal watchdog to abort the wedged
+// transaction).
+//
+// Workaround: cap `readwrite` operations on the `Options` store with a
+// short timeout. On timeout, we log a warning and resolve the promise as
+// a no-op so init proceeds. The values that didn't get persisted are
+// session metadata (`pageTitle`, `persistNotification`, webhook URLs,
+// click-handler config, `lastPushToken`, `isPushEnabled`, etc.) that the
+// service worker reads with sensible fallbacks if missing or stale.
+const OPTIONS_WRITE_TIMEOUT_MS = 1500;
+
+function withOptionsWriteTimeout<T>(label: string, op: () => Promise<T>): Promise<T | undefined> {
+  return new Promise<T | undefined>((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      Log._warn(
+        `[SDK-4336] db.${label} timed out after ${OPTIONS_WRITE_TIMEOUT_MS}ms; ` +
+          `IndexedDB Options store is wedged (likely iOS Safari PWA after push ` +
+          `subscription). Skipping write to avoid blocking init.`,
+      );
+      resolve(undefined);
+    }, OPTIONS_WRITE_TIMEOUT_MS);
+    op().then(
+      (v) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(e);
+      },
+    );
+  });
+}
+
 export const db = {
   async get<K extends IDBStoreName>(
     storeName: K,
@@ -105,10 +156,18 @@ export const db = {
     return (await dbPromise).getAll(storeName);
   },
   async put<K extends IDBStoreName>(storeName: K, value: IndexedDBSchema[K]['value']) {
-    return (await dbPromise).put(storeName, value);
+    const op = async () => (await dbPromise).put(storeName, value);
+    if (storeName === 'Options') {
+      return withOptionsWriteTimeout(`put(${storeName})`, op);
+    }
+    return op();
   },
   async delete<K extends IDBStoreName>(storeName: K, key: IndexedDBSchema[K]['key']) {
-    return (await dbPromise).delete(storeName, key);
+    const op = async () => (await dbPromise).delete(storeName, key);
+    if (storeName === 'Options') {
+      return withOptionsWriteTimeout(`delete(${storeName}/${String(key)})`, op);
+    }
+    return op();
   },
 };
 

--- a/src/shared/database/client.ts
+++ b/src/shared/database/client.ts
@@ -94,34 +94,36 @@ export const getDb = (version = VERSION) => {
 };
 
 // SDK-4336: iOS 26 Safari PWA, on the navigation back to a page after the
-// user has subscribed to push, leaves the `ONE_SIGNAL_SDK_DB` database in
-// a state where every `readwrite` request on the `Options` object store
-// stalls indefinitely (no `success`, no `error`, no transaction lifecycle
-// event). Fresh connections inherit the same per-store WebKit lock state,
-// so reopening doesn't help. Reads work, and `readwrite` on other stores
-// works — only `readwrite` on `Options` is poisoned.
+// user has subscribed to push, leaves the `ONE_SIGNAL_SDK_DB` database
+// in a state where `readwrite` requests stall indefinitely (no
+// `success`, no `error`, no transaction lifecycle event). Fresh
+// connections inherit the same WebKit lock state, so reopening doesn't
+// help. Reads still work; only `readwrite` is poisoned.
 //
-// Without this guard, `OneSignal.init()` blocks on the very first Options
-// `put` in `initSaveState`/`saveInitOptions` and never returns, which the
-// support team has observed as init "hanging for ~30 minutes" (the time
-// it eventually takes WebKit's internal watchdog to abort the wedged
-// transaction).
+// Without this guard, `OneSignal.init()` blocks on the first `Options`
+// `put` in `initSaveState`/`saveInitOptions` and never returns, and
+// even after init the operation queue (`OperationRepo`) gets stuck
+// because `_executeOperations` awaits writes to the `operations` /
+// `identity` / `properties` / `pushSubscriptions` stores that never
+// settle. The support team has observed this as init "hanging for ~30
+// minutes" (the time it eventually takes WebKit's internal watchdog to
+// abort the wedged transaction) plus persistent failure to flush
+// queued user/subscription operations.
 //
-// Workaround: cap `readwrite` operations on the `Options` store with a
-// short timeout. On timeout, we log a warning, trip a circuit breaker
-// for the rest of the page's lifetime so subsequent Options writes
-// short-circuit instead of each paying the timeout, and resolve the
-// promise as a no-op so init proceeds. The values that didn't get
-// persisted are session metadata (`pageTitle`, `persistNotification`,
-// webhook URLs, click-handler config, `lastPushToken`, `isPushEnabled`,
-// etc.) that the service worker reads with sensible fallbacks if
-// missing or stale.
-const OPTIONS_WRITE_TIMEOUT_MS = 1500;
-let optionsWriteWedged = false;
+// Workaround: cap every `readwrite` op (`put` / `delete` / `clear`)
+// with a short timeout. On timeout, log a `[SDK-4336]` warning, trip a
+// page-scoped circuit breaker so subsequent readwrites short-circuit
+// instead of each paying the timeout, and resolve the promise as a
+// no-op so callers proceed. The values that don't get persisted are
+// either session metadata the SW re-derives from network state on the
+// next visit, or queued operations whose effects are idempotent and
+// will be re-attempted next session.
+const READWRITE_TIMEOUT_MS = 1500;
+let readwriteWedged = false;
 
-function withOptionsWriteTimeout<T>(label: string, op: () => Promise<T>): Promise<T | undefined> {
-  if (optionsWriteWedged) {
-    Log._warn(`[SDK-4336] db.${label} skipped; Options store is known wedged for this page.`);
+function withReadwriteTimeout<T>(label: string, op: () => Promise<T>): Promise<T | undefined> {
+  if (readwriteWedged) {
+    Log._warn(`[SDK-4336] db.${label} skipped; IndexedDB readwrite is wedged for this page.`);
     return Promise.resolve(undefined);
   }
   return new Promise<T | undefined>((resolve, reject) => {
@@ -129,15 +131,15 @@ function withOptionsWriteTimeout<T>(label: string, op: () => Promise<T>): Promis
     const timer = setTimeout(() => {
       if (settled) return;
       settled = true;
-      optionsWriteWedged = true;
+      readwriteWedged = true;
       Log._warn(
-        `[SDK-4336] db.${label} timed out after ${OPTIONS_WRITE_TIMEOUT_MS}ms; ` +
-          `IndexedDB Options store is wedged (likely iOS Safari PWA after push ` +
-          `subscription). Tripping circuit breaker; subsequent Options writes ` +
-          `on this page will be skipped immediately.`,
+        `[SDK-4336] db.${label} timed out after ${READWRITE_TIMEOUT_MS}ms; ` +
+          `IndexedDB is wedged (likely iOS Safari PWA after push subscription). ` +
+          `Tripping circuit breaker; subsequent readwrites on this page will be ` +
+          `skipped immediately.`,
       );
       resolve(undefined);
-    }, OPTIONS_WRITE_TIMEOUT_MS);
+    }, READWRITE_TIMEOUT_MS);
     op().then(
       (v) => {
         if (settled) return;
@@ -166,23 +168,21 @@ export const db = {
     return (await dbPromise).getAll(storeName);
   },
   async put<K extends IDBStoreName>(storeName: K, value: IndexedDBSchema[K]['value']) {
-    const op = async () => (await dbPromise).put(storeName, value);
-    if (storeName === 'Options') {
-      return withOptionsWriteTimeout(`put(${storeName})`, op);
-    }
-    return op();
+    return withReadwriteTimeout(`put(${storeName})`, async () =>
+      (await dbPromise).put(storeName, value),
+    );
   },
   async delete<K extends IDBStoreName>(storeName: K, key: IndexedDBSchema[K]['key']) {
-    const op = async () => (await dbPromise).delete(storeName, key);
-    if (storeName === 'Options') {
-      return withOptionsWriteTimeout(`delete(${storeName}/${String(key)})`, op);
-    }
-    return op();
+    return withReadwriteTimeout(`delete(${storeName}/${String(key)})`, async () =>
+      (await dbPromise).delete(storeName, key),
+    );
   },
 };
 
 export const clearStore = async <K extends IDBStoreName>(storeName: K) => {
-  return (await dbPromise).clear(storeName);
+  return withReadwriteTimeout(`clear(${storeName})`, async () =>
+    (await dbPromise).clear(storeName),
+  );
 };
 
 export const getObjectStoreNames = async () => {

--- a/src/shared/database/client.ts
+++ b/src/shared/database/client.ts
@@ -101,7 +101,7 @@ export const getDb = (version = VERSION) => {
 // writes with a short timeout, then trip a page-scoped circuit breaker so
 // subsequent writes short-circuit. The values that fail to persist are
 // session metadata the SW reads with sensible fallbacks. Remove if WebKit
-// ever fixes the underlying bug.
+// ever fixes the underlying bug: https://bugs.webkit.org/show_bug.cgi?id=315804
 const OPTIONS_WRITE_TIMEOUT_MS = 1500;
 let optionsWriteWedged = false;
 

--- a/src/shared/database/client.ts
+++ b/src/shared/database/client.ts
@@ -107,44 +107,26 @@ let optionsWriteWedged = false;
 
 export const isOptionsWriteWedged = () => optionsWriteWedged;
 
-// `op` is invoked synchronously so the timeout scopes only to the readwrite
-// request itself — DB open/upgrade time is awaited by callers before they
-// hand us a sync closure, so a slow `open()` (e.g. cross-tab `blocked` event,
-// schema migration on a slow device) won't false-trip the breaker.
+// `op` is invoked synchronously (callers await `dbPromise` first), so the
+// timeout scopes only to the readwrite request, not DB open/upgrade. Once a
+// write times out we trip a page-scoped circuit breaker so the rest of init's
+// Options writes short-circuit instead of each paying the full timeout.
 function guardOptionsWrite<T>(
   storeName: IDBStoreName,
   label: string,
   op: () => Promise<T>,
 ): Promise<T | undefined> {
   if (storeName !== 'Options') return op();
-  if (optionsWriteWedged) {
-    Log._warn(`db.${label} skipped (Options store wedged)`);
-    return Promise.resolve(undefined);
-  }
-  return new Promise<T | undefined>((resolve, reject) => {
-    let settled = false;
-    const timer = setTimeout(() => {
-      if (settled) return;
-      settled = true;
+  if (optionsWriteWedged) return Promise.resolve(undefined);
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<undefined>((resolve) => {
+    timer = setTimeout(() => {
       optionsWriteWedged = true;
-      Log._warn(`db.${label} timed out; tripping Options-write circuit breaker`);
+      Log._warn(`db.${label} timed out`);
       resolve(undefined);
     }, OPTIONS_WRITE_TIMEOUT_MS);
-    op().then(
-      (v) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        resolve(v);
-      },
-      (e) => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        reject(e);
-      },
-    );
   });
+  return Promise.race([op(), timeout]).finally(() => clearTimeout(timer));
 }
 
 export const db = {
@@ -163,7 +145,7 @@ export const db = {
   },
   async delete<K extends IDBStoreName>(storeName: K, key: IndexedDBSchema[K]['key']) {
     const _db = await dbPromise;
-    return guardOptionsWrite(storeName, `delete(${storeName}/${String(key)})`, () =>
+    return guardOptionsWrite(storeName, `delete(${storeName}/${key})`, () =>
       _db.delete(storeName, key),
     );
   },

--- a/src/shared/database/client.ts
+++ b/src/shared/database/client.ts
@@ -94,36 +94,34 @@ export const getDb = (version = VERSION) => {
 };
 
 // SDK-4336: iOS 26 Safari PWA, on the navigation back to a page after the
-// user has subscribed to push, leaves the `ONE_SIGNAL_SDK_DB` database
-// in a state where `readwrite` requests stall indefinitely (no
-// `success`, no `error`, no transaction lifecycle event). Fresh
-// connections inherit the same WebKit lock state, so reopening doesn't
-// help. Reads still work; only `readwrite` is poisoned.
+// user has subscribed to push, leaves the `ONE_SIGNAL_SDK_DB` database in
+// a state where every `readwrite` request on the `Options` object store
+// stalls indefinitely (no `success`, no `error`, no transaction lifecycle
+// event). Fresh connections inherit the same per-store WebKit lock state,
+// so reopening doesn't help. Reads work, and `readwrite` on other stores
+// works — only `readwrite` on `Options` is poisoned.
 //
-// Without this guard, `OneSignal.init()` blocks on the first `Options`
-// `put` in `initSaveState`/`saveInitOptions` and never returns, and
-// even after init the operation queue (`OperationRepo`) gets stuck
-// because `_executeOperations` awaits writes to the `operations` /
-// `identity` / `properties` / `pushSubscriptions` stores that never
-// settle. The support team has observed this as init "hanging for ~30
-// minutes" (the time it eventually takes WebKit's internal watchdog to
-// abort the wedged transaction) plus persistent failure to flush
-// queued user/subscription operations.
+// Without this guard, `OneSignal.init()` blocks on the very first Options
+// `put` in `initSaveState`/`saveInitOptions` and never returns, which the
+// support team has observed as init "hanging for ~30 minutes" (the time
+// it eventually takes WebKit's internal watchdog to abort the wedged
+// transaction).
 //
-// Workaround: cap every `readwrite` op (`put` / `delete` / `clear`)
-// with a short timeout. On timeout, log a `[SDK-4336]` warning, trip a
-// page-scoped circuit breaker so subsequent readwrites short-circuit
-// instead of each paying the timeout, and resolve the promise as a
-// no-op so callers proceed. The values that don't get persisted are
-// either session metadata the SW re-derives from network state on the
-// next visit, or queued operations whose effects are idempotent and
-// will be re-attempted next session.
-const READWRITE_TIMEOUT_MS = 1500;
-let readwriteWedged = false;
+// Workaround: cap `readwrite` operations on the `Options` store with a
+// short timeout. On timeout, we log a warning, trip a circuit breaker
+// for the rest of the page's lifetime so subsequent Options writes
+// short-circuit instead of each paying the timeout, and resolve the
+// promise as a no-op so init proceeds. The values that didn't get
+// persisted are session metadata (`pageTitle`, `persistNotification`,
+// webhook URLs, click-handler config, `lastPushToken`, `isPushEnabled`,
+// etc.) that the service worker reads with sensible fallbacks if
+// missing or stale.
+const OPTIONS_WRITE_TIMEOUT_MS = 1500;
+let optionsWriteWedged = false;
 
-function withReadwriteTimeout<T>(label: string, op: () => Promise<T>): Promise<T | undefined> {
-  if (readwriteWedged) {
-    Log._warn(`[SDK-4336] db.${label} skipped; IndexedDB readwrite is wedged for this page.`);
+function withOptionsWriteTimeout<T>(label: string, op: () => Promise<T>): Promise<T | undefined> {
+  if (optionsWriteWedged) {
+    Log._warn(`[SDK-4336] db.${label} skipped; Options store is known wedged for this page.`);
     return Promise.resolve(undefined);
   }
   return new Promise<T | undefined>((resolve, reject) => {
@@ -131,15 +129,15 @@ function withReadwriteTimeout<T>(label: string, op: () => Promise<T>): Promise<T
     const timer = setTimeout(() => {
       if (settled) return;
       settled = true;
-      readwriteWedged = true;
+      optionsWriteWedged = true;
       Log._warn(
-        `[SDK-4336] db.${label} timed out after ${READWRITE_TIMEOUT_MS}ms; ` +
-          `IndexedDB is wedged (likely iOS Safari PWA after push subscription). ` +
-          `Tripping circuit breaker; subsequent readwrites on this page will be ` +
-          `skipped immediately.`,
+        `[SDK-4336] db.${label} timed out after ${OPTIONS_WRITE_TIMEOUT_MS}ms; ` +
+          `IndexedDB Options store is wedged (likely iOS Safari PWA after push ` +
+          `subscription). Tripping circuit breaker; subsequent Options writes ` +
+          `on this page will be skipped immediately.`,
       );
       resolve(undefined);
-    }, READWRITE_TIMEOUT_MS);
+    }, OPTIONS_WRITE_TIMEOUT_MS);
     op().then(
       (v) => {
         if (settled) return;
@@ -168,21 +166,23 @@ export const db = {
     return (await dbPromise).getAll(storeName);
   },
   async put<K extends IDBStoreName>(storeName: K, value: IndexedDBSchema[K]['value']) {
-    return withReadwriteTimeout(`put(${storeName})`, async () =>
-      (await dbPromise).put(storeName, value),
-    );
+    const op = async () => (await dbPromise).put(storeName, value);
+    if (storeName === 'Options') {
+      return withOptionsWriteTimeout(`put(${storeName})`, op);
+    }
+    return op();
   },
   async delete<K extends IDBStoreName>(storeName: K, key: IndexedDBSchema[K]['key']) {
-    return withReadwriteTimeout(`delete(${storeName}/${String(key)})`, async () =>
-      (await dbPromise).delete(storeName, key),
-    );
+    const op = async () => (await dbPromise).delete(storeName, key);
+    if (storeName === 'Options') {
+      return withOptionsWriteTimeout(`delete(${storeName}/${String(key)})`, op);
+    }
+    return op();
   },
 };
 
 export const clearStore = async <K extends IDBStoreName>(storeName: K) => {
-  return withReadwriteTimeout(`clear(${storeName})`, async () =>
-    (await dbPromise).clear(storeName),
-  );
+  return (await dbPromise).clear(storeName);
 };
 
 export const getObjectStoreNames = async () => {

--- a/src/shared/database/client.ts
+++ b/src/shared/database/client.ts
@@ -108,23 +108,33 @@ export const getDb = (version = VERSION) => {
 // transaction).
 //
 // Workaround: cap `readwrite` operations on the `Options` store with a
-// short timeout. On timeout, we log a warning and resolve the promise as
-// a no-op so init proceeds. The values that didn't get persisted are
-// session metadata (`pageTitle`, `persistNotification`, webhook URLs,
-// click-handler config, `lastPushToken`, `isPushEnabled`, etc.) that the
-// service worker reads with sensible fallbacks if missing or stale.
+// short timeout. On timeout, we log a warning, trip a circuit breaker
+// for the rest of the page's lifetime so subsequent Options writes
+// short-circuit instead of each paying the timeout, and resolve the
+// promise as a no-op so init proceeds. The values that didn't get
+// persisted are session metadata (`pageTitle`, `persistNotification`,
+// webhook URLs, click-handler config, `lastPushToken`, `isPushEnabled`,
+// etc.) that the service worker reads with sensible fallbacks if
+// missing or stale.
 const OPTIONS_WRITE_TIMEOUT_MS = 1500;
+let optionsWriteWedged = false;
 
 function withOptionsWriteTimeout<T>(label: string, op: () => Promise<T>): Promise<T | undefined> {
+  if (optionsWriteWedged) {
+    Log._warn(`[SDK-4336] db.${label} skipped; Options store is known wedged for this page.`);
+    return Promise.resolve(undefined);
+  }
   return new Promise<T | undefined>((resolve, reject) => {
     let settled = false;
     const timer = setTimeout(() => {
       if (settled) return;
       settled = true;
+      optionsWriteWedged = true;
       Log._warn(
         `[SDK-4336] db.${label} timed out after ${OPTIONS_WRITE_TIMEOUT_MS}ms; ` +
           `IndexedDB Options store is wedged (likely iOS Safari PWA after push ` +
-          `subscription). Skipping write to avoid blocking init.`,
+          `subscription). Tripping circuit breaker; subsequent Options writes ` +
+          `on this page will be skipped immediately.`,
       );
       resolve(undefined);
     }, OPTIONS_WRITE_TIMEOUT_MS);

--- a/src/shared/helpers/init.test.ts
+++ b/src/shared/helpers/init.test.ts
@@ -6,9 +6,18 @@ import Context from 'src/page/models/Context';
 import { type AppConfig } from 'src/shared/config/types';
 import { beforeEach, describe, expect, test, vi, type MockInstance } from 'vite-plus/test';
 
+import * as clientModule from '../database/client';
 import { db } from '../database/client';
 import { getAppState } from '../database/config';
 import * as InitHelper from './init';
+
+vi.mock('../database/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../database/client')>();
+  return {
+    ...actual,
+    isOptionsWriteWedged: vi.fn(() => false),
+  };
+});
 
 let isSubscriptionExpiringSpy: MockInstance;
 
@@ -190,5 +199,18 @@ describe('initSaveState: App ID migration', () => {
 
     const storedAppId = await db.get('Ids', 'appId');
     expect(storedAppId?.id).toBe(NEW_APP_ID);
+  });
+
+  test('defers App ID commit when Options write breaker is tripped', async () => {
+    await seedStaleState();
+    await db.put('Ids', { type: 'userId', id: 'old-user-id' });
+
+    vi.mocked(clientModule.isOptionsWriteWedged).mockReturnValueOnce(true);
+
+    await InitHelper.initSaveState();
+
+    expect((await db.get('Ids', 'appId'))?.id).toBe(OLD_APP_ID);
+    expect((await db.get('Ids', 'registrationId'))?.id).toBe('old-reg-token');
+    expect((await db.get('Ids', 'userId'))?.id).toBe('old-user-id');
   });
 });

--- a/src/shared/helpers/init.ts
+++ b/src/shared/helpers/init.ts
@@ -357,10 +357,7 @@ export async function initSaveState(overridingPageTitle?: string) {
     // `previousAppId !== appId` gate above would keep us out of this branch
     // on later loads — leaving the stale values permanent. Skipping the
     // appId commit instead lets a future non-wedged load complete the reset.
-    if (isOptionsWriteWedged()) {
-      Log._warn('App ID change reset deferred; will retry on next non-wedged load');
-      return;
-    }
+    if (isOptionsWriteWedged()) return;
     await db.put('Ids', { type: 'registrationId', id: null });
     await db.put('Ids', { type: 'userId', id: null });
     OneSignal._coreDirector._subscriptionModelStore._clear(ModelChangeTags._Hydrate);

--- a/src/shared/helpers/init.ts
+++ b/src/shared/helpers/init.ts
@@ -3,7 +3,7 @@ import { ModelChangeTags } from 'src/core/types/models';
 import Bell from '../../page/bell/Bell';
 import type { AppConfig } from '../config/types';
 import type { ContextInterface } from '../context/types';
-import { db, getIdsValue } from '../database/client';
+import { db, getIdsValue, isOptionsWriteWedged } from '../database/client';
 import { getSubscription, setSubscription } from '../database/subscription';
 import type { OptionKey } from '../database/types';
 import Log from '../libraries/Log';
@@ -352,6 +352,15 @@ export async function initSaveState(overridingPageTitle?: string) {
     await db.put('Options', { key: 'lastPushId', value: null });
     await db.put('Options', { key: 'lastPushToken', value: null });
     await db.put('Options', { key: 'lastOptedIn', value: null });
+    // Bail out if the Options reset got circuit-broken. Committing the new
+    // appId now would strand the previous app's metadata under it, and the
+    // `previousAppId !== appId` gate above would keep us out of this branch
+    // on later loads — leaving the stale values permanent. Skipping the
+    // appId commit instead lets a future non-wedged load complete the reset.
+    if (isOptionsWriteWedged()) {
+      Log._warn('App ID change reset deferred; will retry on next non-wedged load');
+      return;
+    }
     await db.put('Ids', { type: 'registrationId', id: null });
     await db.put('Ids', { type: 'userId', id: null });
     OneSignal._coreDirector._subscriptionModelStore._clear(ModelChangeTags._Hydrate);


### PR DESCRIPTION
# Description

## 1 Line Summary

Stops `OneSignal.init()` from hanging for ~30 minutes on iOS 26 Safari PWAs by capping `Options`-store readwrite operations with a 1.5s hard timeout and tripping a page-scoped circuit breaker once the wedge is detected.

Note: A bug report ([315804](https://bugs.webkit.org/show_bug.cgi?id=315804)) was filed in Webkit upstream to investigate this.

## Details

### Root cause

On iOS 26 Safari running as a Home-Screen PWA (`display: standalone`), the navigation back into the app *after a successful push subscription* leaves the `ONE_SIGNAL_SDK_DB` IndexedDB in a poisoned state where every `readwrite` request on the `Options` object store stalls indefinitely. The `IDBRequest` is created and goes to `pending`, but **no event ever fires** — no `success`, no `error`, no transaction `complete` / `abort`, no `IDBDatabase.onclose`. WebKit's internal transaction watchdog only forcibly aborts the wedged transaction after roughly 30 minutes; until then `await db.put('Options', ...)` never settles.

`OneSignal.init()` always writes to `Options` very early — `initSaveState` writes `pageTitle`, `saveInitOptions` writes 7+ entries (webhook URLs, persistNotification, click-handler config, `lastPushToken`, `isPushEnabled`, etc.). Without this guard, **the very first of those writes blocks init forever** and the support team observes \"init hanging for 30 minutes, then eventually recovers\" — exactly the watchdog timer.

What we ruled out and how:

- **NetworkProcess crash family** (WebKit bugs [273827](https://bugs.webkit.org/show_bug.cgi?id=273827) / [277615](https://bugs.webkit.org/show_bug.cgi?id=277615) / [309386](https://bugs.webkit.org/show_bug.cgi?id=309386)). Those throw `UnknownError: Connection to Indexed Database server lost` and fire `IDBDatabase.onclose`. We never see either.
- **Process suspension** ([202705](https://bugs.webkit.org/show_bug.cgi?id=202705)). That throws `TransactionInactiveError` synchronously. We throw nothing.
- **PWA total freeze** ([211018](https://bugs.webkit.org/show_bug.cgi?id=211018)). All other JS keeps running — timers fire, fetch works, the SW heartbeat keeps ticking — only this one `IDBRequest` is dead.
- **Connection-level wedge.** Reads (`get`, `getAll`) on the same DB connection still work. `readwrite` on other stores still works. Closing and re-opening the database returns a fresh `IDBDatabase` whose first `readwrite` on `Options` wedges identically.
- **Origin-wide IDB wedge.** A diagnostic probe that opened a *different* IndexedDB name at the same origin and issued a `readwrite put` completed in 11 ms while the real DB was hung. The wedge is per-database, not origin-wide.

Filed upstream as WebKit bug [315804](https://bugs.webkit.org/show_bug.cgi?id=315804) ("A readwrite IDBTransaction never fires oncomplete, onerror, or onabort after the user subscribes to web push in an installed PWA") with a link back to this PR for steps on how to reproduce. The source comment in `client.ts` also references the bug so the workaround can be removed once WebKit ships a fix.

### Fix

Three commits, each independently revertable:

1. **`81415fdd` — fix: fail-fast Options writes.** Wrap `db.put('Options', ...)` and `db.delete('Options', ...)` with a 1500ms hard timeout. On timeout, log a `[SDK-4336]` warning and resolve the promise as a no-op so init proceeds. Other stores keep their existing behavior. The values that don't get persisted are session metadata that the SW reads with sensible fallbacks if missing or stale, so push delivery is unaffected.

2. **`1ae8abdf` — perf: short-circuit after first wedge.** Once a single `Options` `readwrite` times out we know the store is poisoned for the rest of this page's lifetime. Add a module-scoped `optionsWriteWedged` flag so the remaining 7 Options writes in `initSaveState` + `saveInitOptions` short-circuit immediately instead of each independently paying the 1500ms timeout. Cuts init latency on a wedged page from ~12s to ~1.5s. The flag is page-scoped (resets on navigation), so a subsequent navigation will probe the wedge fresh.

3. **`88e4cd59` — chore(preview): repro sandbox** (will be reverted before merge). Two-page demo + dev-server hardening that lets a reviewer reproduce the original 30-minute hang on `main` and confirm this branch resolves it. Detailed testing instructions in a separate PR comment.

A 4th commit (`3c41181b`) generalizing the timeout to *all* readwrite stores was tried and reverted (`83cbff87`) because we couldn't validate it on device — every subsequent on-device repro happened with an empty operation queue. Parked in branch history with the validation steps captured in a Linear comment on SDK-4336.

# Systems Affected

- [x] WebSDK
- [ ] Backend
- [ ] Dashboard

# Validation

## Tests

### Info

- Full suite: **512/512 pass**, lint clean, formatter clean.
- The fix path is exercised by the existing `client.test.ts` round-trip tests (every `Options` write goes through the new wrapper, so all 12 client tests are effectively also covering the timeout path's happy case).
- On-device verification on iPhone running iOS 26.4 (logs11.txt → logs14.txt in the chat): pre-fix init hung indefinitely; post-fix init completes within ~1.5s on the wedged navigation, with a `[SDK-4336] db.put(Options) timed out … Tripping circuit breaker` warning and 7 follow-up `db.put(Options) skipped` warnings, then `internalInit` → SW handshake → `sessionInit` proceed normally.
- I haven't added a unit test specifically for the timeout path because the existing `client.test.ts` uses `fake-indexeddb` which doesn't reproduce the WebKit-specific wedge — a synthetic timeout test would only verify the timer plumbing, which is straightforward enough that the on-device evidence is more meaningful.

### Checklist

- [x] All the automated tests pass or I explained why that is not possible
- [x] I have personally tested this on my machine or explained why that is not possible
- [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**

Interfaces:

- [x] Don't use default export
- [x] New interfaces are in model files

Functions:

- [x] Don't use default export
- [x] All function signatures have return types
- [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:

- [x] No Typescript warnings
- [x] Avoid silencing null/undefined warnings with the exclamation point

Other:

- [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
- [x] Avoid using global OneSignal accessor for `context` if possible.

## Screenshots

### Info

N/A — runtime correctness fix, no UI changes. See on-device console logs in the SDK-4336 Linear ticket and chat history.

### Checklist

- [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

[SDK-4336](https://linear.app/onesignal/issue/SDK-4336/bug-onesignalinit-hangs-on-subsequent-page-navigations-in-ios-safari)