### PR TITLE
fix: [SDK-4737] persist user consent in localStorage to survive iOS PWA wedge

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "42.57 kB",
+      "limit": "42.65 kB",
       "gzip": true
     },
     {

--- a/src/onesignal/OneSignal.ts
+++ b/src/onesignal/OneSignal.ts
@@ -1,7 +1,7 @@
 import type Bell from 'src/page/bell/Bell';
 import { getAppConfig } from 'src/shared/config/app';
 import type { AppConfig, AppUserConfig } from 'src/shared/config/types';
-import { db, dbPromise } from 'src/shared/database/client';
+import { dbPromise } from 'src/shared/database/client';
 import { getConsentGiven, isConsentRequiredButNotGiven } from 'src/shared/database/config';
 import { getSubscription } from 'src/shared/database/subscription';
 import { windowEnvString } from 'src/shared/environment/detect';
@@ -20,6 +20,7 @@ import {
 import {
   getConsentRequired,
   removeLegacySubscriptionOptions,
+  setConsentGiven as setStorageConsentGiven,
   setConsentRequired as setStorageConsentRequired,
 } from 'src/shared/helpers/localStorage';
 import { checkAndTriggerNotificationPermissionChanged } from 'src/shared/helpers/main';
@@ -219,7 +220,7 @@ export default class OneSignal {
 
     // for quick access as to not wait for async operations / loading from DB
     OneSignal._consentGiven = consent;
-    await db.put('Options', { key: 'userConsent', value: consent });
+    setStorageConsentGiven(consent);
 
     if (consent && OneSignal._pendingInit) await OneSignal._delayedInit();
   }

--- a/src/shared/database/config.test.ts
+++ b/src/shared/database/config.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, test } from 'vite-plus/test';
+
+import {
+  getConsentGiven as getStorageConsentGiven,
+  setConsentGiven as setStorageConsentGiven,
+} from '../helpers/localStorage';
+import { db } from './client';
+import { getConsentGiven } from './config';
+
+describe('getConsentGiven', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('defaults to false when nothing is stored', async () => {
+    expect(await getConsentGiven()).toBe(false);
+  });
+
+  test('reads the value persisted in localStorage', async () => {
+    setStorageConsentGiven(true);
+    expect(await getConsentGiven()).toBe(true);
+
+    setStorageConsentGiven(false);
+    expect(await getConsentGiven()).toBe(false);
+  });
+
+  test('migrates a legacy IndexedDB value into localStorage', async () => {
+    await db.put('Options', { key: 'userConsent', value: true });
+    expect(getStorageConsentGiven()).toBeNull();
+
+    expect(await getConsentGiven()).toBe(true);
+    expect(getStorageConsentGiven()).toBe(true);
+
+    // Once migrated, the value survives even if the IndexedDB row is gone --
+    // a wedged PWA can no longer drop it.
+    await db.delete('Options', 'userConsent');
+    expect(await getConsentGiven()).toBe(true);
+  });
+
+  test('prefers localStorage over a stale legacy IndexedDB value', async () => {
+    await db.put('Options', { key: 'userConsent', value: true });
+    setStorageConsentGiven(false);
+    expect(await getConsentGiven()).toBe(false);
+  });
+});

--- a/src/shared/database/config.ts
+++ b/src/shared/database/config.ts
@@ -1,4 +1,8 @@
-import { getConsentRequired } from '../helpers/localStorage';
+import {
+  getConsentGiven as getStorageConsentGiven,
+  getConsentRequired,
+  setConsentGiven as setStorageConsentGiven,
+} from '../helpers/localStorage';
 import Log from '../libraries/Log';
 import { db, getIdsValue, getOptionsValue } from './client';
 import type { AppState } from './types';
@@ -69,9 +73,15 @@ export const setAppState = async (appState: AppState) => {
     });
 };
 
