### PR TITLE
fix: [SDK-5014] omit local subscription IDs from the create user request

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,11 +216,18 @@
       // simulates a subscription whose create operation was dropped.
       const NO_PROPOGATE = 1;
 
-      const getPushModel = () => OneSignal._coreDirector._getPushSubscriptionModel();
+      // _coreDirector is undefined until init finishes, so callers must handle that.
+      const getCoreDirector = () => OneSignal?._coreDirector;
+      const getPushModel = () => getCoreDirector()?._getPushSubscriptionModel();
 
       async function refreshState() {
         try {
-          const model = await getPushModel();
+          const core = getCoreDirector();
+          if (!core) {
+            $('sub-id').textContent = '(SDK not ready)';
+            return;
+          }
+          const model = await core._getPushSubscriptionModel();
           const subId = model?.id;
           $('sub-id').textContent = subId || '(no push subscription model)';
           if (subId) {
@@ -230,7 +237,7 @@
           } else {
             $('sub-id-type').innerHTML = '<span class="tag tag-unknown">unknown</span>';
           }
-          const identity = OneSignal._coreDirector._getIdentityModel();
+          const identity = core._getIdentityModel();
           $('external-id').textContent = identity._externalId || '(anonymous)';
           $('onesignal-id').textContent = identity._onesignalId || '—';
         } catch (e) {

--- a/index.html
+++ b/index.html
@@ -4,22 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OneSignal Dev — SDK-4180 Safari VAPID Test</title>
+    <title>OneSignal Dev — SDK-5014 Local Subscription ID Repro</title>
     <style>
-      .in-app-notification {
-        position: fixed;
-        top: 20px;
-        right: 20px;
-        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-        color: white;
-        padding: 16px 24px;
-        border-radius: 12px;
-        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
-        max-width: 350px;
-        z-index: 10000;
-        animation: slideIn 0.3s ease-out;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      }
       * {
         box-sizing: border-box;
       }
@@ -78,7 +64,7 @@
         font-size: 12px;
         padding: 16px;
         border-radius: 8px;
-        max-height: 300px;
+        max-height: 340px;
         overflow-y: auto;
         white-space: pre-wrap;
         word-break: break-all;
@@ -111,11 +97,11 @@
         font-size: 12px;
         font-weight: 600;
       }
-      .tag-legacy {
+      .tag-local {
         background: #ffc9c9;
         color: #c92a2a;
       }
-      .tag-vapid {
+      .tag-real {
         background: #b2f2bb;
         color: #2b8a3e;
       }
@@ -125,18 +111,36 @@
       }
     </style>
     <script>
-      // set can a query param ?app_id=your_app_id OR
+      // set a query param ?app_id=your_app_id OR
       // create an .env file and set VITE_APP_ID to your app id
       const appId = new URLSearchParams(window.location.search).get('app_id') || '%VITE_APP_ID%';
+
+      // Log every Create User request and response before the SDK loads,
+      // so the payload with the subscription IDs is visible on the page.
+      const originalFetch = window.fetch.bind(window);
+      window.fetch = async (input, init) => {
+        const url = typeof input === 'string' ? input : input.url;
+        const isCreateUser = /\/apps\/[^/]+\/users$/.test(url) && init?.method === 'POST';
+        if (isCreateUser) {
+          window.__logToPage?.('POST ' + url, 'info');
+          window.__logToPage?.('request body: ' + init.body, 'info');
+        }
+        const response = await originalFetch(input, init);
+        if (isCreateUser) {
+          const clone = response.clone();
+          const text = await clone.text();
+          const cls = response.ok ? 'success' : 'error';
+          window.__logToPage?.('response ' + response.status + ': ' + text, cls);
+        }
+        return response;
+      };
 
       window.OneSignalDeferred = window.OneSignalDeferred || [];
       OneSignalDeferred.push(async function (OneSignal) {
         OneSignal.Debug.setLogLevel('trace');
-        OneSignal._isNewVisitor = true;
 
         OneSignal.init({
           appId,
-          safari_web_id: 'web.onesignal.auto.6187ce57-f346-4a86-93e4-7d70d494c000',
           notifyButton: {
             enable: true,
             prenotify: true,
@@ -147,44 +151,46 @@
     </script>
   </head>
   <body>
+    <h1>SDK-5014 — local subscription ID in Create User</h1>
+    <p class="subtitle">
+      Repro for the bug where a <code>local-*</code> placeholder subscription ID reaches the backend
+      and gets a 400 response.
+    </p>
+
     <div class="card">
-      <h3>Browser & Safari Push Info</h3>
+      <h3>SDK State</h3>
       <table>
         <tr>
-          <td>User Agent</td>
-          <td id="ua">—</td>
+          <td>Push subscription ID</td>
+          <td id="sub-id">—</td>
         </tr>
         <tr>
-          <td>window.safari exists</td>
-          <td id="safari-exists">—</td>
+          <td>ID type</td>
+          <td id="sub-id-type"><span class="tag tag-unknown">unknown</span></td>
         </tr>
         <tr>
-          <td>Legacy permission state</td>
-          <td id="legacy-perm">—</td>
+          <td>External ID</td>
+          <td id="external-id">—</td>
         </tr>
         <tr>
-          <td>Legacy deviceToken</td>
-          <td id="legacy-token">—</td>
+          <td>OneSignal ID</td>
+          <td id="onesignal-id">—</td>
         </tr>
         <tr>
           <td>Notification.permission</td>
           <td id="notif-perm">—</td>
         </tr>
-        <tr>
-          <td>PushSubscriptionOptions</td>
-          <td id="vapid-support">—</td>
-        </tr>
-        <tr>
-          <td>Expected push path</td>
-          <td id="push-path">—</td>
-        </tr>
       </table>
     </div>
 
     <div class="card">
-      <h3>Actions</h3>
-      <button class="btn-primary" id="request-perm">Request Permission</button>
-      <button class="btn-secondary" id="refresh-info">Refresh Info</button>
+      <h3>Repro Steps (run in order)</h3>
+      <button class="btn-primary" id="step-subscribe">1. Subscribe</button>
+      <button class="btn-primary" id="step-seed">2. Seed stuck local ID</button>
+      <button class="btn-primary" id="step-login">3. Login</button>
+      <br />
+      <button class="btn-secondary" id="refresh-state">Refresh state</button>
+      <button class="btn-secondary" id="reset-sdk">Reset SDK state</button>
     </div>
 
     <div class="card">
@@ -203,71 +209,100 @@
         el.appendChild(span);
         el.scrollTop = el.scrollHeight;
       };
+      window.__logToPage = log;
 
-      function refreshInfo() {
-        $('ua').textContent = navigator.userAgent;
+      // ModelChangeTags._NoPropogate: the change enqueues no operation, which
+      // simulates a subscription whose create operation was dropped.
+      const NO_PROPOGATE = 1;
 
-        const hasSafari =
-          typeof window.safari !== 'undefined' &&
-          typeof window.safari.pushNotification !== 'undefined';
-        $('safari-exists').textContent = hasSafari ? 'Yes' : 'No';
+      const getPushModel = () => OneSignal._coreDirector._getPushSubscriptionModel();
 
-        if (hasSafari) {
-          try {
-            const safariWebId =
-              OneSignal?.config?.safariWebId ||
-              'web.onesignal.auto.6187ce57-f346-4a86-93e4-7d70d494c000';
-            const perm = window.safari.pushNotification.permission(safariWebId);
-            $('legacy-perm').textContent = perm.permission;
-            $('legacy-token').textContent = perm.deviceToken || '(null)';
-
-            if (perm.permission === 'granted' && perm.deviceToken) {
-              $('push-path').innerHTML =
-                '<span class="tag tag-legacy">Legacy Safari Push</span> (existing subscriber)';
-            } else {
-              $('push-path').innerHTML =
-                '<span class="tag tag-vapid">Standard VAPID Push</span> (new user)';
-            }
-          } catch (e) {
-            $('legacy-perm').textContent = 'Error: ' + e.message;
-            $('legacy-token').textContent = '—';
+      async function refreshState() {
+        try {
+          const model = await getPushModel();
+          const subId = model?.id;
+          $('sub-id').textContent = subId || '(no push subscription model)';
+          if (subId) {
+            $('sub-id-type').innerHTML = subId.startsWith('local-')
+              ? '<span class="tag tag-local">local placeholder</span>'
+              : '<span class="tag tag-real">server-assigned</span>';
+          } else {
+            $('sub-id-type').innerHTML = '<span class="tag tag-unknown">unknown</span>';
           }
-        } else {
-          $('legacy-perm').textContent = 'N/A (not Safari)';
-          $('legacy-token').textContent = 'N/A';
-          const isVapid = typeof PushSubscriptionOptions !== 'undefined';
-          $('push-path').innerHTML = isVapid
-            ? '<span class="tag tag-vapid">Standard VAPID Push</span>'
-            : '<span class="tag tag-unknown">Push not supported</span>';
+          const identity = OneSignal._coreDirector._getIdentityModel();
+          $('external-id').textContent = identity._externalId || '(anonymous)';
+          $('onesignal-id').textContent = identity._onesignalId || '—';
+        } catch (e) {
+          log('State read failed: ' + e.message, 'error');
         }
-
-        const vapidSupport = typeof PushSubscriptionOptions !== 'undefined';
-        $('vapid-support').textContent = vapidSupport ? 'Supported' : 'Not available';
         $('notif-perm').textContent =
           typeof Notification !== 'undefined' ? Notification.permission : 'N/A';
       }
 
-      $('request-perm').addEventListener('click', async () => {
-        log('Requesting push permission...', 'info');
+      $('step-subscribe').addEventListener('click', async () => {
+        log('Step 1: request push permission...', 'info');
         try {
           await OneSignal.Notifications.requestPermission();
-          log('Permission granted!', 'success');
+          log('Permission result: ' + Notification.permission, 'success');
+          log('Wait for the subscription ID to become server-assigned, then run step 2.', 'info');
         } catch (e) {
           log('Error: ' + e.message, 'error');
         }
-        refreshInfo();
+        refreshState();
       });
 
-      $('refresh-info').addEventListener('click', refreshInfo);
+      $('step-seed').addEventListener('click', async () => {
+        log('Step 2: seed a stuck local subscription ID...', 'info');
+        try {
+          const model = await getPushModel();
+          if (!model) {
+            log('No push subscription model. Run step 1 first.', 'error');
+            return;
+          }
+          const localId = 'local-' + crypto.randomUUID();
+          model._setProperty('id', localId, NO_PROPOGATE);
+          log('Subscription ID is now: ' + localId, 'success');
+          log('No pending operation can translate this ID. Run step 3.', 'info');
+        } catch (e) {
+          log('Error: ' + e.message, 'error');
+        }
+        refreshState();
+      });
+
+      $('step-login').addEventListener('click', async () => {
+        const externalId = 'sdk5014-repro-' + Math.random().toString(36).slice(2, 8);
+        log('Step 3: OneSignal.login("' + externalId + '")...', 'info');
+        log('Watch the Create User request below for the subscriptions array.', 'info');
+        try {
+          await OneSignal.login(externalId);
+          log('login() resolved', 'success');
+        } catch (e) {
+          log('login() rejected: ' + e.message, 'error');
+        }
+        refreshState();
+      });
+
+      $('refresh-state').addEventListener('click', refreshState);
+
+      $('reset-sdk').addEventListener('click', async () => {
+        log('Reset: unregister service workers and delete the SDK database...', 'info');
+        const registrations = await navigator.serviceWorker.getRegistrations();
+        await Promise.all(registrations.map((r) => r.unregister()));
+        await new Promise((resolve) => {
+          const req = indexedDB.deleteDatabase('ONE_SIGNAL_SDK_DB');
+          req.onsuccess = req.onerror = req.onblocked = resolve;
+        });
+        log('Done. The page will reload.', 'success');
+        setTimeout(() => location.reload(), 500);
+      });
 
       window.OneSignalDeferred = window.OneSignalDeferred || [];
       OneSignalDeferred.push(() => {
         log('OneSignal initialized', 'success');
-        refreshInfo();
+        refreshState();
       });
 
-      // Initial info on page load
-      setTimeout(refreshInfo, 500);
+      setTimeout(refreshState, 500);
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,8 +4,22 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OneSignal Dev — SDK-5014 Local Subscription ID Repro</title>
+    <title>OneSignal Dev — SDK-4180 Safari VAPID Test</title>
     <style>
+      .in-app-notification {
+        position: fixed;
+        top: 20px;
+        right: 20px;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        color: white;
+        padding: 16px 24px;
+        border-radius: 12px;
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+        max-width: 350px;
+        z-index: 10000;
+        animation: slideIn 0.3s ease-out;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      }
       * {
         box-sizing: border-box;
       }
@@ -64,7 +78,7 @@
         font-size: 12px;
         padding: 16px;
         border-radius: 8px;
-        max-height: 340px;
+        max-height: 300px;
         overflow-y: auto;
         white-space: pre-wrap;
         word-break: break-all;
@@ -97,11 +111,11 @@
         font-size: 12px;
         font-weight: 600;
       }
-      .tag-local {
+      .tag-legacy {
         background: #ffc9c9;
         color: #c92a2a;
       }
-      .tag-real {
+      .tag-vapid {
         background: #b2f2bb;
         color: #2b8a3e;
       }
@@ -111,36 +125,18 @@
       }
     </style>
     <script>
-      // set a query param ?app_id=your_app_id OR
+      // set can a query param ?app_id=your_app_id OR
       // create an .env file and set VITE_APP_ID to your app id
       const appId = new URLSearchParams(window.location.search).get('app_id') || '%VITE_APP_ID%';
-
-      // Log every Create User request and response before the SDK loads,
-      // so the payload with the subscription IDs is visible on the page.
-      const originalFetch = window.fetch.bind(window);
-      window.fetch = async (input, init) => {
-        const url = typeof input === 'string' ? input : input.url;
-        const isCreateUser = /\/apps\/[^/]+\/users$/.test(url) && init?.method === 'POST';
-        if (isCreateUser) {
-          window.__logToPage?.('POST ' + url, 'info');
-          window.__logToPage?.('request body: ' + init.body, 'info');
-        }
-        const response = await originalFetch(input, init);
-        if (isCreateUser) {
-          const clone = response.clone();
-          const text = await clone.text();
-          const cls = response.ok ? 'success' : 'error';
-          window.__logToPage?.('response ' + response.status + ': ' + text, cls);
-        }
-        return response;
-      };
 
       window.OneSignalDeferred = window.OneSignalDeferred || [];
       OneSignalDeferred.push(async function (OneSignal) {
         OneSignal.Debug.setLogLevel('trace');
+        OneSignal._isNewVisitor = true;
 
         OneSignal.init({
           appId,
+          safari_web_id: 'web.onesignal.auto.6187ce57-f346-4a86-93e4-7d70d494c000',
           notifyButton: {
             enable: true,
             prenotify: true,
@@ -151,47 +147,44 @@
     </script>
   </head>
   <body>
-    <h1>SDK-5014 — local subscription ID in Create User</h1>
-    <p class="subtitle">
-      Repro for the bug where a <code>local-*</code> placeholder subscription ID reaches the backend
-      and gets a 400 response.
-    </p>
-
     <div class="card">
-      <h3>SDK State</h3>
+      <h3>Browser & Safari Push Info</h3>
       <table>
         <tr>
-          <td>Push subscription ID</td>
-          <td id="sub-id">—</td>
+          <td>User Agent</td>
+          <td id="ua">—</td>
         </tr>
         <tr>
-          <td>ID type</td>
-          <td id="sub-id-type"><span class="tag tag-unknown">unknown</span></td>
+          <td>window.safari exists</td>
+          <td id="safari-exists">—</td>
         </tr>
         <tr>
-          <td>External ID</td>
-          <td id="external-id">—</td>
+          <td>Legacy permission state</td>
+          <td id="legacy-perm">—</td>
         </tr>
         <tr>
-          <td>OneSignal ID</td>
-          <td id="onesignal-id">—</td>
+          <td>Legacy deviceToken</td>
+          <td id="legacy-token">—</td>
         </tr>
         <tr>
           <td>Notification.permission</td>
           <td id="notif-perm">—</td>
         </tr>
+        <tr>
+          <td>PushSubscriptionOptions</td>
+          <td id="vapid-support">—</td>
+        </tr>
+        <tr>
+          <td>Expected push path</td>
+          <td id="push-path">—</td>
+        </tr>
       </table>
     </div>
 
     <div class="card">
-      <h3>Repro Steps (run in order)</h3>
-      <button class="btn-primary" id="step-subscribe">1. Subscribe</button>
-      <button class="btn-primary" id="step-login">2. Login</button>
-      <button class="btn-primary" id="step-seed">3. Seed stuck local ID</button>
-      <button class="btn-primary" id="step-logout">4. Logout</button>
-      <br />
-      <button class="btn-secondary" id="refresh-state">Refresh state</button>
-      <button class="btn-secondary" id="reset-sdk">Reset SDK state</button>
+      <h3>Actions</h3>
+      <button class="btn-primary" id="request-perm">Request Permission</button>
+      <button class="btn-secondary" id="refresh-info">Refresh Info</button>
     </div>
 
     <div class="card">
@@ -210,130 +203,71 @@
         el.appendChild(span);
         el.scrollTop = el.scrollHeight;
       };
-      window.__logToPage = log;
 
-      // ModelChangeTags._NoPropogate: the change enqueues no operation, which
-      // simulates a subscription whose create operation was dropped.
-      const NO_PROPOGATE = 1;
+      function refreshInfo() {
+        $('ua').textContent = navigator.userAgent;
 
-      // _coreDirector is undefined until init finishes, so callers must handle that.
-      const getCoreDirector = () => OneSignal?._coreDirector;
-      const getPushModel = () => getCoreDirector()?._getPushSubscriptionModel();
+        const hasSafari =
+          typeof window.safari !== 'undefined' &&
+          typeof window.safari.pushNotification !== 'undefined';
+        $('safari-exists').textContent = hasSafari ? 'Yes' : 'No';
 
-      async function refreshState() {
-        try {
-          const core = getCoreDirector();
-          if (!core) {
-            $('sub-id').textContent = '(SDK not ready)';
-            return;
+        if (hasSafari) {
+          try {
+            const safariWebId =
+              OneSignal?.config?.safariWebId ||
+              'web.onesignal.auto.6187ce57-f346-4a86-93e4-7d70d494c000';
+            const perm = window.safari.pushNotification.permission(safariWebId);
+            $('legacy-perm').textContent = perm.permission;
+            $('legacy-token').textContent = perm.deviceToken || '(null)';
+
+            if (perm.permission === 'granted' && perm.deviceToken) {
+              $('push-path').innerHTML =
+                '<span class="tag tag-legacy">Legacy Safari Push</span> (existing subscriber)';
+            } else {
+              $('push-path').innerHTML =
+                '<span class="tag tag-vapid">Standard VAPID Push</span> (new user)';
+            }
+          } catch (e) {
+            $('legacy-perm').textContent = 'Error: ' + e.message;
+            $('legacy-token').textContent = '—';
           }
-          const model = await core._getPushSubscriptionModel();
-          const subId = model?.id;
-          $('sub-id').textContent = subId || '(no push subscription model)';
-          if (subId) {
-            $('sub-id-type').innerHTML = subId.startsWith('local-')
-              ? '<span class="tag tag-local">local placeholder</span>'
-              : '<span class="tag tag-real">server-assigned</span>';
-          } else {
-            $('sub-id-type').innerHTML = '<span class="tag tag-unknown">unknown</span>';
-          }
-          const identity = core._getIdentityModel();
-          $('external-id').textContent = identity._externalId || '(anonymous)';
-          $('onesignal-id').textContent = identity._onesignalId || '—';
-        } catch (e) {
-          log('State read failed: ' + e.message, 'error');
+        } else {
+          $('legacy-perm').textContent = 'N/A (not Safari)';
+          $('legacy-token').textContent = 'N/A';
+          const isVapid = typeof PushSubscriptionOptions !== 'undefined';
+          $('push-path').innerHTML = isVapid
+            ? '<span class="tag tag-vapid">Standard VAPID Push</span>'
+            : '<span class="tag tag-unknown">Push not supported</span>';
         }
+
+        const vapidSupport = typeof PushSubscriptionOptions !== 'undefined';
+        $('vapid-support').textContent = vapidSupport ? 'Supported' : 'Not available';
         $('notif-perm').textContent =
           typeof Notification !== 'undefined' ? Notification.permission : 'N/A';
       }
 
-      $('step-subscribe').addEventListener('click', async () => {
-        log('Step 1: request push permission...', 'info');
+      $('request-perm').addEventListener('click', async () => {
+        log('Requesting push permission...', 'info');
         try {
           await OneSignal.Notifications.requestPermission();
-          log('Permission result: ' + Notification.permission, 'success');
-          log('Wait for the subscription ID to become server-assigned, then run step 2.', 'info');
+          log('Permission granted!', 'success');
         } catch (e) {
           log('Error: ' + e.message, 'error');
         }
-        refreshState();
+        refreshInfo();
       });
 
-      $('step-login').addEventListener('click', async () => {
-        const externalId = 'sdk5014-repro-' + Math.random().toString(36).slice(2, 8);
-        log('Step 2: OneSignal.login("' + externalId + '")...', 'info');
-        try {
-          await OneSignal.login(externalId);
-          log('login() resolved', 'success');
-        } catch (e) {
-          log('login() rejected: ' + e.message, 'error');
-        }
-        refreshState();
-      });
-
-      $('step-seed').addEventListener('click', async () => {
-        log('Step 3: seed a stuck local subscription ID...', 'info');
-        try {
-          const model = await getPushModel();
-          if (!model) {
-            log('No push subscription model. Run step 1 first.', 'error');
-            return;
-          }
-          const localId = 'local-' + crypto.randomUUID();
-          model._setProperty('id', localId, NO_PROPOGATE);
-          log('Subscription ID is now: ' + localId, 'success');
-          log('No pending operation can translate this ID. Run step 4.', 'info');
-        } catch (e) {
-          log('Error: ' + e.message, 'error');
-        }
-        refreshState();
-      });
-
-      $('step-logout').addEventListener('click', async () => {
-        log('Step 4: OneSignal.logout()...', 'info');
-        log('Watch the Create User request below for the subscriptions array.', 'info');
-        try {
-          await OneSignal.logout();
-          log('logout() resolved', 'success');
-        } catch (e) {
-          log('logout() rejected: ' + (e?.message ?? e), 'error');
-        }
-        refreshState();
-      });
-
-      $('refresh-state').addEventListener('click', refreshState);
-
-      $('reset-sdk').addEventListener('click', async () => {
-        log('Reset: unregister service workers and delete the SDK database...', 'info');
-        const registrations = await navigator.serviceWorker.getRegistrations();
-        await Promise.all(registrations.map((r) => r.unregister()));
-        await new Promise((resolve) => {
-          const req = indexedDB.deleteDatabase('ONE_SIGNAL_SDK_DB');
-          req.onsuccess = req.onerror = req.onblocked = resolve;
-        });
-        log('Done. The page will reload.', 'success');
-        setTimeout(() => location.reload(), 500);
-      });
+      $('refresh-info').addEventListener('click', refreshInfo);
 
       window.OneSignalDeferred = window.OneSignalDeferred || [];
-      OneSignalDeferred.push((OneSignal) => {
+      OneSignalDeferred.push(() => {
         log('OneSignal initialized', 'success');
-        refreshState();
-
-        // Refresh the state card when a subscription or a user change happens outside
-        // the repro buttons (for example, the slidedown or the bell).
-        OneSignal.User.PushSubscription.addEventListener('change', (event) => {
-          log('PushSubscription change: id=' + (event.current.id ?? '(none)'), 'info');
-          refreshState();
-        });
-        OneSignal.Notifications.addEventListener('permissionChange', (granted) => {
-          log('permissionChange: ' + granted, 'info');
-          refreshState();
-        });
-        OneSignal.User.addEventListener('change', () => refreshState());
+        refreshInfo();
       });
 
-      setTimeout(refreshState, 500);
+      // Initial info on page load
+      setTimeout(refreshInfo, 500);
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -186,8 +186,9 @@
     <div class="card">
       <h3>Repro Steps (run in order)</h3>
       <button class="btn-primary" id="step-subscribe">1. Subscribe</button>
-      <button class="btn-primary" id="step-seed">2. Seed stuck local ID</button>
-      <button class="btn-primary" id="step-login">3. Login</button>
+      <button class="btn-primary" id="step-login">2. Login</button>
+      <button class="btn-primary" id="step-seed">3. Seed stuck local ID</button>
+      <button class="btn-primary" id="step-logout">4. Logout</button>
       <br />
       <button class="btn-secondary" id="refresh-state">Refresh state</button>
       <button class="btn-secondary" id="reset-sdk">Reset SDK state</button>
@@ -251,8 +252,20 @@
         refreshState();
       });
 
+      $('step-login').addEventListener('click', async () => {
+        const externalId = 'sdk5014-repro-' + Math.random().toString(36).slice(2, 8);
+        log('Step 2: OneSignal.login("' + externalId + '")...', 'info');
+        try {
+          await OneSignal.login(externalId);
+          log('login() resolved', 'success');
+        } catch (e) {
+          log('login() rejected: ' + e.message, 'error');
+        }
+        refreshState();
+      });
+
       $('step-seed').addEventListener('click', async () => {
-        log('Step 2: seed a stuck local subscription ID...', 'info');
+        log('Step 3: seed a stuck local subscription ID...', 'info');
         try {
           const model = await getPushModel();
           if (!model) {
@@ -262,22 +275,21 @@
           const localId = 'local-' + crypto.randomUUID();
           model._setProperty('id', localId, NO_PROPOGATE);
           log('Subscription ID is now: ' + localId, 'success');
-          log('No pending operation can translate this ID. Run step 3.', 'info');
+          log('No pending operation can translate this ID. Run step 4.', 'info');
         } catch (e) {
           log('Error: ' + e.message, 'error');
         }
         refreshState();
       });
 
-      $('step-login').addEventListener('click', async () => {
-        const externalId = 'sdk5014-repro-' + Math.random().toString(36).slice(2, 8);
-        log('Step 3: OneSignal.login("' + externalId + '")...', 'info');
+      $('step-logout').addEventListener('click', async () => {
+        log('Step 4: OneSignal.logout()...', 'info');
         log('Watch the Create User request below for the subscriptions array.', 'info');
         try {
-          await OneSignal.login(externalId);
-          log('login() resolved', 'success');
+          await OneSignal.logout();
+          log('logout() resolved', 'success');
         } catch (e) {
-          log('login() rejected: ' + e.message, 'error');
+          log('logout() rejected: ' + (e?.message ?? e), 'error');
         }
         refreshState();
       });

--- a/index.html
+++ b/index.html
@@ -316,9 +316,21 @@
       });
 
       window.OneSignalDeferred = window.OneSignalDeferred || [];
-      OneSignalDeferred.push(() => {
+      OneSignalDeferred.push((OneSignal) => {
         log('OneSignal initialized', 'success');
         refreshState();
+
+        // Refresh the state card when a subscription or a user change happens outside
+        // the repro buttons (for example, the slidedown or the bell).
+        OneSignal.User.PushSubscription.addEventListener('change', (event) => {
+          log('PushSubscription change: id=' + (event.current.id ?? '(none)'), 'info');
+          refreshState();
+        });
+        OneSignal.Notifications.addEventListener('permissionChange', (granted) => {
+          log('permissionChange: ' + granted, 'info');
+          refreshState();
+        });
+        OneSignal.User.addEventListener('change', () => refreshState());
       });
 
       setTimeout(refreshState, 500);

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "42.7 kB",
+      "limit": "42.71 kB",
       "gzip": true
     },
     {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     },
     {
       "path": "./build/releases/OneSignalSDK.page.es6.js",
-      "limit": "42.71 kB",
+      "limit": "42.78 kB",
       "gzip": true
     },
     {

--- a/src/core/executors/LoginUserOperationExecutor.test.ts
+++ b/src/core/executors/LoginUserOperationExecutor.test.ts
@@ -615,6 +615,36 @@ describe('LoginUserOperationExecutor', () => {
       expect(res).toEqual({ _result: ExecutionResult._FailNoretry });
     });
 
+    test('skips a local subscription with no token when transferring', async () => {
+      setCreateUserResponse({
+        onesignalId: ONESIGNAL_ID,
+      });
+      const executor = getExecutor();
+
+      const localSubId = IDManager._createLocalId();
+      const subscriptionModel = new SubscriptionModel();
+      subscriptionModel._mergeData({
+        id: localSubId,
+        enabled: true,
+        token: '',
+        type: SubscriptionType._ChromePush,
+      });
+      subscriptionModelStore._add(subscriptionModel, ModelChangeTags._NoPropogate);
+
+      const loginOp = new LoginUserOperation(APP_ID, ONESIGNAL_ID);
+      loginOp._setProperty('externalId', EXTERNAL_ID);
+      const transferSubOp = new TransferSubscriptionOperation(APP_ID, ONESIGNAL_ID, localSubId);
+
+      await executor._execute([loginOp, transferSubOp]);
+
+      expect(createUserFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          identity: { external_id: EXTERNAL_ID },
+          subscriptions: [],
+        }),
+      );
+    });
+
     test('can delete a subscription', async () => {
       setCreateUserResponse({
         onesignalId: ONESIGNAL_ID,

--- a/src/core/executors/LoginUserOperationExecutor.test.ts
+++ b/src/core/executors/LoginUserOperationExecutor.test.ts
@@ -554,6 +554,67 @@ describe('LoginUserOperationExecutor', () => {
       );
     });
 
+    // logout shape: a login op with no externalId grouped with a transfer op.
+    // The payload must carry the subscription data so the backend accepts the
+    // request and creates the subscription for the new anonymous user.
+    test('rebuilds subscription data from the model when transferring with a local ID', async () => {
+      setCreateUserResponse({
+        onesignalId: ONESIGNAL_ID,
+      });
+      const executor = getExecutor();
+
+      const localSubId = IDManager._createLocalId();
+      const subscriptionModel = new SubscriptionModel();
+      subscriptionModel._mergeData({
+        id: localSubId,
+        enabled: true,
+        notification_types: NotificationType._Subscribed,
+        token: PUSH_TOKEN,
+        type: SubscriptionType._ChromePush,
+      });
+      subscriptionModelStore._add(subscriptionModel, ModelChangeTags._NoPropogate);
+
+      const loginOp = new LoginUserOperation(APP_ID, ONESIGNAL_ID);
+      const transferSubOp = new TransferSubscriptionOperation(APP_ID, ONESIGNAL_ID, localSubId);
+
+      await executor._execute([loginOp, transferSubOp]);
+
+      expect(createUserFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          identity: {},
+          subscriptions: [
+            {
+              enabled: true,
+              device_model: '',
+              device_os: DEVICE_OS,
+              notification_types: NotificationType._Subscribed,
+              sdk: __VERSION__,
+              token: PUSH_TOKEN,
+              type: SubscriptionType._ChromePush,
+            },
+          ],
+        }),
+      );
+    });
+
+    test('drops an anonymous create user instead of an empty payload', async () => {
+      createUserFn.mockClear();
+      const executor = getExecutor();
+
+      // transfer op with a local ID and no subscription model to rebuild from
+      const loginOp = new LoginUserOperation(APP_ID, ONESIGNAL_ID);
+      const transferSubOp = new TransferSubscriptionOperation(
+        APP_ID,
+        ONESIGNAL_ID,
+        IDManager._createLocalId(),
+      );
+
+      const res = await executor._execute([loginOp, transferSubOp]);
+
+      expect(createUserFn).not.toHaveBeenCalled();
+      expect(res).toEqual({ _result: ExecutionResult._FailNoretry });
+    });
+
     test('can delete a subscription', async () => {
       setCreateUserResponse({
         onesignalId: ONESIGNAL_ID,

--- a/src/core/executors/LoginUserOperationExecutor.test.ts
+++ b/src/core/executors/LoginUserOperationExecutor.test.ts
@@ -21,6 +21,7 @@ import {
 } from '__test__/support/helpers/requests';
 import { updateIdentityModel, updatePropertiesModel } from '__test__/support/helpers/setup';
 import { getPushToken, setPushToken } from 'src/shared/database/subscription';
+import { IDManager } from 'src/shared/managers/IDManager';
 import { NotificationType, SubscriptionType } from 'src/shared/subscriptions/constants';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vite-plus/test';
 
@@ -489,6 +490,61 @@ describe('LoginUserOperationExecutor', () => {
               device_model: '',
               device_os: DEVICE_OS,
               id: SUB_ID,
+              sdk: __VERSION__,
+              type: mockSubscriptionOpInfo.type,
+              token: mockSubscriptionOpInfo.token,
+            },
+          ],
+        }),
+      );
+    });
+
+    // The backend rejects local IDs as invalid UUIDs, so a transfer op whose
+    // subscription ID was not translated yet must not add it to the payload.
+    test('does not send a subscription with only a local ID when transferring', async () => {
+      setCreateUserResponse({
+        onesignalId: ONESIGNAL_ID,
+      });
+      const executor = getExecutor();
+
+      const loginOp = new LoginUserOperation(APP_ID, ONESIGNAL_ID);
+      loginOp._setProperty('externalId', EXTERNAL_ID);
+
+      const transferSubOp = new TransferSubscriptionOperation(
+        APP_ID,
+        ONESIGNAL_ID,
+        IDManager._createLocalId(),
+      );
+
+      await executor._execute([loginOp, transferSubOp]);
+
+      expect(createUserFn).toHaveBeenCalledWith(expect.objectContaining({ subscriptions: [] }));
+    });
+
+    test('omits the id but keeps the subscription data when the transfer ID is local', async () => {
+      setCreateUserResponse({
+        onesignalId: ONESIGNAL_ID,
+      });
+      const executor = getExecutor();
+
+      const loginOp = new LoginUserOperation(APP_ID, ONESIGNAL_ID);
+      loginOp._setProperty('externalId', EXTERNAL_ID);
+
+      const localSubId = IDManager._createLocalId();
+      const createSubOp = new CreateSubscriptionOperation({
+        ...mockSubscriptionOpInfo,
+        subscriptionId: localSubId,
+      });
+      const transferSubOp = new TransferSubscriptionOperation(APP_ID, ONESIGNAL_ID, localSubId);
+
+      await executor._execute([loginOp, createSubOp, transferSubOp]);
+
+      expect(createUserFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subscriptions: [
+            {
+              device_model: '',
+              device_os: DEVICE_OS,
               sdk: __VERSION__,
               type: mockSubscriptionOpInfo.type,
               token: mockSubscriptionOpInfo.token,

--- a/src/core/executors/LoginUserOperationExecutor.ts
+++ b/src/core/executors/LoginUserOperationExecutor.ts
@@ -3,6 +3,7 @@ import { ExecutionResult, type IOperationExecutor } from 'src/core/types/operati
 import { getResponseStatusType, ResponseStatusType } from 'src/shared/helpers/network';
 import Log from 'src/shared/libraries/Log';
 import { checkAndTriggerUserChanged } from 'src/shared/listeners';
+import { IDManager } from 'src/shared/managers/IDManager';
 
 import { IdentityConstants, OPERATION_NAME } from '../constants';
 import { type IPropertiesModelKeys } from '../models/PropertiesModel';
@@ -289,6 +290,11 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
 
       case operation instanceof TransferSubscriptionOperation: {
         const subscriptionId = operation._subscriptionId;
+
+        // A local ID means the subscription does not exist on the backend yet,
+        // so there is nothing to transfer and the backend rejects local IDs as
+        // invalid UUIDs. A grouped create operation still creates it.
+        if (IDManager._isLocalId(subscriptionId)) return currentSubs;
 
         return {
           ...currentSubs,

--- a/src/core/executors/LoginUserOperationExecutor.ts
+++ b/src/core/executors/LoginUserOperationExecutor.ts
@@ -308,7 +308,7 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
           if (currentSubs[subscriptionId]) return currentSubs;
 
           const model = this._subscriptionsModelStore._getBySubscriptionId(subscriptionId);
-          if (!model) return currentSubs;
+          if (!model?.token) return currentSubs;
 
           return {
             ...currentSubs,

--- a/src/core/executors/LoginUserOperationExecutor.ts
+++ b/src/core/executors/LoginUserOperationExecutor.ts
@@ -149,6 +149,15 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
     }
 
     const subscriptionList = Object.entries(subscriptions);
+
+    // The backend rejects a create user request that has no identity and no
+    // subscriptions, so drop the operation instead of a request that always
+    // fails. The Android SDK has the same guard.
+    if (Object.keys(identity).length === 0 && subscriptionList.length === 0) {
+      Log._debug('CreateUser: skipped, no identity and no subscriptions');
+      return { _result: ExecutionResult._FailNoretry };
+    }
+
     const response = await createNewUser(
       { appId: createUserOperation._appId },
       {
@@ -293,8 +302,29 @@ export class LoginUserOperationExecutor implements IOperationExecutor {
 
         // A local ID means the subscription does not exist on the backend yet,
         // so there is nothing to transfer and the backend rejects local IDs as
-        // invalid UUIDs. A grouped create operation still creates it.
-        if (IDManager._isLocalId(subscriptionId)) return currentSubs;
+        // invalid UUIDs. Send the subscription data from its model instead so
+        // the backend creates it. A grouped create operation already has it.
+        if (IDManager._isLocalId(subscriptionId)) {
+          if (currentSubs[subscriptionId]) return currentSubs;
+
+          const model = this._subscriptionsModelStore._getBySubscriptionId(subscriptionId);
+          if (!model) return currentSubs;
+
+          return {
+            ...currentSubs,
+            [subscriptionId]: {
+              enabled: model.enabled,
+              device_model: model.device_model,
+              device_os: model.device_os,
+              notification_types: model._notification_types,
+              sdk: model.sdk,
+              token: model.token,
+              type: model.type,
+              web_auth: model.web_auth,
+              web_p256: model.web_p256,
+            },
+          };
+        }
 
         return {
           ...currentSubs,


### PR DESCRIPTION
# Description

## 1 Line Summary

Stop the SDK from sending `local-*` placeholder subscription IDs in the Create User request, which the backend rejects as invalid UUIDs.

## Details

The `login()` and `logout()` flows enqueue a `TransferSubscriptionOperation` with the current push subscription model ID. That ID can still be a `local-*` placeholder when the create-subscription operation did not complete first (for example, after a network failure dropped the pending operations). `_canStartExecute` blocks such a transfer op from starting on its own, but `OperationRepo._getGroupableOperations` does not check `_canStartExecute` for grouped operations. A `LoginUserOperation` with the same comparison key groups the transfer op, and the transfer branch in `LoginUserOperationExecutor` copied the local ID into the payload as `{"id": "local-..."}`. The backend rejects the request with `uuid: incorrect UUID length 42`.

The failure then persists: the 400 maps to `FailPauseOpRepo`, so the operations re-queue, persist in IndexedDB, and fail again on every page load. Affected users stay unsubscribed until they clear site data.

The fix changes the transfer branch for a local subscription ID. A transfer grouped with a create op keeps the create data and adds no `id`. A lone transfer op rebuilds the subscription data from the model in `SubscriptionModelStore`, again with no `id`, so the backend creates the subscription and ID translation still runs. A model with no token is skipped, because the store listener never sends a token-less subscription as enabled and the model self-heals on the next subscribe. A create user request that ends with no identity and no subscriptions is dropped (`FailNoretry`) instead of sent, which matches the Android SDK. Users who are stuck today recover on their next page load because the persisted login operation now sends a valid payload.

The size limit for `OneSignalSDK.page.es6.js` moves from 42.7 kB to 42.78 kB; the new branch pushed the gzip size 67 bytes over the old limit.

The manual repro harness used during review is not part of the final diff. Commit `9a0f42e` on this branch has the last version of it, and the PR comment "How to test this manually" has the steps.

# Systems Affected

- [x] WebSDK
- [ ] Backend
- [ ] Dashboard

# Validation

## Tests

### Info

5 new unit tests in `LoginUserOperationExecutor.test.ts`. Before the fix, the first test reproduced the exact invalid payload from the customer report (`subscriptions: [{"id": "local-..."}]`). The other tests cover the create-plus-transfer group, the rebuild from the model on logout, the token-less model, and the dropped empty payload. All pass after the fix, along with the full suite, `vp check`, and `vp run build:prod`.

### Checklist

- [x] All the automated tests pass or I explained why that is not possible
- [x] I have personally tested this on my machine or explained why that is not possible
- [x] I have included test coverage for these changes or explained why they are not needed

**Programming Checklist**
Interfaces:

- [x] Don't use default export
- [x] New interfaces are in model files

Functions:

- [x] Don't use default export
- [x] All function signatures have return types
- [x] Helpers should not access any data but rather be given the data to operate on.

Typescript:

- [x] No Typescript warnings
- [x] Avoid silencing null/undefined warnings with the exclamation point

Other:

- [x] Iteration: refrain from using `elem of array` syntax. Prefer `forEach` or use `map`
- [x] Avoid using global OneSignal accessor for `context` if possible. Instead, we can pass it to function/constructor so that we don't call `OneSignal.context`

## Screenshots

### Info

Not needed: the change affects a network payload with no UI impact. The unit tests assert the payload contents.

### Checklist

- [x] I have included screenshots/recordings of the intended results or explained why they are not needed

---

## Related Tickets

[SDK-5014](https://linear.app/onesignal/issue/SDK-5014/web-sdk-v16-sends-local-prefixed-placeholder-subscription-id-in-create)

---

