### PR TITLE
fix: [SDK-4897] add alt text to bell dialog images

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "42.7 kB",
+      "limit": "42.75 kB",
       "gzip": true
     },
     {

--- a/src/page/bell/Dialog.test.ts
+++ b/src/page/bell/Dialog.test.ts
@@ -113,6 +113,7 @@ describe('Dialog', () => {
     await dialog._updateContent();
     const img = dialog._element!.querySelector('.push-notification-icon img');
     expect(img?.getAttribute('src')).toBe('https://example.com/icon.png');
+    expect(img?.getAttribute('alt')).toBe('');
   });
 
   test('_updateContent uses default icon class when no custom icon', async () => {
@@ -144,6 +145,8 @@ describe('Dialog', () => {
     );
     expect(body.querySelector('.instructions')).not.toBeNull();
     expect(body.querySelector('img')?.src).toContain('chrome-unblock.jpg');
+    // the alt gives the wrapping icon-only link its accessible name
+    expect(body.querySelector('a img')?.getAttribute('alt')).toBeTruthy();
   });
 
   test('blocked content shows mobile instructions for Chrome mobile', async () => {

--- a/src/page/bell/Dialog.ts
+++ b/src/page/bell/Dialog.ts
@@ -122,7 +122,7 @@ export default class Dialog {
       const imagePath = UNBLOCK_IMAGES[browserName];
       if (imagePath) {
         const imageUrl = STATIC_RESOURCES_URL + imagePath;
-        instructionsHtml = `<a href="${imageUrl}" target="_blank"><img src="${imageUrl}" alt="How to unblock notifications"></a>`;
+        instructionsHtml = `<a href="${imageUrl}" target="_blank"><img src="${imageUrl}" alt="Unblock notifications"></a>`;
       }
     }
 

--- a/src/page/bell/Dialog.ts
+++ b/src/page/bell/Dialog.ts
@@ -89,7 +89,7 @@ export default class Dialog {
 
     const iconHtml =
       imageUrl !== 'default-icon'
-        ? `<div class="push-notification-icon"><img></div>`
+        ? `<div class="push-notification-icon"><img alt=""></div>`
         : `<div class="push-notification-icon push-notification-icon-default"></div>`;
 
     const isSubscribed = this._bell._state === BellState._Subscribed;
@@ -122,7 +122,7 @@ export default class Dialog {
       const imagePath = UNBLOCK_IMAGES[browserName];
       if (imagePath) {
         const imageUrl = STATIC_RESOURCES_URL + imagePath;
-        instructionsHtml = `<a href="${imageUrl}" target="_blank"><img src="${imageUrl}"></a>`;
+        instructionsHtml = `<a href="${imageUrl}" target="_blank"><img src="${imageUrl}" alt="How to unblock notifications"></a>`;
       }
     }
 


### PR DESCRIPTION
# Description

## 1 Line Summary

Add alt text to the two images in the bell dialog so they pass "images must have alternate text" and "links must have discernible text" accessibility audits.

## Details

Follow-up to #1478 (merged).

Follow-up to the launcher `aria-label` fix, covering the remaining audit failures inside the dialog (per the ticket: "apply the same treatment to any other icon-only controls in the bell/dialog"):

- The notification icon `<img>` in the subscription view now has `alt=""` — it is decorative next to the dialog text, so it is correctly hidden from the accessibility tree instead of being announced by filename.
- The unblock-instructions image in the blocked view now has `alt="Unblock notifications"`. This also gives its wrapping icon-only `<a>` its accessible name, fixing the "links must have discernible text" failure.
- The gzipped `page.es6.js` size limit was bumped 42.7 kB → 42.75 kB (was 8 B over; the limit is routinely bumped in small increments).

These only surface while the dialog popover is open, so resting-page scans (e.g. PageSpeed) do not catch them, but manual audits of the open dialog would.

# Systems Affected

- [x] WebSDK
- [ ] Backend
- [ ] Dashboard

# Validation

## Tests

### Info

- Extended existing `Dialog.test.ts` cases to assert the icon's empty alt and the instructions image's non-empty alt.
- `vp check`, full test suite (526 tests), and `build:prod` (size-limit + bundle API validation) all pass.

### Checklist

- [x] All the automated tests pass or I explained why that is not possible
- [x] I have personally tested this on my machine or explained why that is not possible
- [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:

- [x] Don't use default export
- [x] New interfaces are in model files

Functions:

- [x] Don't use default export
- [x] All function signatures have return types
- [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:

- [x] No Typescript warnings
- [x] Avoid silencing null/undefined warnings with the exclamation point

Other:

- [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
- [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots

### Info

Not needed — no visual change; only `alt` attributes were added.

### Checklist

- [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

[SDK-4897](https://linear.app/onesignal/issue/SDK-4897/web-sdk-v16-subscription-bell-launcher-button-has-no-accessible-name)

---