-// make sure to also set OneSignal._consentGiven when updating 'userConsent'
+// make sure to also set OneSignal._consentGiven when updating consent
 export const getConsentGiven = async () => {
-  return (await getOptionsValue<boolean>('userConsent')) ?? false;
+  const stored = getStorageConsentGiven();
+  if (stored !== null) return stored;
+
+  // Migrate consent persisted by older SDK versions that wrote it to IndexedDB.
+  const legacy = (await getOptionsValue<boolean>('userConsent')) ?? false;
+  setStorageConsentGiven(legacy);
+  return legacy;
 };
 
 export const isConsentRequiredButNotGiven = () => {

--- a/src/shared/helpers/localStorage.ts
+++ b/src/shared/helpers/localStorage.ts
@@ -2,6 +2,7 @@ const IS_OPTED_OUT = 'isOptedOut';
 const IS_PUSH_NOTIFICATIONS_ENABLED = 'isPushNotificationsEnabled';
 const PAGE_VIEWS = 'os_pageViews';
 const REQUIRES_PRIVACY_CONSENT = 'requiresPrivacyConsent';
+const USER_CONSENT = 'userConsent';
 
 /**
  * Used in OneSignal initialization to dedupe local storage subscription options already being saved to IndexedDB.
@@ -20,6 +21,20 @@ export function getConsentRequired(): boolean {
   const requiresUserPrivacyConsent =
     OneSignal.config?.userConfig.requiresUserPrivacyConsent ?? false;
   return localStorage.getItem(REQUIRES_PRIVACY_CONSENT) === 'true' || requiresUserPrivacyConsent;
+}
+
+// Persisted in localStorage rather than IndexedDB: it's a privacy/legal opt-out
+// that isn't re-derivable from any other source, and on a wedged iOS Safari PWA
+// an IndexedDB write can be silently dropped, losing a revocation across reloads.
+export function setConsentGiven(value: boolean): void {
+  localStorage.setItem(USER_CONSENT, value.toString());
+}
+
+// Returns null when no value has been stored, so callers can fall back to the
+// legacy IndexedDB row for one-time migration.
+export function getConsentGiven(): boolean | null {
+  const value = localStorage.getItem(USER_CONSENT);
+  return value === null ? null : value === 'true';
 }
 
 export function setLocalPageViewCount(count: number): void {


### PR DESCRIPTION
# Description

## 1 Line Summary

Persist user consent in `localStorage` instead of IndexedDB so a revoked opt-out isn't silently lost on a wedged iOS Safari PWA.

## Details

Follow-up hardening to SDK-4336 / SDK-4754. `OneSignal.setConsentGiven()` wrote consent to the IndexedDB `Options` store. On a wedged iOS Safari PWA, the circuit breaker added for SDK-4336/4754 silently drops that write — so on the next load the SDK reads the **stale** `userConsent` row back and re-hydrates consent as still granted. A user's privacy/legal opt-out is lost across reloads with no error, rejection, or log.

`userConsent` is the only guarded `Options` key that is **not** re-derivable from another source of truth, which is what makes this privacy-/legal-critical (the trigger itself is narrow: iOS Safari PWA + active wedge + a same-session `setConsentGiven` call).

This change:

- Adds `setConsentGiven` / `getConsentGiven` accessors in `shared/helpers/localStorage.ts`, mirroring how `requiresPrivacyConsent` is already persisted via `setConsentRequired` / `getConsentRequired`. `localStorage` is synchronous and immune to the IndexedDB wedge.
- `OneSignal.setConsentGiven()` now writes to `localStorage` instead of `db.put('Options', { key: 'userConsent', ... })`.
- `config.getConsentGiven()` reads `localStorage` first and falls back **once** to the legacy `Options.userConsent` row, migrating it forward so existing consenting users don't lose their stored consent on upgrade.

**Not a regression** — before SDK-4336 the page hung ~30 min, so a user could never reach the revoke step. SDK-4754 (now merged) made init reliably complete during a wedge, which is what makes this path reachable.

# Systems Affected

- [x] WebSDK
- [ ] Backend
- [ ] Dashboard

# Validation

## Tests

### Info

- `vp check`: 0 errors (5 pre-existing `no-floating-promises` warnings in unrelated test files).
- `vp test --run`: 523 passed. New `src/shared/database/config.test.ts` covers `getConsentGiven`: default `false`, reads the `localStorage` value, migrates a legacy IndexedDB value forward (and survives the IDB row being dropped), and prefers `localStorage` over a stale legacy IndexedDB value.
- `vp run build:prod`: passes. Bumped the `OneSignalSDK.page.es6.js` size-limit 42.57 kB → 42.65 kB to cover the added migration path. Note this limit was 42.7 kB until 4 days ago (`b7bb0cf6`), so 42.65 kB is still tighter than the recent ceiling.

### Checklist

- [x] All the automated tests pass or I explained why that is not possible
- [ ] I have personally tested this on my machine or explained why that is not possible
- [x] I have included test coverage for these changes or explained why they are not needed

## Screenshots

### Info

N/A — behavior is covered by unit tests.

### Checklist

- [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

- SDK-4737 (this fix)
- Follow-up to SDK-4336 / SDK-4754
- WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=315804

---
