### PR TITLE
fix: join service worker path with a single slash

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,12 +77,12 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "42.7 kB",
+      "limit": "42.57 kB",
       "gzip": true
     },
     {
       "path": "./build/releases/OneSignalSDK.sw.js",
-      "limit": "12.65 kB",
+      "limit": "12.51 kB",
       "gzip": true
     },
     {

--- a/src/shared/helpers/context.test.ts
+++ b/src/shared/helpers/context.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vite-plus/test';
+
+import type { AppConfig } from '../config/types';
+import type { ContextInterface } from '../context/types';
+import { getServiceWorkerManager } from './context';
+
+const buildContext = (path: string, serviceWorkerPath: string): ContextInterface =>
+  ({
+    _appConfig: {
+      userConfig: { path, serviceWorkerPath },
+    } as AppConfig,
+  }) as ContextInterface;
+
+const workerPathFor = (path: string, serviceWorkerPath: string): string => {
+  const manager = getServiceWorkerManager(buildContext(path, serviceWorkerPath));
+  return manager['_config'].workerPath._getFullPath();
+};
+
+describe('getServiceWorkerManager worker path', () => {
+  test('joins default root path with worker file name', () => {
+    expect(workerPathFor('/', 'OneSignalSDKWorker.js')).toBe('/OneSignalSDKWorker.js');
+  });
+
+  test('collapses a leading slash in serviceWorkerPath to avoid a protocol-relative URL', () => {
+    expect(workerPathFor('/', '/OneSignalSDKWorker.js')).toBe('/OneSignalSDKWorker.js');
+  });
+
+  test('joins a nested path with a trailing slash', () => {
+    expect(workerPathFor('/push/onesignal/', 'OneSignalSDKWorker.js')).toBe(
+      '/push/onesignal/OneSignalSDKWorker.js',
+    );
+  });
+
+  test('normalizes slashes on both sides of the join', () => {
+    expect(workerPathFor('/push/', '/OneSignalSDKWorker.js')).toBe('/push/OneSignalSDKWorker.js');
+  });
+});

--- a/src/shared/helpers/context.ts
+++ b/src/shared/helpers/context.ts
@@ -17,9 +17,12 @@ export function getServiceWorkerManager(context: ContextInterface): ServiceWorke
 
   if (config.userConfig) {
     if (config.userConfig.path) {
-      serviceWorkerManagerConfig.workerPath = new Path(
-        `${config.userConfig.path}${config.userConfig.serviceWorkerPath}`,
-      );
+      // Join with exactly one slash. A leading "//" forms a protocol-relative
+      // URL, which the browser resolves to a different origin and rejects with a
+      // SecurityError when registering the worker.
+      const basePath = config.userConfig.path.replace(/\/+$/, '');
+      const workerPath = (config.userConfig.serviceWorkerPath ?? '').replace(/^\/+/, '');
+      serviceWorkerManagerConfig.workerPath = new Path(`${basePath}/${workerPath}`);
     }
     if (config.userConfig.serviceWorkerParam) {
       serviceWorkerManagerConfig.registrationOptions = config.userConfig.serviceWorkerParam;


### PR DESCRIPTION
# Description

## 1 Line Summary

Harden the service-worker path join so a leading slash in `serviceWorkerPath` can't produce a protocol-relative `//` URL that fails worker registration.

## Details

Adds a guard to prevent the potential for a simple misconfiguration from silently breaking push.

`getServiceWorkerManager` (`src/shared/helpers/context.ts`) builds the worker URL by directly concatenating `userConfig.path` and `userConfig.serviceWorkerPath`:

```ts
new Path(`${config.userConfig.path}${config.userConfig.serviceWorkerPath}`)
```

`path` defaults to `"/"`. If an integration configures `serviceWorkerPath: "/OneSignalSDKWorker.js"` (with a leading slash), the result is `"//OneSignalSDKWorker.js"`. The browser interprets a leading `//` as a **protocol-relative URL**, treating `onesignalsdkworker.js` as a hostname (`https://onesignalsdkworker.js/`). Worker registration is then rejected cross-origin:

```
SecurityError: Failed to register a ServiceWorker: The origin of the provided scriptURL
('https://onesignalsdkworker.js') does not match the current origin (...).
```

With no worker, no push token is ever acquired, which downstream surfaces as `subscription-10` ("Subscription can't change notification_types to positive integer while disabled") because the subscription is sent with an empty token.

The fix strips a trailing slash from `path` and a leading slash from `serviceWorkerPath`, then joins them with exactly one slash — so both `"/" + "OneSignalSDKWorker.js"` and `"/" + "/OneSignalSDKWorker.js"` resolve to `/OneSignalSDKWorker.js`.

# Systems Affected

- [x] WebSDK
- [ ] Backend
- [ ] Dashboard

# Validation

## Tests

### Info

Added `src/shared/helpers/context.test.ts` covering the join logic:
- default root path + worker file name
- leading-slash `serviceWorkerPath` no longer yields `//`
- nested path with a trailing slash
- slashes on both sides of the join

### Checklist

- [x] All the automated tests pass or I explained why that is not possible
- [x] I have personally tested this on my machine or explained why that is not possible
- [x] I have included test coverage for these changes or explained why they are not needed

## Screenshots

### Checklist

- [x] I have included screenshots/recordings of the intended results or explained why they are not needed (config/URL normalization, covered by unit tests)

---

## Related Tickets

Surfaced while investigating SDK-4341.