### PR TITLE
fix: [SDK-4336] add circuit breaker and defer appId commit on wedge

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,12 +77,12 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "42.4 kB",
+      "limit": "42.5 kB",
       "gzip": true
     },
     {
       "path": "./build/releases/OneSignalSDK.sw.js",
-      "limit": "12.354 kB",
+      "limit": "12.43 kB",
       "gzip": true
     },
     {

--- a/package.json
+++ b/package.json
@@ -77,12 +77,12 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "42.5 kB",
+      "limit": "42.6 kB",
       "gzip": true
     },
     {
       "path": "./build/releases/OneSignalSDK.sw.js",
-      "limit": "12.43 kB",
+      "limit": "12.55 kB",
       "gzip": true
     },
     {

--- a/src/shared/database/client.ts
+++ b/src/shared/database/client.ts
@@ -99,14 +99,28 @@ export const getDb = (version = VERSION) => {
 // (~30 min). Other stores and reads are unaffected, and reopening the DB
 // doesn't help. Cap Options writes with a short timeout and resolve undefined
 // on stall; the dropped values are session metadata the SW reads with sensible
-// fallbacks. Remove if WebKit ever fixes the underlying bug:
-// https://bugs.webkit.org/show_bug.cgi?id=315804
+// fallbacks. Once any write times out we trip a page-scoped circuit breaker
+// so the remaining ~7 Options writes during init short-circuit instead of
+// each paying the full timeout. Remove if WebKit ever fixes the underlying
+// bug: https://bugs.webkit.org/show_bug.cgi?id=315804
+let optionsWriteWedged = false;
+export const isOptionsWriteWedged = () => optionsWriteWedged;
+
 function guardOptionsWrite<T>(
   storeName: IDBStoreName,
   op: () => Promise<T>,
 ): Promise<T | undefined> {
   if (storeName !== 'Options') return op();
-  return Promise.race([op(), new Promise<undefined>((r) => setTimeout(r, 2000))]);
+  if (optionsWriteWedged) return Promise.resolve(undefined);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<undefined>((resolve) => {
+    timer = setTimeout(() => {
+      optionsWriteWedged = true;
+      Log._warn(`db.${storeName} timed out`);
+      resolve(undefined);
+    }, 2000);
+  });
+  return Promise.race([op(), timeout]).finally(() => clearTimeout(timer));
 }
 
 // Export db object with the same API as before

--- a/src/shared/database/client.ts
+++ b/src/shared/database/client.ts
@@ -93,6 +93,22 @@ export const getDb = (version = VERSION) => {
   return dbPromise;
 };
 
+// On iOS Safari PWA after a push subscription, `readwrite` requests on the
+// `Options` object store can stall indefinitely (no success/error/abort),
+// hanging `OneSignal.init()` until WebKit's watchdog aborts the transaction
+// (~30 min). Other stores and reads are unaffected, and reopening the DB
+// doesn't help. Cap Options writes with a short timeout and resolve undefined
+// on stall; the dropped values are session metadata the SW reads with sensible
+// fallbacks. Remove if WebKit ever fixes the underlying bug:
+// https://bugs.webkit.org/show_bug.cgi?id=315804
+function guardOptionsWrite<T>(
+  storeName: IDBStoreName,
+  op: () => Promise<T>,
+): Promise<T | undefined> {
+  if (storeName !== 'Options') return op();
+  return Promise.race([op(), new Promise<undefined>((r) => setTimeout(r, 2000))]);
+}
+
 // Export db object with the same API as before
 export const db = {
   async get<K extends IDBStoreName>(
@@ -105,10 +121,12 @@ export const db = {
     return (await dbPromise).getAll(storeName);
   },
   async put<K extends IDBStoreName>(storeName: K, value: IndexedDBSchema[K]['value']) {
-    return (await dbPromise).put(storeName, value);
+    const _db = await dbPromise;
+    return guardOptionsWrite(storeName, () => _db.put(storeName, value));
   },
   async delete<K extends IDBStoreName>(storeName: K, key: IndexedDBSchema[K]['key']) {
-    return (await dbPromise).delete(storeName, key);
+    const _db = await dbPromise;
+    return guardOptionsWrite(storeName, () => _db.delete(storeName, key));
   },
 };
 

--- a/src/shared/helpers/init.ts
+++ b/src/shared/helpers/init.ts
@@ -3,7 +3,7 @@ import { ModelChangeTags } from 'src/core/types/models';
 import Bell from '../../page/bell/Bell';
 import type { AppConfig } from '../config/types';
 import type { ContextInterface } from '../context/types';
-import { db, getIdsValue } from '../database/client';
+import { db, getIdsValue, isOptionsWriteWedged } from '../database/client';
 import { getSubscription, setSubscription } from '../database/subscription';
 import type { OptionKey } from '../database/types';
 import Log from '../libraries/Log';
@@ -352,6 +352,12 @@ export async function initSaveState(overridingPageTitle?: string) {
     await db.put('Options', { key: 'lastPushId', value: null });
     await db.put('Options', { key: 'lastPushToken', value: null });
     await db.put('Options', { key: 'lastOptedIn', value: null });
+    // Bail out if the Options reset got circuit-broken. Committing the new
+    // appId now would strand the previous app's metadata under it, and the
+    // `previousAppId !== appId` gate above would keep us out of this branch
+    // on later loads — leaving the stale values permanent. Skipping the
+    // appId commit instead lets a future non-wedged load complete the reset.
+    if (isOptionsWriteWedged()) return;
     await db.put('Ids', { type: 'registrationId', id: null });
     await db.put('Ids', { type: 'userId', id: null });
     OneSignal._coreDirector._subscriptionModelStore._clear(ModelChangeTags._Hydrate);


### PR DESCRIPTION
## Summary

Two follow-up fixes layered on top of [7f5df216](https://github.com/OneSignal/OneSignal-Website-SDK/commit/7f5df21652bd90ad266c0c8b28520004c6eba481), surfaced during review of the (now-closed) #1468:

- **Circuit breaker** — once any Options write times out, trip a page-scoped flag so the remaining ~7 Options writes during a wedged init short-circuit immediately. Cuts wedged-init time from ~14s (7 × 2s timeout) to ~2s (single timeout, rest skip).
- **Defer the new-appId commit on wedge** — `Ids.appId` is unguarded, so on a wedged page during an app-ID switch the `Ids.appId` write would succeed while the previous app's `Options.{isPushEnabled,lastPushId,lastPushToken,lastOptedIn}` stayed put. The `previousAppId !== appId` gate would then keep the reset branch from re-entering on later loads — making the cross-app contamination permanent. With the new `isOptionsWriteWedged()` accessor, `initSaveState` now bails early on a tripped breaker so a future non-wedged load can finish the reset cleanly.

Also fixes a minor leak — `Promise.race` now uses `.finally(() => clearTimeout(timer))` so healthy pages don't accumulate dangling 2s timers across the dozens of Options writes init issues.

Adds a single `Log._warn` on timeout so support can correlate the breaker tripping with init slowness in console logs.

## Test plan

- [x] `vp test --run` — 512/512 passing.
- [x] `vp check` — clean (5 unrelated pre-existing warnings).
- [x] `vp run build:prod` — passes; bundle deltas covered by a +80 B / +120 B size-limit bump.
- [ ] On-device sanity check on iOS 26 PWA (the original repro path), confirming wedged init now resolves in ~2s and the `db.Options timed out` warning fires once.

## Why a follow-up rather than amending #1468

#1468 had been chasing the same ticket and was effectively superseded by 7f5df216 landing on `main`. Closing it as superseded and re-uploading just the additive hardening on top of `main` keeps this diff minimal and reviewable (3 files, +26/-6).