### PR TITLE
fix: [SDK-4968] send the first on_session increment for newly created users

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,12 +77,12 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "42.75 kB",
+      "limit": "42.7 kB",
       "gzip": true
     },
     {
       "path": "./build/releases/OneSignalSDK.sw.js",
-      "limit": "12.51 kB",
+      "limit": "12.5 kB",
       "gzip": true
     },
     {

--- a/src/shared/helpers/service-worker.ts
+++ b/src/shared/helpers/service-worker.ts
@@ -10,9 +10,9 @@ import Log from '../libraries/Log';
 import type { OutcomesNotificationClicked } from '../models/OutcomesNotificationEvents';
 import Path from '../models/Path';
 import type { OutcomesConfig } from '../outcomes/types';
-import { SessionOrigin, SessionStatus } from '../session/constants';
+import { SessionStatus } from '../session/constants';
 import { initializeNewSession } from '../session/helpers';
-import type { Session, SessionOriginValue } from '../session/types';
+import type { Session } from '../session/types';
 import { getBaseUrl } from './general';
 import { getConfigAttribution } from './OutcomesHelper';
 
@@ -43,7 +43,6 @@ export async function upsertSession(
   subscriptionId: string,
   sessionThresholdInSeconds: number,
   sendOnFocusEnabled: boolean,
-  sessionOrigin: SessionOriginValue,
   outcomesConfig: OutcomesConfig,
 ): Promise<void> {
   const existingSession = await getCurrentSession();
@@ -59,13 +58,7 @@ export async function upsertSession(
     }
 
     await db.put('Sessions', session);
-    await sendOnSessionCallIfNotPlayerCreate(
-      appId,
-      onesignalId,
-      subscriptionId,
-      sessionOrigin,
-      session,
-    );
+    await sendOnSessionCall(appId, onesignalId, subscriptionId, session);
     return;
   }
 
@@ -107,13 +100,7 @@ export async function upsertSession(
   );
   const session: Session = initializeNewSession({ appId });
   await db.put('Sessions', session);
-  await sendOnSessionCallIfNotPlayerCreate(
-    appId,
-    onesignalId,
-    subscriptionId,
-    sessionOrigin,
-    session,
-  );
+  await sendOnSessionCall(appId, onesignalId, subscriptionId, session);
 }
 
 export async function deactivateSession(
@@ -176,21 +163,12 @@ export async function deactivateSession(
   return cancelableFinalize;
 }
 
-/**
- * Updates session only if it isn't from the result of a user create,
- * as it already initializes it with the first session.
- */
-async function sendOnSessionCallIfNotPlayerCreate(
+async function sendOnSessionCall(
   appId: string,
   onesignalId: string,
   subscriptionId: string,
-  sessionOrigin: SessionOriginValue,
   session: Session,
 ) {
-  if (sessionOrigin === SessionOrigin._UserCreate) {
-    return;
-  }
-
   void db.put('Sessions', session);
   void resetSentUniqueOutcomes();
 

--- a/src/shared/managers/sessionManager/SessionManager.ts
+++ b/src/shared/managers/sessionManager/SessionManager.ts
@@ -246,7 +246,6 @@ export class SessionManager implements ISessionManager {
     if (supportsServiceWorkers()) {
       this._setupSessionEventListeners();
     } else {
-      this._onSessionSent = sessionOrigin === SessionOrigin._UserCreate;
       void OneSignal._emitter._emit(OneSignal.EVENTS.SESSION_STARTED);
     }
   }

--- a/src/sw/serviceWorker/ServiceWorker.test.ts
+++ b/src/sw/serviceWorker/ServiceWorker.test.ts
@@ -1,6 +1,7 @@
 import { APP_ID, ONESIGNAL_ID, SUB_ID } from '__test__/constants';
 import TestContext from '__test__/support/environment/TestContext';
 import { TestEnvironment } from '__test__/support/environment/TestEnvironment';
+import { setUpdateUserResponse, updateUserFn } from '__test__/support/helpers/requests';
 import { MockServiceWorker } from '__test__/support/mocks/MockServiceWorker';
 import { mockOSMinifiedNotificationPayload } from '__test__/support/mocks/notifcations';
 import { server } from '__test__/support/mocks/server';
@@ -614,6 +615,7 @@ describe('ServiceWorker', () => {
 
       test('with non-safari client', async () => {
         await putNotificationClickedForOutcomes(appId, clickOutcome);
+        setUpdateUserResponse();
 
         const event = new ExtendableMessageEvent('message', {
           command: WorkerMessengerCommand._SessionUpsert,
@@ -638,7 +640,37 @@ describe('ServiceWorker', () => {
             status: SessionStatus._Active,
           }),
         );
+
+        expect(updateUserFn).toHaveBeenCalledWith({
+          refresh_device_metadata: true,
+          deltas: { session_count: 1 },
+        });
       });
+
+      // Creating a user does not seed session_count, so a newly created user needs this
+      // increment just as much as a returning one.
+      test.each([SessionOrigin._UserCreate, SessionOrigin._UserNewSession])(
+        'sends the on_session increment for session origin %i',
+        async (sessionOrigin) => {
+          setUpdateUserResponse();
+
+          const event = new ExtendableMessageEvent('message', {
+            command: WorkerMessengerCommand._SessionUpsert,
+            payload: {
+              ...baseMessagePayload,
+              isSafari: false,
+              sessionOrigin,
+            } satisfies UpsertOrDeactivateSessionPayload,
+          });
+          await dispatchEvent(event);
+
+          expect(updateUserFn).toHaveBeenCalledTimes(1);
+          expect(updateUserFn).toHaveBeenCalledWith({
+            refresh_device_metadata: true,
+            deltas: { session_count: 1 },
+          });
+        },
+      );
     });
 
     describe('session deactivate event', () => {

--- a/src/sw/serviceWorker/ServiceWorker.ts
+++ b/src/sw/serviceWorker/ServiceWorker.ts
@@ -402,7 +402,6 @@ async function updateSessionBasedOnHasActive(
       options.subscriptionId,
       options.sessionThreshold,
       options.enableSessionDuration,
-      options.sessionOrigin,
       options.outcomesConfig,
     );
   } else {


### PR DESCRIPTION
# Description

## 1 Line Summary

Send the `session_count` delta on the first session for newly created users, so new web subscribers land on 1 session instead of 0.

## Details

The SDK deliberately skipped the first `on_session` increment when a session originated from a user create. That was correct while the backend seeded `session_count = 1` on create — the skip existed to avoid double counting.

That assumption stopped holding when [perseus#2023](https://github.com/OneSignal/perseus/pull/2023) shipped for UD-4311 and made `CreateSubscription` default `session_count` to `0`. With the skip still in place, new web subscribers got `0` and stayed there until their next visit.

The skip lived in two places, both keyed off `SessionOrigin._UserCreate`:

- `src/shared/helpers/service-worker.ts` — `sendOnSessionCallIfNotPlayerCreate()` returned early for the create origin. This is the main path (Chrome/Firefox/Safari with a service worker).
- `src/shared/managers/sessionManager/SessionManager.ts` — pre-set `_onSessionSent = true` on create, which made the page-side fallback (used when service workers are unavailable) bail out.

Both are removed, so the follow-up `PATCH /users/by/onesignal_id/{id}` now sends `{"deltas": {"session_count": 1}}` for new and returning users alike. `0 + 1 = 1`, matching what the Android and iOS SDKs already do.

The now-unused `sessionOrigin` parameter was dropped from `upsertSession()`. The page-to-service-worker message payload (`UpsertOrDeactivateSessionPayload`) is **unchanged**, so there is no wire-format break between an old service worker and a new page script.

# Systems Affected

- [x] WebSDK
- [ ] Backend
- [ ] Dashboard

# Validation

## Tests

### Info

- Full suite: 528 tests across 60 files pass.
- `vp check`: 0 errors (5 pre-existing warnings in files untouched by this PR).
- `vp run build:prod`: passes, including size-limit checks. The SW bundle got marginally smaller since this removes code.
- Confirmed the added tests are genuine regression tests by stashing the source fix and re-running: both fail without it. The parameterized case passes for `_UserNewSession` even without the fix, which confirms the returning-user path was already correct and user-create was the only broken origin.

### Checklist

- [x] All the automated tests pass or I explained why that is not possible
- [x] I have personally tested this on my machine or explained why that is not possible
- [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:

- [x] Don't use default export
- [x] New interfaces are in model files

Functions:

- [x] Don't use default export
- [x] All function signatures have return types
- [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:

- [x] No Typescript warnings
- [x] Avoid silencing null/undefined warnings with the exclamation point

Other:

- [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
- [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots

### Info

No UI surface is affected — this changes the body of a network request only.

### Checklist

- [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

- SDK-4968
- UD-4311 (backend fix: perseus#2023, turbine#1762)

---