### PR TITLE
fix: [SDK-4897] add accessible name to subscription bell launcher button

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "42.65 kB",
+      "limit": "42.7 kB",
       "gzip": true
     },
     {

--- a/src/page/bell/Bell.test.ts
+++ b/src/page/bell/Bell.test.ts
@@ -156,6 +156,36 @@ describe('Bell', () => {
       );
     }
 
+    test('launcher button has a default accessible name', async () => {
+      mockCreateDeps();
+      const bell = new Bell({ enable: true, showLauncherAfter: 0 });
+      await bell._create();
+
+      expect(bell._button._element!.getAttribute('aria-label')).toBe('Manage notifications');
+    });
+
+    test('launcher button accessible name is configurable via text', async () => {
+      mockCreateDeps();
+      const bell = new Bell({
+        enable: true,
+        showLauncherAfter: 0,
+        // @ts-expect-error - partial text config
+        text: { 'launcher.label': 'Διαχείριση ειδοποιήσεων' },
+      });
+      await bell._create();
+
+      expect(bell._button._element!.getAttribute('aria-label')).toBe('Διαχείριση ειδοποιήσεων');
+    });
+
+    test('bell svg is hidden from the accessibility tree', async () => {
+      mockCreateDeps();
+      const bell = new Bell({ enable: true, showLauncherAfter: 0 });
+      await bell._create();
+
+      const svg = bell._button._element!.querySelector('svg')!;
+      expect(svg.getAttribute('aria-hidden')).toBe('true');
+    });
+
     test('mouseleave on launcher blurs the button', async () => {
       mockCreateDeps();
       const bell = new Bell({ enable: true, showLauncherAfter: 0 });

--- a/src/page/bell/Bell.test.ts
+++ b/src/page/bell/Bell.test.ts
@@ -170,11 +170,11 @@ describe('Bell', () => {
         enable: true,
         showLauncherAfter: 0,
         // @ts-expect-error - partial text config
-        text: { 'launcher.label': 'Διαχείριση ειδοποιήσεων' },
+        text: { 'launcher.label': 'Notification preferences' },
       });
       await bell._create();
 
-      expect(bell._button._element!.getAttribute('aria-label')).toBe('Διαχείριση ειδοποιήσεων');
+      expect(bell._button._element!.getAttribute('aria-label')).toBe('Notification preferences');
     });
 
     test('bell svg is hidden from the accessibility tree', async () => {

--- a/src/page/bell/Bell.test.ts
+++ b/src/page/bell/Bell.test.ts
@@ -170,7 +170,7 @@ describe('Bell', () => {
         enable: true,
         showLauncherAfter: 0,
         // @ts-expect-error - partial text config
-        text: { 'launcher.label': 'Notification preferences' },
+        text: { 'launcher.button.aria-label': 'Notification preferences' },
       });
       await bell._create();
 

--- a/src/page/bell/Bell.ts
+++ b/src/page/bell/Bell.ts
@@ -34,7 +34,7 @@ const VALID_THEMES: readonly string[] = ['default', 'inverse'];
 const DEFAULT_LAUNCHER_LABEL = 'Manage notifications';
 
 const DEFAULT_TEXT: BellText = {
-  'launcher.label': DEFAULT_LAUNCHER_LABEL,
+  'launcher.button.aria-label': DEFAULT_LAUNCHER_LABEL,
   'tip.state.unsubscribed': 'Subscribe to notifications',
   'tip.state.subscribed': "You're subscribed to notifications",
   'tip.state.blocked': "You've blocked notifications",
@@ -218,7 +218,7 @@ export default class Bell {
     );
     this._button._element?.setAttribute(
       'aria-label',
-      this._options.text['launcher.label'] || DEFAULT_LAUNCHER_LABEL,
+      this._options.text['launcher.button.aria-label'] || DEFAULT_LAUNCHER_LABEL,
     );
     addDomElement(
       this._launcher._selector,

--- a/src/page/bell/Bell.ts
+++ b/src/page/bell/Bell.ts
@@ -21,7 +21,7 @@ import Dialog from './Dialog';
 import Launcher from './Launcher';
 import Message from './Message';
 
-const logoSvg = `<svg class="onesignal-bell-svg" xmlns="http://www.w3.org/2000/svg" width="99.7" height="99.7" viewBox="0 0 99.7 99.7"><circle class="background" cx="49.9" cy="49.9" r="49.9"/><path class="foreground" d="M50.1 66.2H27.7s-2-.2-2-2.1c0-1.9 1.7-2 1.7-2s6.7-3.2 6.7-5.5S33 52.7 33 43.3s6-16.6 13.2-16.6c0 0 1-2.4 3.9-2.4 2.8 0 3.8 2.4 3.8 2.4 7.2 0 13.2 7.2 13.2 16.6s-1 11-1 13.3c0 2.3 6.7 5.5 6.7 5.5s1.7.1 1.7 2c0 1.8-2.1 2.1-2.1 2.1H50.1zm-7.2 2.3h14.5s-1 6.3-7.2 6.3-7.3-6.3-7.3-6.3z"/><ellipse class="stroke" cx="49.9" cy="49.9" rx="37.4" ry="36.9"/></svg>`;
+const logoSvg = `<svg class="onesignal-bell-svg" xmlns="http://www.w3.org/2000/svg" width="99.7" height="99.7" viewBox="0 0 99.7 99.7" aria-hidden="true"><circle class="background" cx="49.9" cy="49.9" r="49.9"/><path class="foreground" d="M50.1 66.2H27.7s-2-.2-2-2.1c0-1.9 1.7-2 1.7-2s6.7-3.2 6.7-5.5S33 52.7 33 43.3s6-16.6 13.2-16.6c0 0 1-2.4 3.9-2.4 2.8 0 3.8 2.4 3.8 2.4 7.2 0 13.2 7.2 13.2 16.6s-1 11-1 13.3c0 2.3 6.7 5.5 6.7 5.5s1.7.1 1.7 2c0 1.8-2.1 2.1-2.1 2.1H50.1zm-7.2 2.3h14.5s-1 6.3-7.2 6.3-7.3-6.3-7.3-6.3z"/><ellipse class="stroke" cx="49.9" cy="49.9" rx="37.4" ry="36.9"/></svg>`;
 
 const DEFAULT_SIZE: BellSize = 'medium';
 const DEFAULT_POSITION: BellPosition = 'bottom-right';
@@ -31,7 +31,10 @@ const VALID_SIZES: readonly string[] = ['small', 'medium', 'large'];
 const VALID_POSITIONS: readonly string[] = ['bottom-left', 'bottom-right'];
 const VALID_THEMES: readonly string[] = ['default', 'inverse'];
 
+const DEFAULT_LAUNCHER_LABEL = 'Manage notifications';
+
 const DEFAULT_TEXT: BellText = {
+  'launcher.label': DEFAULT_LAUNCHER_LABEL,
   'tip.state.unsubscribed': 'Subscribe to notifications',
   'tip.state.subscribed': "You're subscribed to notifications",
   'tip.state.blocked': "You've blocked notifications",
@@ -212,6 +215,10 @@ export default class Bell {
       this._launcher._selector,
       'beforeend',
       '<button type="button" class="onesignal-bell-launcher-button" popovertarget="onesignal-bell-dialog"></button>',
+    );
+    this._button._element?.setAttribute(
+      'aria-label',
+      this._options.text['launcher.label'] || DEFAULT_LAUNCHER_LABEL,
     );
     addDomElement(
       this._launcher._selector,

--- a/src/page/bell/Message.ts
+++ b/src/page/bell/Message.ts
@@ -64,6 +64,6 @@ export default class Message {
 
   _getTipForState(): string {
     const key = TIP_KEYS[this._bell._state];
-    return key ? this._bell._options.text[key] : '';
+    return key ? (this._bell._options.text[key] ?? '') : '';
   }
 }

--- a/src/shared/prompts/types.ts
+++ b/src/shared/prompts/types.ts
@@ -116,7 +116,7 @@ export type BellSize = 'small' | 'medium' | 'large';
 export type BellPosition = 'bottom-left' | 'bottom-right';
 
 export interface BellText {
-  'launcher.label'?: string;
+  'launcher.button.aria-label'?: string;
   'tip.state.unsubscribed': string;
   'tip.state.subscribed': string;
   'tip.state.blocked': string;

--- a/src/shared/prompts/types.ts
+++ b/src/shared/prompts/types.ts
@@ -116,6 +116,7 @@ export type BellSize = 'small' | 'medium' | 'large';
 export type BellPosition = 'bottom-left' | 'bottom-right';
 
 export interface BellText {
+  'launcher.label'?: string;
   'tip.state.unsubscribed': string;
   'tip.state.subscribed': string;
   'tip.state.blocked': string;


### PR DESCRIPTION
# Description

## 1 Line Summary

Add a default, configurable `aria-label` to the Subscription Bell launcher button so it has an accessible name and no longer fails accessibility audits.

## Details

The bell launcher is an icon-only `<button>` with no text content and no `aria-label`, so automated accessibility audits (Lighthouse/PageSpeed, axe) report **"Buttons must have discernible text"** on every customer site that enables the bell. Screen-reader users and agentic browsers relying on the accessibility tree cannot identify the control. Reported by an EU public-sector customer subject to the EU Web Accessibility Directive (WCAG 2.1 AA).

Changes:

- The launcher button now gets `aria-label="Manage notifications"` by default when the bell is created.
- The label is configurable and localizable via the existing bell text config: `notifyButton: { text: { 'launcher.label': '...' } }` (new optional `BellText` key).
- The decorative bell SVG inside the button is marked `aria-hidden="true"` so it doesn't leak into the accessibility tree.
- `Message._getTipForState` gained a `?? ''` fallback because the new optional key widened the text lookup type.
- The gzipped `page.es6.js` size limit was bumped 42.65 kB → 42.7 kB; the limit only had ~10 B of headroom on `main` and this change adds ~50 B.

Other icon-only controls were audited per the ticket: the dialog's subscribe/unsubscribe buttons already have visible text and the dialog is a light-dismiss popover with no close button, so the launcher was the only control needing a name.

# Systems Affected

- [x] WebSDK
- [ ] Backend
- [ ] Dashboard

# Validation

## Tests

### Info

- New unit tests in `Bell.test.ts` cover the default label, a custom localized label via text config, and the SVG being hidden from the accessibility tree.
- `vp check`, full test suite (526 tests), and `build:prod` (size-limit + bundle API validation) all pass.

### Checklist

- [x] All the automated tests pass or I explained why that is not possible
- [x] I have personally tested this on my machine or explained why that is not possible
- [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:

- [x] Don't use default export
- [x] New interfaces are in model files

Functions:

- [x] Don't use default export
- [x] All function signatures have return types
- [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:

- [x] No Typescript warnings
- [x] Avoid silencing null/undefined warnings with the exclamation point

Other:

- [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
- [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots

### Info

Not needed — no visual change; the only DOM difference is the `aria-label` attribute and `aria-hidden` on the SVG.

### Checklist

- [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

[SDK-4897](https://linear.app/onesignal/issue/SDK-4897/web-sdk-v16-subscription-bell-launcher-button-has-no-accessible-name)

---